### PR TITLE
[#1/ui] feat: Badge 컴포넌트

### DIFF
--- a/docs/storybook/stories/Badge.stories.tsx
+++ b/docs/storybook/stories/Badge.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Badge } from "@5unwan/ui/badge";
+
+const meta: Meta<typeof Badge> = {
+  component: Badge,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'sub1', 'sub2', 'brand', 'destructive']
+    },
+    size: {
+      control: 'select',
+      options: ['small', 'medium', 'large']
+    }
+  },
+  args: {
+    children: "Badge",
+    size: 'medium'
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {
+  args: {
+    variant: "default",
+    children: '00/20'
+  },
+};
+export const Sub1: Story = {
+  args: {
+    variant: 'sub1',
+    children: '00/20'
+  }
+}
+export const Sub2: Story = {
+  args: {
+    variant: 'sub2',
+    children: 'PT완료'
+  }
+}
+export const Brand: Story = {
+  args: {
+    variant: 'brand',
+    children: '00/20'
+  }
+}
+export const Destructive: Story = {
+  args: {
+    variant: 'destructive'
+  }
+}

--- a/docs/storybook/stories/Badge.stories.tsx
+++ b/docs/storybook/stories/Badge.stories.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@5unwan/ui/badge";
 
 const meta: Meta<typeof Badge> = {
   component: Badge,
+  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -46,6 +46,7 @@
     "tailwind-merge": "^2.6.0"
   },
   "exports": {
-    "./utils": "./lib/utils.ts"
+    "./utils": "./lib/utils.ts",
+    "./badge": "./src/components/Badge.tsx"
   }
 }

--- a/packages/ui/postcss.config.js
+++ b/packages/ui/postcss.config.js
@@ -1,7 +1,4 @@
-// If you want to use other PostCSS plugins, see the following:
-// https://tailwindcss.com/docs/using-with-preprocessors
-
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/packages/ui/src/components/Badge.tsx
+++ b/packages/ui/src/components/Badge.tsx
@@ -1,0 +1,38 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "../lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border border-transparent px-3 py-[7px] font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 shadow",
+  {
+    variants: {
+      variant: {
+        default: "bg-background-sub4 text-text-sub5",
+        sub1: "bg-background-sub1 text-text-primary",
+        sub2: "bg-background-sub2 text-text-primary",
+        brand: "bg-brand-primary-500 text-text-primary",
+        destructive: "bg-notification text-text-primary",
+      },
+      size: {
+        large: "h-[32px] text-[17px]",
+        medium: "h-[29px] text-[15px]",
+        small: "h-[25px] text-[13px]",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "medium",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, size, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant, size }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
# [#1/ui] feat: Badge 컴포넌트

## 📝 작업 내용

Badge 공통 컴포넌트를 구현하고, 스토리를 작성했습니다
- packages/ui/src/components/Badge.tsx
- docs/storybook/stories/Badge.stories.tsx : Badge 역할별로 story를 작성했습니다 (variant). 제공하는 controls는 다음과 같습니다
   - children: Badge content(내용) 지정
   - variant: Badge 종류(역할) 지정. [default, sub1, sub2, brand, destructive]
   - size: Badge 크기 지정. [small, medium, large] 


close #1
