### PR TITLE
[#19/root] fix: 사용되지 않는 TailwindCSS 기본 설정 제거 및 누락된 TailwindCSS 기본 설정 추가

### DIFF
--- a/docs/storybook/src/tailwind.css
+++ b/docs/storybook/src/tailwind.css
@@ -1,5 +1,1 @@
 @import "@5unwan/tailwind-config/variables";
-
-@tailwind base;
-@tailwind components;
-@tailwind utilities;

--- a/packages/config-tailwind/variables.css
+++ b/packages/config-tailwind/variables.css
@@ -1,21 +1,25 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 @layer base {
   :root {
-    --brand-primary: 87 85 255;
-    --brand-secondary: 255 142 107;
+    --brand-primary: 87 85% 255%;
+    --brand-secondary: 255 142% 107%;
 
-    --text-primary: 0 0 100;
-    --text-sub1: 0 0 91;
-    --text-sub2: 0 0 75;
-    --text-sub3: 0 0 47;
-    --text-sub4: 0 0 30;
-    --text-sub5: 0 0 11;
+    --text-primary: 0 0% 100%;
+    --text-sub1: 0 0% 91%;
+    --text-sub2: 0 0% 75%;
+    --text-sub3: 0 0% 47%;
+    --text-sub4: 0 0% 30%;
+    --text-sub5: 0 0% 11%;
 
-    --background-primary: 0 0 11;
-    --background-sub1: 0 0 14;
-    --background-sub2: 0 0 18;
-    --background-sub3: 0 0 30;
-    --background-sub4: 0 0 100;
+    --background-primary: 0 0% 11%;
+    --background-sub1: 0 0% 14%;
+    --background-sub2: 0 0% 18%;
+    --background-sub3: 0 0% 30%;
+    --background-sub4: 0 0% 100%;
 
-    --notification: 360 100 66
+    --notification: 360 100% 66%;
   }
 }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,5 +1,1 @@
 @import "@5unwan/tailwind-config/variables";
-
-@tailwind base;
-@tailwind components;
-@tailwind utilities;


### PR DESCRIPTION
<!-- 작업 패키지: root, ui, trainer, user, config-eslint, config-typescript, config-tailwind, docs/storybook -->

## 📝 작업 내용

사용되지 않는 TailwindCSS 기본 설정 제거 및 누락된 TailwindCSS 기본 설정 추가하였습니다.
- `config-tailwind/variables.css`에 누락된 TailwindCSS 기본 설정을 추가하였습니다.
- `config-tailwind/variables.css` 모듈을 `ui`, `docs/storybook`에서 import 하여 사용하고 있으므로 불필요한 TailwindCSS 기본 설정을 제거하였습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

close #19 
