### PR TITLE
[#7/config-eslint] chore: 코딩 컨벤션에 명시된 룰 중, eslint로 설정할 수 있는 eslint rule 추가

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 # pr 제목은 아래와 같이 작성해주세요.
 
-[#이슈 번호] Commit Type: pr 제목
+[#이슈 번호/작업 패키지] Commit Type: pr 제목
+
+<!-- 작업 패키지: root, ui, trainer, user, config-eslint, config-typescript, config-tailwind, docs/storybook -->
 
 ## 📝 작업 내용
 

--- a/apps/trainer/.eslintrc.json
+++ b/apps/trainer/.eslintrc.json
@@ -1,4 +1,4 @@
 {
   "root": true,
-  "extends": ["@5unwan/eslint-config/next"]
+  "extends": ["@5unwan/eslint-config/next", "@5unwan/eslint-config/react-internal"]
 }

--- a/apps/user/.eslintrc.json
+++ b/apps/user/.eslintrc.json
@@ -1,4 +1,4 @@
 {
   "root": true,
-  "extends": ["@5unwan/eslint-config/next"]
+  "extends": ["@5unwan/eslint-config/next", "@5unwan/eslint-config/react-internal"]
 }

--- a/packages/config-eslint/base.js
+++ b/packages/config-eslint/base.js
@@ -18,6 +18,15 @@ module.exports = {
   rules: {
     "unused-imports/no-unused-imports": "error",
     "@typescript-eslint/no-unused-vars": "error",
+    "no-var": "error",
+    "padding-line-between-statements": [
+      "error",
+      { blankLine: "always", prev: "*", next: "return" },
+    ],
+    "space-before-blocks": [2, "always"],
+    "no-plusplus": "error",
+    "no-magic-numbers": ["error", { ignoreArrayIndexes: true }],
+
     "import/order": [
       "error",
       {

--- a/packages/config-eslint/next.js
+++ b/packages/config-eslint/next.js
@@ -8,7 +8,7 @@ const project = resolve(process.cwd(), "tsconfig.json");
  */
 
 module.exports = {
-  extends: ["@5unwan/eslint-config/base", "plugin:@next/next/recommended", "plugin:storybook/recommended"],
+  extends: ["@5unwan/eslint-config/base", "plugin:@next/next/recommended"],
   parserOptions: {
     project,
   },

--- a/packages/config-eslint/react-internal.js
+++ b/packages/config-eslint/react-internal.js
@@ -14,7 +14,6 @@ module.exports = {
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:@tanstack/query/recommended",
-    "plugin:storybook/recommended",
   ],
   parserOptions: {
     project,

--- a/packages/config-eslint/react-internal.js
+++ b/packages/config-eslint/react-internal.js
@@ -19,12 +19,14 @@ module.exports = {
   parserOptions: {
     project,
   },
-  plugins: ["react-refresh"],
+  plugins: ["react-refresh", "react"],
   rules: {
-   "react-refresh/only-export-components": [
-      "warn",
-      { allowConstantExport: true },
-    ],
+    "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+    "react/prop-types": "off",
+    "react/react-in-jsx-scope": "off",
+    "react/function-component-definition": ["error", { namedComponents: ["function-declaration"] }],
+    "react/jsx-key": "error",
+    "react/jsx-fragments": ["error", "syntax"],
   },
   globals: {
     React: true,

--- a/packages/config-eslint/react-internal.js
+++ b/packages/config-eslint/react-internal.js
@@ -19,7 +19,7 @@ module.exports = {
   parserOptions: {
     project,
   },
-  plugins: ["react-refresh", "react"],
+  plugins: ["react-refresh"],
   rules: {
     "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
     "react/prop-types": "off",


### PR DESCRIPTION
## 📝 작업 내용

- FE 팀 내 코딩 컨벤션에 명시된 룰 중에서 eslint로 설정할 수 있는 eslint rule을 추가 하였으며, 빠른 룰 적용을 위해 필요하다고 생각되는 부분만 우선적으로 rule로 추가하였습니다. 개발을 진행하면서 FE 팀 내 코딩 컨벤션에 명시된 모든 내용과 추가적으로 적용하면 좋을 rule을 차차 적용하도록 할 예정입니다. 
- trainer 및 user 패키지에서 React 관련 eslint rule을 사용할 수 있도록 각 패키지 내의 `.eslintrc.json`에 extends로 추가하였습니다.
- PR 템플릿의 title 작성 방법을 바뀐 템플릿으로 수정하였습니다.
 
추가된 각 룰의 목적은 아래와 같습니다. ⬇️

```typescript
{
 // var 키워드 사용을 금지하고 대신 let 또는 const를 사용하도록 강제  
 "no-var": "error",  
  // 특정 구문 사이에 빈 줄을 강제 (여기서는 모든 이전 구문 뒤에 return 구문이 올 경우 빈 줄을 삽입)
  "padding-line-between-statements": [ 
    "error",
    { blankLine: "always", prev: "*", next: "return" }
  ],
  // 코드 블록(`{}`) 앞에 항상 공백을 강제
  "space-before-blocks": [2, "always"],
  // 후위 및 전위 증감 연산자(++ 또는 --) 사용을 금지
  "no-plusplus": "error",   
  // "마법의 숫자" 사용 금지 (명확한 의미를 가지는 상수로 대체 권장), 단 배열의 인덱스는 예외로 허용
  "no-magic-numbers": ["error", { ignoreArrayIndexes: true }],
  // React 컴포넌트에서 PropTypes 사용을 비활성화 (타입스크립트를 사용하는 경우 주로 설정)
  "react/prop-types": "off",   
  // React를 JSX 범위 내에서 사용하도록 강제하지 않음 (React 17+에서는 불필요)
  "react/react-in-jsx-scope": "off",   
  // React 컴포넌트를 선언할 때 함수 선언 방식만 허용
  "react/function-component-definition": ["error", { namedComponents: ["function-declaration"] }],
  // JSX 엘리먼트의 각 자식에게 고유한 `key` prop을 반드시 할당하도록 강제
  "react/jsx-key": "error",   
  // React Fragment를 사용할 때 짧은 문법(`<>...</>`)만 허용
  "react/jsx-fragments": ["error", "syntax"]   
}
```

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

close #7 
