### PR TITLE
[FLIZ-5/root] chore: pnpm 버전 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prettier-plugin-tailwindcss": "^0.5.11",
     "turbo": "^2.3.3"
   },
-  "packageManager": "pnpm@8.15.6",
+  "packageManager": "pnpm@9.15.3+sha512.1f79bc245a66eb0b07c5d4d83131240774642caaa86ef7d0434ab47c0d16f66b04e21e0c086eb61e62c77efc4d7f7ec071afad3796af64892fae66509173893a",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
# [FLIZ-5/root] chore: pnpm 버전 업데이트

## 📝 작업 내용

turbo template에서 최신화되지 않았던 pnpm 버전을 9.15.3으로 업데이트합니다
- corepack을 활성화하여 package.json의 packageManager 옵션에 프로젝트에서 사용하는 pnpm 버전을 지정했습니다

> corepack이 활성화되지 않은 로컬 환경에서는 package.json packageManager가 적용되지 않습니다. [공식문서](https://pnpm.io/ko/9.x/installation#corepack-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0)를 참고하여 **corepack이 활성화되지 않은 FE 작업자는 활성화 부탁드립니다**.
