### PR TITLE
[#4/ui] feat: 디자인 토큰(색상) 및 유틸리티 설정

### DIFF
--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@5unwan/ui": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -19,7 +20,6 @@
     "@5unwan/eslint-config": "workspace:*",
     "@5unwan/tailwind-config": "workspace:*",
     "@5unwan/typescript-config": "workspace:*",
-    "@5unwan/ui": "workspace:*",
     "@chromatic-com/storybook": "^3.2.3",
     "@eslint/js": "^9.17.0",
     "@storybook/addon-essentials": "^8.4.7",

--- a/docs/storybook/src/tailwind.css
+++ b/docs/storybook/src/tailwind.css
@@ -1,3 +1,5 @@
+@import "5unwan/tailwind-config/variables";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/docs/storybook/src/tailwind.css
+++ b/docs/storybook/src/tailwind.css
@@ -1,4 +1,4 @@
-@import "5unwan/tailwind-config/variables";
+@import "@5unwan/tailwind-config/variables";
 
 @tailwind base;
 @tailwind components;

--- a/docs/storybook/stories/Colors.mdx
+++ b/docs/storybook/stories/Colors.mdx
@@ -1,0 +1,37 @@
+import { Meta, ColorPalette, ColorItem } from '@storybook/blocks';
+
+import resolveConfig from 'tailwindcss/resolveConfig';
+import tailwindConfig from '../tailwind.config.ts';
+
+export const fullConfig = resolveConfig(tailwindConfig);
+export const colors = fullConfig.theme.colors;
+
+<Meta title='System Colors' />
+
+<ColorPalette style={{ wordBreak: 'break-word' }}>
+  <ColorItem
+    title='brand-primary'
+    subtitle='Primary Brand Gradient'
+    colors={colors.brand.primary}
+  />
+  <ColorItem
+    title='brand-secondary'
+    subtitle='Secondary Brand Gradient'
+    colors={colors.brand.secondary}
+  />
+  <ColorItem
+    title='text'
+    subtitle='Text Gradient'
+    colors={colors.text}
+  />
+  <ColorItem
+    title='background'
+    subtitle='Background Gradient'
+    colors={colors.background}
+  />
+   <ColorItem
+    title='notification'
+    subtitle='Notification'
+    colors={{notification: colors.notification}}
+  />
+</ColorPalette>

--- a/packages/config-tailwind/globals.css
+++ b/packages/config-tailwind/globals.css
@@ -3,19 +3,19 @@
     --brand-primary: 87 85 255;
     --brand-secondary: 255 142 107;
 
-    --text-primary: 255 255 255;
-    --text-sub1: 233 233 233;
-    --text-sub2: 190 190 190;
-    --text-sub3: 119 119 119;
-    --text-sub4: 76 76 76;
-    --text-sub5: 28 28 28;
+    --text-primary: 0 0 100;
+    --text-sub1: 0 0 91;
+    --text-sub2: 0 0 75;
+    --text-sub3: 0 0 47;
+    --text-sub4: 0 0 30;
+    --text-sub5: 0 0 11;
 
-    --background-primary: 28 28 28; 
-    --background-sub1: 36 36 36;
-    --background-sub2: 47 47 47;
-    --background-sub3: 76 76 76;
-    --background-sub4: 255 255 255;
+    --background-primary: 0 0 11;
+    --background-sub1: 0 0 14;
+    --background-sub2: 0 0 18;
+    --background-sub3: 0 0 30;
+    --background-sub4: 0 0 100;
 
-    --notification: 255 84 85
+    --notification: 360 100 66
   }
 }

--- a/packages/config-tailwind/globals.css
+++ b/packages/config-tailwind/globals.css
@@ -1,0 +1,21 @@
+@layer base {
+  :root {
+    --brand-primary: 87 85 255;
+    --brand-secondary: 255 142 107;
+
+    --text-primary: 255 255 255;
+    --text-sub1: 233 233 233;
+    --text-sub2: 190 190 190;
+    --text-sub3: 119 119 119;
+    --text-sub4: 76 76 76;
+    --text-sub5: 28 28 28;
+
+    --background-primary: 28 28 28; 
+    --background-sub1: 36 36 36;
+    --background-sub2: 47 47 47;
+    --background-sub3: 76 76 76;
+    --background-sub4: 255 255 255;
+
+    --notification: 255 84 85
+  }
+}

--- a/packages/config-tailwind/package.json
+++ b/packages/config-tailwind/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "exports": {
     ".": "./tailwind.config.ts",
-    "./cn": "./utils/cn.ts"
+    "./variables": "./globals.css"
   },
   "devDependencies": {
     "@5unwan/typescript-config": "workspace:*",

--- a/packages/config-tailwind/tailwind.config.ts
+++ b/packages/config-tailwind/tailwind.config.ts
@@ -2,7 +2,32 @@ import type { Config } from "tailwindcss";
 
 // We want each package to be responsible for its own content.
 const config: Omit<Config, "content"> = {
-  theme: {},
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          primary: "hsl(var(--brand-primary))",
+          secondary: "hsl(var(--brand-secondary))",
+        },
+        text: {
+          primary: "hsl(var(--text-primary))",
+          sub1: "hsl(var(--text-sub1))",
+          sub2: "hsl(var(--text-sub2))",
+          sub3: "hsl(var(--text-sub3))",
+          sub4: "hsl(var(--text-sub4))",
+          sub5: "hsl(var(--text-sub5))",
+        },
+        background: {
+          primary: "hsl(var(--background-primary))",
+          sub1: "hsl(var(--background-sub1))",
+          sub2: "hsl(var(--background-sub2))",
+          sub3: "hsl(var(--background-sub3))",
+          sub4: "hsl(var(--background-sub4))"
+        },
+        notification: "hsl(var(--notification))",
+      }
+    }
+  },
   plugins: [],
 };
 export default config;

--- a/packages/config-tailwind/tailwind.config.ts
+++ b/packages/config-tailwind/tailwind.config.ts
@@ -6,8 +6,28 @@ const config: Omit<Config, "content"> = {
     extend: {
       colors: {
         brand: {
-          primary: "hsl(var(--brand-primary))",
-          secondary: "hsl(var(--brand-secondary))",
+          primary: {
+            100: 'hsl(241 100 93)',
+            200: 'hsl(241 100 87)',
+            300: 'hsl(241 100 80)',
+            400: 'hsl(241 100 73)',
+            500: 'hsl(241 100 67)',
+            600: 'hsl(241 57 53)',
+            700: 'hsl(241 50 40)',
+            800: 'hsl(241 50 27)',
+            900: 'hsl(241 50 13)',
+          },
+          secondary: {
+            100: 'hsl(14 100 94)',
+            200: 'hsl(14 100 88)',
+            300: 'hsl(14 100 83)',
+            400: 'hsl(14 100 77)',
+            500: 'hsl(14 100 71)',
+            600: 'hsl(14 54 57)',
+            700: 'hsl(14 41 43)',
+            800: 'hsl(14 41 28)',
+            900: 'hsl(14 41 14)',
+          },
         },
         text: {
           primary: "hsl(var(--text-primary))",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,5 +44,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "tailwind-merge": "^2.6.0"
+  },
+  "exports": {
+    "./utils": "./lib/utils.ts"
   }
 }

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-export function cn(...inputs: ClassValue[]) {
+export const cn = (...inputs: ClassValue[]) => {
   return twMerge(clsx(inputs));
-}
+};

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,3 +1,5 @@
+@import "5unwan/tailwind-config/variables";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,4 +1,4 @@
-@import "5unwan/tailwind-config/variables";
+@import "@5unwan/tailwind-config/variables";
 
 @tailwind base;
 @tailwind components;

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -4,7 +4,6 @@ import type { Config } from "tailwindcss";
 
 const config: Pick<Config, "prefix" | "presets" | "content"> = {
   content: ["./src/**/*.tsx"],
-  prefix: "ui-",
   presets: [sharedConfig],
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
 
   docs/storybook:
     dependencies:
+      '@5unwan/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -212,9 +215,6 @@ importers:
       '@5unwan/typescript-config':
         specifier: workspace:*
         version: link:../../packages/config-typescript
-      '@5unwan/ui':
-        specifier: workspace:*
-        version: link:../../packages/ui
       '@chromatic-com/storybook':
         specifier: ^3.2.3
         version: 3.2.3(react@18.3.1)(storybook@8.4.7)


### PR DESCRIPTION
# [#4/ui] feat: 디자인 토큰(색상) 및 유틸리티 설정

## 📝 작업 내용

각 경로에서 작업한 내용은 아래와 같습니다:
- packages/config-tailwind
   - `globals.css`: 프로젝트 전반에서 사용하는 디자인 토큰(색상)을 css variables로 정의했습니다. `tailwind.config.ts`에서만 색상을 custom 하지 않은 이유는 mvp 이후 배포에서 dark/light 모드 지원을 위함입니다 (css 클래스에 따른 light/dark 모드)
   - `tailwind.config.ts`: `globals.css`에서 정의한 색상을 tailwind 설정으로 추가했습니다. 여기서 `colors.brand.primary`, `colors.brand.secondary`가 css변수 없이 바로 hsl값으로 정의된 이유는 라이트/다크 모드에 따른 변화가 없는 색상이기 때문입니다.
- packages/ui
   - `lib/utils.ts` : `tailwind-merge`와 `clsx`를 사용하여 cn 유틸리티 함수를 정의했습니다. 다른 패키지에서 `utils.ts` 경로에 접근할 떄는 `@5unwan/utils` 로 접근하면 되도록 설정했습니다.
- docs/storybook
   - `Colors.mdx`: `packages/config-tailwind/tailwind.config.ts`에서 정의한 색상 토큰을 명세했습니다. Storybook의 `ColorPalette`, `ColorItem`을 사용하였습니다. (스크린샷-a)

### 📷 스크린샷 (선택)
- a
<img width="1072" alt="스크린샷 2024-12-26 오후 4 24 23" src="https://github.com/user-attachments/assets/95de9d86-a120-4351-b53b-9eef93fbcd7f" />


## 참고

https://tailwindcss.com/docs/customizing-colors#using-css-variables

close #4
