### PR TITLE
[#18/ui] feat: Input 공통 컴포넌트 구현

### DIFF
--- a/docs/storybook/stories/Input.stories.tsx
+++ b/docs/storybook/stories/Input.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Input } from "@5unwan/ui/components/Input";
+
+const meta: Meta<typeof Input> = {
+  component: Input,
+  tags: ["autodocs"],
+  argTypes: {
+    type: {
+      control: "select",
+      options: ["text", "password", "email", "number"],
+    },
+    disabled: {
+      control: "boolean",
+    },
+    placeholder: {
+      control: "text",
+    },
+  },
+  args: {
+    type: "text",
+    placeholder: "검색어를 입력하세요.",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    type: "text",
+    placeholder: "검색어를 입력하세요.",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    type: "text",
+    placeholder: "Disabled input",
+    disabled: true,
+  },
+};

--- a/packages/ui/src/components/Input.tsx
+++ b/packages/ui/src/components/Input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "../lib/utils";
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "placeholder:text-text-sub3 bg-background-sub3 text-body-1 text-text-primary flex h-[45px] w-[358px] rounded-[10px] px-[13px] py-2.5 shadow-sm transition-colors focus-visible:outline-none disabled:cursor-not-allowed",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,6 +1,25 @@
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+import resolveConfig from "tailwindcss/resolveConfig";
+
+import tailwindConfig from "../../tailwind.config.ts";
+
+const customTailwindTheme = resolveConfig(tailwindConfig).theme.fontSize;
+const customFontSizes = Object.keys(customTailwindTheme);
+
+const customTwMerge = extendTailwindMerge({
+  extend: {
+    theme: {},
+    classGroups: {
+      "font-size": [
+        {
+          text: customFontSizes,
+        },
+      ],
+    },
+  },
+});
 
 export const cn = (...inputs: ClassValue[]) => {
-  return twMerge(clsx(inputs));
+  return customTwMerge(clsx(inputs));
 };


### PR DESCRIPTION
<!-- 작업 패키지: root, ui, trainer, user, config-eslint, config-typescript, config-tailwind, docs/storybook -->

## 📝 작업 내용

<img width="300" alt="image" src="https://github.com/user-attachments/assets/4b5956dc-d4af-47ea-8597-dcaa3dcfba28" />

### 피그마에 정의된 Input 공통 컴포넌트를 구현하였습니다.
- 피그마에 나와있는 Input은 위 이미지 외에도 여러가지가 있지만(with icon, with label 등) `Atmoic`한 컴포넌트 구현을 위헤 현재 PR에서는 단일 Input 컴포넌트만 구현하였습니다.
- 하나의 컴포넌트에서 모든 상황을 대응하다보면 컴포넌트의 크기가 커지고 props가 많아져 복잡할 것이라고 예상이되며, 하나의 컴포넌트에서 모든 상황을 대응하는 것이 아닌, 컴포넌트 분리를 통해 좀 더 높은 직관성을 가져가기 위함입니다.
- `with icon`, `with label`등 input을 활용하는 공통 컴포넌트는 따로 분리하여 구현하도록 할 예정입니다.

### extendTailwindMerge를 사용한 text utility 스타일 충돌 해결
- [extendTailwindMerge github](https://github.com/dcastil/tailwind-merge/blob/main/docs/api-reference.md#extendtailwindmerge), [extendTailwindMerge 적용한 블로그](https://happynet-fe.tistory.com/1)를 참고하여 기존의 twMerge를 사용하던 `packages/ui` 내부의 `utils.ts` 함수를 수정하였습니다.
- 간단하게 말씀을 드리면 `extendTailwindMerge`를 사용하여 기존에 `twMerge`만 사용했을 때 특정 스타일이 충돌하여 먼저 작성된 특정 스타일이 제거되지 않고 병합이 될 수 있도록 작성한 것입니다. twMerge의 기능은 그대로 확장됩니다.


### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

close #18 
