### PR TITLE
[PRIZ-31/root] chore: JIRA 연동 설정

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,11 +1,8 @@
 echo 'wait add jira issue number we found from branch name'
 
 BRANCH_NAME=$(git symbolic-ref -q HEAD)
-echo $BRANCH_NAME
 BRANCH_NAME=$(echo "$BRANCH_NAME" | awk -F'/' '{print $(NF-2)"/"$(NF-1)"/"$NF}')
-echo $BRANCH_NAME
 ISSUE_TICKET=$(echo "$BRANCH_NAME" | sed -n 's/^\([A-Z]*-[0-9]*\)\/\(.*\)$/\1/p')
-echo $ISSUE_TICKET
 # Check if ISSUE_TICKET is not empty
 if [ -n "$ISSUE_TICKET" ]; then
   # Output extracted Jira 이슈 티켓 번호

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -13,5 +13,5 @@ if [ -n "$ISSUE_TICKET" ]; then
   COMMIT_MSG=$(cat $COMMIT_MSG_FILE)
 
   # Prepend Jira 이슈 티켓 번호 to the commit message with a hyphen and remove the space
-  echo "$ISSUE_TICKET/$COMMIT_MSG" > $COMMIT_MSG_FILE
+  echo "$ISSUE_TICKET $COMMIT_MSG" > $COMMIT_MSG_FILE
 fi

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,20 @@
+echo 'wait add jira issue number we found from branch name'
+
+BRANCH_NAME=$(git symbolic-ref -q HEAD)
+echo $BRANCH_NAME
+BRANCH_NAME=$(echo "$BRANCH_NAME" | awk -F'/' '{print $(NF-2)"/"$(NF-1)"/"$NF}')
+echo $BRANCH_NAME
+ISSUE_TICKET=$(echo "$BRANCH_NAME" | sed -n 's/^\([A-Z]*-[0-9]*\)\/\(.*\)$/\1/p')
+echo $ISSUE_TICKET
+# Check if ISSUE_TICKET is not empty
+if [ -n "$ISSUE_TICKET" ]; then
+  # Output extracted Jira 이슈 티켓 번호
+  echo "Extracted Jira 이슈 티켓 번호: $ISSUE_TICKET"
+
+  # Read the commit message from the temporary file
+  COMMIT_MSG_FILE=$1
+  COMMIT_MSG=$(cat $COMMIT_MSG_FILE)
+
+  # Prepend Jira 이슈 티켓 번호 to the commit message with a hyphen and remove the space
+  echo "$ISSUE_TICKET/$COMMIT_MSG" > $COMMIT_MSG_FILE
+fi

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -13,4 +13,10 @@ module.exports = {
       ["feat", "fix", "style", "refactor", "docs", "test", "ci", "chore", "rename", "merge"],
     ],
   },
+  parserPreset: {
+    parserOpts: {
+      headerPattern: /^([A-Z]+-[0-9]+)\/(\w+):\s(.+)$/,
+      headerCorrespondence: ["ticket", "type", "subject"],
+    },
+  },
 };

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -15,7 +15,7 @@ module.exports = {
   },
   parserPreset: {
     parserOpts: {
-      headerPattern: /^([A-Z]+-[0-9]+)\/(\w+):\s(.+)$/,
+      headerPattern: /^([A-Z]+-[0-9]+)\s(\w+):\s(.+)$/,
       headerCorrespondence: ["ticket", "type", "subject"],
     },
   },


### PR DESCRIPTION
# [PRIZ-31/root] chore: JIRA 연동 설정

## 📝 작업 내용

> 적용할 commit, 브랜치 정책은 다음과 같습니다
   - JIRA 연동 후 커밋 메세지 형식
```
[JIRA 티켓] [커밋 type]: [커밋 내용]
```
   - JIRA 연동을 위한 브랜치 형식
```
[JIRA 티켓]/[커밋 type]/[작업위치]
```

- husky의 prepare-commit-msg를 활용하여 git commit 실행마다 브랜치에서 JIRA 티켓을 parsing하여 commit마다 prefix로 추가합니다.
   - parsing 로직은 아래와 같습니다 (단계별 예시는 line마다 주석에서 확인 가능합니다):
``` bash
BRANCH_NAME=$(git symbolic-ref -q HEAD)  # refs/heads/PRIZ-31/chore/root
BRANCH_NAME=$(echo "$BRANCH_NAME" | awk -F'/' '{print $(NF-2)"/"$(NF-1)"/"$NF}')   # PRIZ-31/chore/root
ISSUE_TICKET=$(echo "$BRANCH_NAME" | sed -n 's/^\([A-Z]*-[0-9]*\)\/\(.*\)$/\1/p')    # PRIZ-31
```
- 이후 husky의 commit-msg 훅이 실행되는데, commitlint.config.cjs에 정의한 규칙으로 commitlint를 실행합니다.
   - [commit conventions](https://www.conventionalcommits.org/en/v1.0.0/)에서 제시한 형식이 아닌 custom 키워드 ticket을 추가한 git message 형식을 사용하기 위해 parserPreset을 정의했습니다
   - headerPattern으로 `/^([A-Z]+-[0-9]+)\s(\w+):\s(.+)$/`을 사용하여 regex match group을 ["ticket", "type", "subject"]로 지정했습니다
   - type과 subject 관련 규칙은 기존 commitlint 정책과 동일합니다.

### 브랜치 및 커밋 작성 플로우
1. JIRA에서 이슈를 생성한다
2. 이슈에 할당된 JIRA 티켓을 확인하고, 위 브랜치 정책대로 브랜치를 생성한다
3. 작업 브랜치에서 커밋마다 개발자가 JIRA 티켓을 prefix로 작성하지 않아도 된다 (JIRA 연동 전 커밋 컨벤션대로 작성). 그 이유는 preapre-commit-msg 훅이 commit마다 실행되어 commit이 완료되기 전 commit 메시지를 수정한다
4. 커밋 후 커밋 로그에서 작성한 커밋에 티켓 prefix가 잘 추가되었는지 확인한다

## JIRA 티켓
[PRIZ-31]


[PRIZ-31]: https://hellpeople.atlassian.net/browse/PRIZ-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ