### PR TITLE
[FLIZ-19/ui] feat: Drawer 공통 컴포넌트 구현

### DIFF
--- a/docs/storybook/stories/Drawer.stories.tsx
+++ b/docs/storybook/stories/Drawer.stories.tsx
@@ -9,6 +9,8 @@ import {
 } from "@5unwan/ui/components/Drawer";
 import { Meta, StoryObj } from "@storybook/react";
 
+import { X } from "lucide-react";
+
 const meta: Meta = {
   component: Drawer,
 };
@@ -17,27 +19,24 @@ export default meta;
 type Story = StoryObj<typeof Drawer>;
 
 export const Default: Story = {
-  args: {
-    shouldScaleBackground: true,
-  },
   render: () => (
-    <div>
-      <Drawer>
-        <DrawerTrigger asChild={true}>
-          <button>Open</button>
-        </DrawerTrigger>
-        <DrawerContent>
-          <DrawerHeader>
-            <DrawerTitle>
-              <div className="text-title-1 flex items-center justify-between">
-                알림
-                <DrawerClose className="text-[20px]">X</DrawerClose>
-              </div>
-            </DrawerTitle>
-            <DrawerDescription></DrawerDescription>
-          </DrawerHeader>
-        </DrawerContent>
-      </Drawer>
-    </div>
+    <Drawer>
+      <DrawerTrigger asChild={true}>
+        <button>Open</button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>
+            <div className="text-title-1 flex items-center justify-between">
+              알림
+              <DrawerClose className="text-[20px]">
+                <X />
+              </DrawerClose>
+            </div>
+          </DrawerTitle>
+          <DrawerDescription></DrawerDescription>
+        </DrawerHeader>
+      </DrawerContent>
+    </Drawer>
   ),
 };

--- a/docs/storybook/stories/Drawer.stories.tsx
+++ b/docs/storybook/stories/Drawer.stories.tsx
@@ -1,0 +1,43 @@
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@5unwan/ui/components/Drawer";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta = {
+  component: Drawer,
+};
+export default meta;
+
+type Story = StoryObj<typeof Drawer>;
+
+export const Default: Story = {
+  args: {
+    shouldScaleBackground: true,
+  },
+  render: () => (
+    <div>
+      <Drawer>
+        <DrawerTrigger asChild={true}>
+          <button>Open</button>
+        </DrawerTrigger>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>
+              <div className="text-title-1 flex items-center justify-between">
+                알림
+                <DrawerClose className="text-[20px]">X</DrawerClose>
+              </div>
+            </DrawerTitle>
+            <DrawerDescription></DrawerDescription>
+          </DrawerHeader>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  ),
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,7 +54,8 @@
     "@radix-ui/react-dialog": "^1.1.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "tailwind-merge": "^2.6.0"
+    "tailwind-merge": "^2.6.0",
+    "vaul": "^1.1.2"
   },
   "exports": {
     "./utils": "./lib/utils.ts",

--- a/packages/ui/src/components/Drawer.tsx
+++ b/packages/ui/src/components/Drawer.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "../lib/utils";
+
+function Drawer({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return (
+    <DrawerPrimitive.Root
+      shouldScaleBackground={shouldScaleBackground}
+      direction={props.direction ?? "left"}
+      {...props}
+    />
+  );
+}
+Drawer.displayName = "Drawer";
+
+const DrawerTrigger = DrawerPrimitive.Trigger;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn("bg-background-primary fixed inset-0 z-50", className)}
+    {...props}
+  />
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "bg-background-sub2 text-text-primary fixed inset-x-0 bottom-0 z-50 flex h-full w-10/12 flex-col pl-[35px] pr-[24px]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = "DrawerContent";
+
+function DrawerHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("grid sm:text-left", className)} {...props} />;
+}
+DrawerHeader.displayName = "DrawerHeader";
+
+function DrawerFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("mt-auto flex flex-col", className)} {...props} />;
+}
+DrawerFooter.displayName = "DrawerFooter";
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title ref={ref} className={cn("text-title-1 mt-[21px]", className)} {...props} />
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-muted-foreground text-sm", className)}
+    {...props}
+  />
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/packages/ui/src/components/Drawer.tsx
+++ b/packages/ui/src/components/Drawer.tsx
@@ -17,7 +17,6 @@ function Drawer({
     />
   );
 }
-Drawer.displayName = "Drawer";
 
 const DrawerTrigger = DrawerPrimitive.Trigger;
 
@@ -60,12 +59,10 @@ DrawerContent.displayName = "DrawerContent";
 function DrawerHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return <div className={cn("grid sm:text-left", className)} {...props} />;
 }
-DrawerHeader.displayName = "DrawerHeader";
 
 function DrawerFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return <div className={cn("mt-auto flex flex-col", className)} {...props} />;
 }
-DrawerFooter.displayName = "DrawerFooter";
 
 const DrawerTitle = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Title>,

--- a/packages/ui/src/components/Drawer.tsx
+++ b/packages/ui/src/components/Drawer.tsx
@@ -46,7 +46,7 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "bg-background-sub2 text-text-primary fixed inset-x-0 bottom-0 z-50 flex h-full w-10/12 flex-col pl-[35px] pr-[24px]",
+        "bg-background-sub2 text-text-primary fixed inset-x-0 bottom-0 z-50 flex h-full w-10/12 flex-col px-[1.5rem]",
         className,
       )}
       {...props}
@@ -71,7 +71,11 @@ const DrawerTitle = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <DrawerPrimitive.Title ref={ref} className={cn("text-title-1 mt-[21px]", className)} {...props} />
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn("text-title-1 ml-[0.688rem] mt-[1.313rem]", className)}
+    {...props}
+  />
 ));
 DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
 
@@ -81,7 +85,7 @@ const DrawerDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Description
     ref={ref}
-    className={cn("text-muted-foreground text-sm", className)}
+    className={cn("text-muted-foreground", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## 📝 작업 내용

`shadcn`에 정의된 `vaul`을 이용하여 notification 관련  Drawer 컴포넌트를 구현하였습니다.
유저 notification에서만 사용하는 것으로 보아, `default` `direction`을 `left`로 변경하였으며,
left만 사용할 것으로 예상되어 그 외 방향은 오히려 다른 컴포넌트가 개발이 진행되고 난 후 개발되는 것이 좋다판단하여 `left` 방향으로만 개발해놓았습니다.

해당 컴포넌트를 스토리북에서도 확인 할 수 있습니다.

사용방법은 다음과 같습니다.
```typescript
import React from "react";

import {
  Drawer,
  DrawerClose,
  DrawerContent,
  DrawerHeader,
  DrawerTitle,
  DrawerTrigger,
} from "./_components/Drawer";

import { X } from "lucide-react";

// 함수명은 자유롭게
function Notification() {
  return (
    <div>
      <Drawer>
        <DrawerTrigger asChild={true}>
          <div>Open</div>
        </DrawerTrigger>
        <DrawerContent>
          <DrawerHeader>
            <DrawerTitle>
              <div className="text-title-1 flex items-center justify-between">
                알림
                <DrawerClose>
                  <X className="relative text-[25px]" />
                </DrawerClose>
              </div>
            </DrawerTitle>
          </DrawerHeader>
        </DrawerContent>
      </Drawer>
    </div>
  );
}

export default page;
```

<Drawer.Title></Drawer.Title> 사이에 "알람" 타이틀과 DrawerClose를 `X` 아이콘으로 감싸 헤더부분을 장식할 수 있습니다.

### 📷 스크린샷 (선택)

<img width="403" alt="스크린샷 2025-01-14 오전 12 43 53" src="https://github.com/user-attachments/assets/f8ed2184-cc7e-48b9-b733-49ce0e81818b" />

🚧 주의
1. shadcn 본문에서 `Drawer.Trigger` 컴포넌트의 자식으로 글자만 넘겨주었는데 컴포넌트가 해당 글자를 가려서 `aria-hidden` 오류가 발생하였습니다.
[aria-hidden - GitHub Issue](https://github.com/emilkowalski/vaul/issues/517)
[aria-hidden - Tistory](https://youngju-js.tistory.com/68)
많은 개발자들이 해당 오류에 대하여 질문을 하고 있었는데, Trigger에 `asChild={true}`로 추가해주고 하위에 글자만이 아닌 <div>태그나 엘리먼트로 감싸주면 해당 오류는 개발자 콘솔에서 사라지는걸 확인하였습니다.


## 💬 리뷰 요구사항(선택)

부족한 부분에 대해서 피드백 주시면 빠르게 수정하겠습니다.
