### PR TITLE
[FLIZ-13/ui] feat: DayOfWeekPicker 구현

### DIFF
--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -22,6 +22,7 @@
     "@storybook/addon-essentials": "^8.4.7",
     "@storybook/addon-interactions": "^8.4.7",
     "@storybook/blocks": "^8.4.7",
+    "@storybook/preview-api": "^8.4.7",
     "@storybook/react": "^8.4.7",
     "@storybook/react-vite": "^8.4.7",
     "@storybook/test": "^8.4.7",

--- a/docs/storybook/stories/DayofWeekPicker.stories.tsx
+++ b/docs/storybook/stories/DayofWeekPicker.stories.tsx
@@ -1,4 +1,4 @@
-import DayOfWeekPicker from "@5unwan/ui/components/DayOfWeekPicker";
+import DayOfWeekPicker from "@5unwan/ui/components/DayOfWeekPicker/DayOfWeekPicker";
 import { Meta, StoryObj } from "@storybook/react";
 import { useArgs } from "@storybook/preview-api";
 

--- a/docs/storybook/stories/DayofWeekPicker.stories.tsx
+++ b/docs/storybook/stories/DayofWeekPicker.stories.tsx
@@ -1,0 +1,48 @@
+import DayOfWeekPicker from "@5unwan/ui/components/DayOfWeekPicker";
+import { Meta, StoryObj } from "@storybook/react";
+import { useArgs } from "@storybook/preview-api";
+
+const meta: Meta<typeof DayOfWeekPicker> = {
+  component: DayOfWeekPicker,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="p-4 bg-background-primary"><Story/></div>
+    )
+  ],
+  argTypes: {
+    currentDay: {
+      control: 'number'
+    },
+    defaultDay: {
+      control: 'number'
+    },
+    className: {
+      control: 'text'
+    }
+  },
+  args: {
+    defaultDay: 0,
+  }
+};
+export default meta;
+
+type Story = StoryObj<typeof DayOfWeekPicker>;
+
+export const Uncontrolled: Story = {}
+
+export const Controlled: Story = {
+  render: function Render(args) {
+    const [{value}, updateArgs] = useArgs();
+
+    const handleCurrentDayChange = (value: number) => {
+      updateArgs({value});
+    }
+    return (
+      <>
+        <div className="text-text-primary">{value}</div>
+        <DayOfWeekPicker {...args} currentDay={value} onCurrentDayChange={handleCurrentDayChange} completed={[true, true, false,false,false,true,false]} className="w-full"/>
+      </>
+    )
+  }
+}

--- a/packages/ui/src/components/DayOfWeekPicker.tsx
+++ b/packages/ui/src/components/DayOfWeekPicker.tsx
@@ -1,0 +1,106 @@
+import React, { forwardRef, useCallback } from "react";
+
+import useControllableState from "../hooks/useControllableState";
+import useDayOfWeekPickerContext from "../hooks/useDayOfWeekPickerContext";
+import { cn } from "../lib/utils";
+import DayOfWeekPickerContext from "./DayOfWeekPicker/Context";
+import { Days } from "./DayOfWeekPicker/Days";
+
+const DayTable = ["월", "화", "수", "목", "금", "토", "일"] as const;
+
+const DAY_OF_WEEK_PICKER_NAME = "DayOfWeekPicker";
+const DAY_OF_WEEK_PICKER_ITEM_NAME = "DayOfWeekPickerItem";
+const DAY_OF_WEEK_PICKER_IMPL_NAME = "DayOfWeekPickerImpl";
+const DAYS_IN_WEEK = 7;
+
+export interface DayOfWeekPickerProps extends React.HTMLAttributes<HTMLDivElement>, WrapperProps {}
+type WrapperProps = {
+  currentDay?: Days;
+  onCurrentDayChange: (value: Days) => void;
+  defaultDay?: Days;
+  completed?: boolean[];
+};
+
+const DayOfWeekPicker = forwardRef<HTMLDivElement, DayOfWeekPickerProps>(
+  ({ currentDay, onCurrentDayChange, completed, defaultDay, ...commonProps }, ref) => {
+    const [value, setValue] = useControllableState({
+      prop: currentDay,
+      defaultProp: defaultDay || Days.Monday,
+      onChange: onCurrentDayChange,
+    });
+
+    return (
+      <DayOfWeekPickerContext.Provider
+        value={{
+          value: value || defaultDay,
+          completed: completed || Array.from(Array(DAYS_IN_WEEK), () => false),
+          onItemClick: useCallback(setValue, [setValue]),
+        }}
+      >
+        <DayOfWeekPickerImpl ref={ref} {...commonProps} />
+      </DayOfWeekPickerContext.Provider>
+    );
+  },
+);
+
+DayOfWeekPicker.displayName = DAY_OF_WEEK_PICKER_NAME;
+
+const DayOfWeekPickerImpl = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...commonProps }, ref) => {
+    return (
+      <div
+        className={cn(
+          "text-body-3 text-text-primary inline-flex items-center justify-between gap-[24px] transition-colors",
+          className,
+        )}
+        {...commonProps}
+        ref={ref}
+      >
+        {Array.from(Array(DAYS_IN_WEEK), (_, index) => Number(index)).map((day) => (
+          <DayOfWeekPickerItem key={day} day={day}>
+            {DayTable[day]}
+          </DayOfWeekPickerItem>
+        ))}
+      </div>
+    );
+  },
+);
+DayOfWeekPickerImpl.displayName = DAY_OF_WEEK_PICKER_IMPL_NAME;
+
+export interface DayOfWeekPickerItemProps extends React.HTMLAttributes<HTMLDivElement>, ItemProps {}
+type ItemProps = {
+  day: Days;
+};
+
+const DayOfWeekPickerItem = forwardRef<HTMLDivElement, DayOfWeekPickerItemProps>(
+  ({ day, children }, ref) => {
+    const context = useDayOfWeekPickerContext();
+    const isCurrent = context.value === day;
+    const handleClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      e.preventDefault();
+      context.onItemClick(day);
+    };
+    const isCompleted = context.completed[day];
+
+    return (
+      <div
+        className={cn(
+          "hover:bg-brand-primary-600 flex h-[30px] w-[30px] items-center justify-center rounded-full border-none transition-colors duration-150",
+          {
+            "bg-background-sub3": isCompleted,
+          },
+          {
+            "bg-brand-primary-500": isCurrent,
+          },
+        )}
+        ref={ref}
+        onClick={handleClick}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+DayOfWeekPickerItem.displayName = DAY_OF_WEEK_PICKER_ITEM_NAME;
+
+export default DayOfWeekPicker;

--- a/packages/ui/src/components/DayOfWeekPicker/Context.tsx
+++ b/packages/ui/src/components/DayOfWeekPicker/Context.tsx
@@ -1,0 +1,13 @@
+import { createContext, Dispatch } from "react";
+
+import { Days } from "./Days";
+
+type DayOfWeekPickerContext = {
+  value?: Days;
+  completed: boolean[];
+  onItemClick: Dispatch<React.SetStateAction<Days | undefined>>;
+};
+
+const DayOfWeekPickerContext = createContext<DayOfWeekPickerContext | null>(null);
+
+export default DayOfWeekPickerContext;

--- a/packages/ui/src/components/DayOfWeekPicker/DayOfWeekPicker.tsx
+++ b/packages/ui/src/components/DayOfWeekPicker/DayOfWeekPicker.tsx
@@ -76,13 +76,13 @@ type ItemProps = {
 
 const DayOfWeekPickerItem = forwardRef<HTMLDivElement, DayOfWeekPickerItemProps>(
   ({ day, children }, ref) => {
-    const context = useDayOfWeekPickerContext();
-    const isCurrent = context.value === day;
+    const { value, onItemClick, completed } = useDayOfWeekPickerContext();
+    const isCurrent = value === day;
     const handleClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
       e.preventDefault();
-      context.onItemClick(day);
+      onItemClick(day);
     };
-    const isCompleted = context.completed[day];
+    const isCompleted = completed[day];
 
     return (
       <div

--- a/packages/ui/src/components/DayOfWeekPicker/DayOfWeekPicker.tsx
+++ b/packages/ui/src/components/DayOfWeekPicker/DayOfWeekPicker.tsx
@@ -15,7 +15,7 @@ const DAY_OF_WEEK_PICKER_ITEM_NAME = "DayOfWeekPickerItem";
 const DAY_OF_WEEK_PICKER_IMPL_NAME = "DayOfWeekPickerImpl";
 const DAYS_IN_WEEK = 7;
 
-export interface DayOfWeekPickerProps extends React.HTMLAttributes<HTMLDivElement>, WrapperProps {}
+export type DayOfWeekPickerProps = React.HTMLAttributes<HTMLDivElement> & WrapperProps;
 type WrapperProps = {
   currentDay?: Days;
   onCurrentDayChange: (value: Days) => void;
@@ -72,7 +72,7 @@ const DayOfWeekPickerImpl = forwardRef<HTMLDivElement, React.HTMLAttributes<HTML
 );
 DayOfWeekPickerImpl.displayName = DAY_OF_WEEK_PICKER_IMPL_NAME;
 
-export interface DayOfWeekPickerItemProps extends React.HTMLAttributes<HTMLDivElement>, ItemProps {}
+export type DayOfWeekPickerItemProps = React.HTMLAttributes<HTMLDivElement> & ItemProps;
 type ItemProps = {
   day: Days;
 };

--- a/packages/ui/src/components/DayOfWeekPicker/DayOfWeekPicker.tsx
+++ b/packages/ui/src/components/DayOfWeekPicker/DayOfWeekPicker.tsx
@@ -58,7 +58,7 @@ const DayOfWeekPickerImpl = forwardRef<HTMLDivElement, React.HTMLAttributes<HTML
         {...commonProps}
         ref={ref}
       >
-        {Array.from(Array(DAYS_IN_WEEK), (_, index) => Number(index)).map((day) => (
+        {Array.from(Array(DAYS_IN_WEEK), (_, index) => index).map((day) => (
           <DayOfWeekPickerItem key={day} day={day}>
             {DayTable[day]}
           </DayOfWeekPickerItem>

--- a/packages/ui/src/components/DayOfWeekPicker/DayOfWeekPicker.tsx
+++ b/packages/ui/src/components/DayOfWeekPicker/DayOfWeekPicker.tsx
@@ -24,10 +24,13 @@ type WrapperProps = {
 };
 
 const DayOfWeekPicker = forwardRef<HTMLDivElement, DayOfWeekPickerProps>(
-  ({ currentDay, onCurrentDayChange, completed, defaultDay, ...commonProps }, ref) => {
+  (
+    { currentDay, onCurrentDayChange, completed, defaultDay = Days.Monday, ...commonProps },
+    ref,
+  ) => {
     const [value, setValue] = useControllableState({
       prop: currentDay,
-      defaultProp: defaultDay || Days.Monday,
+      defaultProp: defaultDay,
       onChange: onCurrentDayChange,
     });
 

--- a/packages/ui/src/components/DayOfWeekPicker/DayOfWeekPicker.tsx
+++ b/packages/ui/src/components/DayOfWeekPicker/DayOfWeekPicker.tsx
@@ -1,10 +1,12 @@
+"use client";
+
 import React, { forwardRef, useCallback } from "react";
 
-import useControllableState from "../hooks/useControllableState";
-import useDayOfWeekPickerContext from "../hooks/useDayOfWeekPickerContext";
-import { cn } from "../lib/utils";
-import DayOfWeekPickerContext from "./DayOfWeekPicker/Context";
-import { Days } from "./DayOfWeekPicker/Days";
+import DayOfWeekPickerContext from "./Context";
+import { Days } from "./Days";
+import useControllableState from "../../hooks/useControllableState";
+import useDayOfWeekPickerContext from "../../hooks/useDayOfWeekPickerContext";
+import { cn } from "../../lib/utils";
 
 const DayTable = ["월", "화", "수", "목", "금", "토", "일"] as const;
 

--- a/packages/ui/src/components/DayOfWeekPicker/Days.ts
+++ b/packages/ui/src/components/DayOfWeekPicker/Days.ts
@@ -1,0 +1,9 @@
+export enum Days {
+  Monday,
+  Tuesday,
+  Wednesday,
+  Thursday,
+  Friday,
+  Saturday,
+  Sunday,
+}

--- a/packages/ui/src/hooks/useDayOfWeekPickerContext.ts
+++ b/packages/ui/src/hooks/useDayOfWeekPickerContext.ts
@@ -1,0 +1,17 @@
+import { useContext } from "react";
+
+import DayOfWeekPickerContext from "../components/DayOfWeekPicker/Context";
+
+export const useDayOfWeekPickerContext = () => {
+  const context = useContext(DayOfWeekPickerContext);
+
+  if (!context) {
+    throw new Error(
+      "useDayOfWeekPickerContext has to be used within <DayOfWeekPickerContext.Provider",
+    );
+  }
+
+  return context;
+};
+
+export default useDayOfWeekPickerContext;

--- a/packages/ui/src/hooks/useDayOfWeekPickerContext.ts
+++ b/packages/ui/src/hooks/useDayOfWeekPickerContext.ts
@@ -7,7 +7,7 @@ export const useDayOfWeekPickerContext = () => {
 
   if (!context) {
     throw new Error(
-      "useDayOfWeekPickerContext has to be used within <DayOfWeekPickerContext.Provider",
+      "DayofWeekPicker components must be used within a <DayofWeekPicker> component.",
     );
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       '@storybook/blocks':
         specifier: ^8.4.7
         version: 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.4.2))
+      '@storybook/preview-api':
+        specifier: ^8.4.7
+        version: 8.4.7(storybook@8.4.7(prettier@3.4.2))
       '@storybook/react':
         specifier: ^8.4.7
         version: 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)


### PR DESCRIPTION
# [FLIZ-13/ui] feat: DayOfWeekPicker 구현

## 📝 작업 내용

DayOfWeekPicker 공통 컴포넌트를 구현했습니다
- 컴포넌트 용도 : 트레이너 도메인>PT수업시간 과 회원 도메인>PT희망시간 에서 요일 별로 공통된 비즈니스 로직을 수행하고, 각 요일의 수행 여부를 파악하기 위해 공통 컴포넌트로 구현했습니다
   - DayOfWeekPicker는 요일을 선택하고, 요일별로 비즈니스 로직을 수행했는지를 파악만 하며, 요일별 비즈니스 로직 상태 및 제어 상태는 DayOfWeekPicker 상위 컴포넌트에서 별도로 관리합니다

- Anatomy 
   - DayOfWeekPickerContext.Provider : DayOfWeekPicker 내부에서 공유하는 상태 (value, completed, onItemClick)를 리액트 Context에 주입합니다
   - DayOfWeekPickerImpl : 실제 DayOfWeekPicker의 구현(DOM으로 나타나는 부분)
   - DayOfWeekPickerItem : DayOfWeekPicker에서 선택할 수 있는 각 항목

- API Reference
   - DayOfWeekPicker
      - currentDay : 제어 상태, onCurrentDayChange와 함께 사용합니다. 현재 선택한 요일을 나타냅니다
      - onCurrentDayChange: DayOfWeekPicker의 상태 변경 시 호출되는 콜백함수입니다
      - defaultDay : 비제어 상태에서 사용되는 기본값. DayOfWeekPicker의 선택 요일의 기본값을 지정합니다
      - completed : 제어 상태. [월, ... 일] 까지 요일별 비즈니스 로직 완료 여부를 boolean[] 으로 나타냅니다.

### 📷 스크린샷 (선택)

![스크린샷 2025-01-15 오전 12 39 17](https://github.com/user-attachments/assets/4f8b15b4-652c-4588-9fbc-d6d8359f2fe4)

## 💬 리뷰 요구사항(선택)

- completed 상태를 비제어 로직으로 표현할 수 없습니다. DayOfWeekPicker 컴포넌트 상위의 컴포넌트에서 비즈니스 로직을 관리하도록 설계하여 비즈니스 로직을 요일별로 수행했는지를 DayOfWeekPicker 내부에서 자체적으로 파악할 수 없습니다. 
- radix-ui 컴포넌트 디자인을 따라 선택한 요일은 비제어/제어 상태로 관리할 수 있도록 지원했으나, 설계 구조상 completed까지 두 방식 모두 지원하는 것은 어려울 것 같습니다.
- 이후에 DayOfWeekPicker를 자식으로 둔 HOC 공통 컴포넌트를 구현하는 것을 고려해보면 좋을 것 같습니다. 해당 HOC는 아토믹 패턴 관점에서 molecule이나 organism 단위로 생각하며, props로 비즈니스 로직이 들어간 Form 컴포넌트나, 콜백함수를 주입하는 방식으로 설계를 할 수 있을 것 같습니다.