### PR TITLE
[#14/storybook] chore: @5unwan/storybook 패키지 빌드 결과 캐싱 및 gitignore 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 dist/
 
 *storybook.log
+storybook-static

--- a/docs/storybook/.gitignore
+++ b/docs/storybook/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 *storybook.log
+storybook-static

--- a/docs/storybook/.gitignore
+++ b/docs/storybook/.gitignore
@@ -24,4 +24,3 @@ dist-ssr
 *.sw?
 
 *storybook.log
-storybook-static

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5478,6 +5478,7 @@ packages:
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    requiresBuild: true
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "storybook-static/**"]
     },
     "lint": {},
     "type-check": {},


### PR DESCRIPTION
# [#14/storybook] chore: @5unwan/storybook 패키지 빌드 결과 캐싱 및 gitignore 설정

## 📝 작업 내용

@5unwan/storybook 패키지 빌드 시 storybook build 스크립트가 실행되면서 storybook-static/* 빌드 파일이 생성됩니다. [turborepo의 storybook 가이드를](https://turbo.build/repo/docs/guides/tools/storybook) 참고하여 turborepo가 빌드를 캐싱할 수 있도록 turbo.json을 수정했습니다
.gitignore에 storybook-static/* 경로를 추가하여 git이 storybook 빌드 결과를 git이 추적하지 않도록 설정했습니다

close #14
