### PR TITLE
[FLIZ-18/ui] feat: TimePicker 공통 컴포넌트 구현

### DIFF
--- a/docs/storybook/stories/TimePicker.stories.tsx
+++ b/docs/storybook/stories/TimePicker.stories.tsx
@@ -1,0 +1,134 @@
+import TimePicker from "@5unwan/ui/components/TimePicker";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof TimePicker> = {
+  component: TimePicker,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="flex h-[240px] w-fit items-center justify-center bg-black">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    startNumber: 0,
+    initIdx: 1,
+    label: undefined,
+    length: 12,
+    loop: false,
+    viewPerspective: "center",
+    setValue: undefined,
+    width: 23,
+  },
+  argTypes: {
+    startNumber: {
+      control: "number",
+      description: "TimePicker의 시작 숫자를 설정합니다.",
+    },
+    initIdx: {
+      control: "number",
+      description: "초기 인덱스를 숫자로 설정할 수 있습니다.",
+    },
+    label: {
+      control: "text",
+      description: "텍스트 입력을 통해 라벨을 설정할 수 있습니다.",
+    },
+    length: {
+      control: "number",
+      description: "TimePicker의 길이를 숫자로 설정할 수 있습니다.",
+    },
+    loop: {
+      control: "boolean",
+      description: "루프 기능을 켜거나 끌 수 있습니다.",
+    },
+    viewPerspective: {
+      control: "select",
+      options: ["left", "right", "center"],
+    },
+    setValue: {
+      action: "setValue",
+      description:
+        "sliderState와 함께 동작하여 각 슬라이드의 상대적 위치나 절대적인 값을 계산한 후, 이를 이용해 value를 생성하는 역할의 외부에서 주입되는 콜백 함수입니다.",
+    },
+    width: {
+      control: "number",
+      description: "TimePicker의 너비를 설정 할 수 있습니다.",
+    },
+    ref: {
+      action: "getValue",
+      description: "ref 주입을 통해 TimePicker에서 선택한 아이템을 참조할 수 있습니다.",
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TimePicker>;
+
+export const Default: Story = {
+  args: {
+    initIdx: 0,
+    length: 60,
+    loop: false,
+    width: 23,
+  },
+  render: (args) => {
+    return (
+      <div className="h-[180px] w-[70px]">
+        <TimePicker {...args} />
+      </div>
+    );
+  },
+};
+
+export const SetHourAndMinites: Story = {
+  render: () => (
+    <>
+      <div className="h-[180px] w-[70px]">
+        <TimePicker initIdx={0} length={24} width={23} loop={false} />
+      </div>
+      <div className="h-[180px] w-[70px]">
+        <TimePicker initIdx={0} length={60} width={23} loop={false} />
+      </div>
+    </>
+  ),
+};
+
+export const WithTimePeriods: Story = {
+  render: () => {
+    const setHalfHours = (relative: number) => {
+      return relative ? "30" : "00";
+    };
+    const setTimePeriods = (relative: number) => {
+      return relative ? "오후" : "오전";
+    };
+    return (
+      <>
+        <div className="h-[180px] w-[70px]">
+          <TimePicker
+            initIdx={0}
+            length={2}
+            width={40}
+            loop={false}
+            viewPerspective="right"
+            setValue={setTimePeriods}
+          />
+        </div>
+        <div className="h-[180px] w-[70px]">
+          <TimePicker startNumber={1} initIdx={0} length={12} width={23} loop={false} />
+        </div>
+        <div className="h-[180px] w-[70px]">
+          <TimePicker
+            initIdx={0}
+            length={2}
+            width={23}
+            loop={false}
+            viewPerspective="left"
+            setValue={setHalfHours}
+          />
+        </div>
+      </>
+    );
+  },
+};

--- a/packages/config-tailwind/tailwind.config.ts
+++ b/packages/config-tailwind/tailwind.config.ts
@@ -130,6 +130,10 @@ const config: Omit<Config, "content"> = {
           "-webkit-mask":
             "radial-gradient(circle 8px at calc(100% - 2px) calc(0% + 2px),#0000 98%,#000)",
         },
+        ".backface-hidden": {
+          "backface-visibility": "hidden",
+          "-webkit-backface-visibility": "hidden",
+        },
       });
     }),
   ],

--- a/packages/config-tailwind/variables.css
+++ b/packages/config-tailwind/variables.css
@@ -23,4 +23,11 @@
 
     --notification: 360 100% 66%;
   }
+
+  body {
+    margin: 0;
+    font-family: "Inter", sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,6 +54,7 @@
     "@radix-ui/react-dialog": "^1.1.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "keen-slider": "^6.8.6",
     "tailwind-merge": "^2.6.0"
   },
   "exports": {

--- a/packages/ui/src/components/TimePicker.tsx
+++ b/packages/ui/src/components/TimePicker.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable no-magic-numbers */
-import { KeenSliderOptions, TrackDetails, useKeenSlider } from "keen-slider/react";
+import {
+  KeenSliderHooks,
+  KeenSliderInstance,
+  KeenSliderOptions,
+  TrackDetails,
+  useKeenSlider,
+} from "keen-slider/react";
 import { forwardRef, useEffect, useRef, useState } from "react";
 
 import { cn } from "../lib/utils";
@@ -35,22 +41,10 @@ const TimePicker = forwardRef<number | string, TimePickerProps>(
 
       initial: initIdx || 0,
       loop: loop,
-      dragSpeed: (val) => {
-        const height = size.current;
-
-        return (
-          val * (height / ((height / 2) * Math.tan(slideDegree * (Math.PI / 180))) / slidesPerView)
-        );
-      },
-      created: (s) => {
-        size.current = s.size;
-      },
-      updated: (s) => {
-        size.current = s.size;
-      },
-      detailsChanged: (s) => {
-        setSliderState(s.track.details);
-      },
+      dragSpeed: handleDragSpeed,
+      created: handleCreated,
+      updated: handleUpdated,
+      detailsChanged: handleDetailsChanged,
       rubberband: !loop,
       mode: "free-snap",
     });
@@ -70,6 +64,26 @@ const TimePicker = forwardRef<number | string, TimePickerProps>(
     useEffect(() => {
       if (slider.current) setRadius(slider.current.size / 2);
     }, [slider]);
+
+    function handleDragSpeed(val: number) {
+      const height = size.current;
+
+      return (
+        val * (height / ((height / 2) * Math.tan(slideDegree * (Math.PI / 180))) / slidesPerView)
+      );
+    }
+
+    function handleCreated(s: KeenSliderInstance<object, object, KeenSliderHooks>) {
+      size.current = s.size;
+    }
+
+    function handleUpdated(s: KeenSliderInstance<object, object, KeenSliderHooks>) {
+      size.current = s.size;
+    }
+
+    function handleDetailsChanged(s: KeenSliderInstance<object, object, KeenSliderHooks>) {
+      setSliderState(s.track.details);
+    }
 
     function slideValues() {
       if (!sliderState) return [];

--- a/packages/ui/src/components/TimePicker.tsx
+++ b/packages/ui/src/components/TimePicker.tsx
@@ -55,7 +55,7 @@ const TimePicker = forwardRef<number | string, TimePickerProps>(
 
     useEffect(() => {
       if (sliderState && ref && "current" in ref) {
-        const getValue = slideValues()[sliderState.abs].value;
+        const getValue = getValues()[sliderState.abs].value;
 
         ref.current = getValue;
       }
@@ -85,7 +85,7 @@ const TimePicker = forwardRef<number | string, TimePickerProps>(
       setSliderState(s.track.details);
     }
 
-    function slideValues() {
+    function getValues() {
       if (!sliderState) return [];
       const offset = loop ? 1 / 2 - 1 / slidesPerView / 2 : 0;
 
@@ -130,7 +130,7 @@ const TimePicker = forwardRef<number | string, TimePickerProps>(
         />
         <div className="perspective-[1000px] transform-style-preserve-3d flex h-[16%] w-full items-center justify-center">
           <div className="relative h-full w-full" style={{ width: width + "px" }}>
-            {slideValues().map(({ style, value }, idx) => (
+            {getValues().map(({ style, value }, idx) => (
               <div
                 className="backface-hidden absolute flex h-full w-full items-center justify-end text-[20px] font-normal"
                 style={style}

--- a/packages/ui/src/components/TimePicker.tsx
+++ b/packages/ui/src/components/TimePicker.tsx
@@ -85,6 +85,12 @@ const TimePicker = forwardRef<number | string, TimePickerProps>(
       setSliderState(s.track.details);
     }
 
+    const convertPxToRem = (px: number, precision: number = 4): string => {
+      const remValue = px / 16;
+
+      return `${remValue.toFixed(precision)}`;
+    };
+
     function getValues() {
       if (!sliderState) return [];
       const offset = loop ? 1 / 2 - 1 / slidesPerView / 2 : 0;
@@ -96,8 +102,8 @@ const TimePicker = forwardRef<number | string, TimePickerProps>(
           : 0;
         const rotate = Math.abs(distance) > wheelSize / 2 ? 180 : distance * (360 / wheelSize) * -1;
         const style = {
-          transform: `rotateX(${rotate}deg) translateZ(${radius}px)`,
-          WebkitTransform: `rotateX(${rotate}deg) translateZ(${radius}px)`,
+          transform: `rotateX(${rotate}deg) translateZ(${convertPxToRem(radius)}rem)`,
+          WebkitTransform: `rotateX(${rotate}deg) translateZ(${convertPxToRem(radius)}rem)`,
         };
         const currentValue = i + (startNumber || 0);
         const value = setValue
@@ -116,23 +122,25 @@ const TimePicker = forwardRef<number | string, TimePickerProps>(
       <div
         className={cn(
           "text-text-primary h-full w-full overflow-visible",
-          perspective === "right" && "perspective-origin-[calc(50%+100px)_50%] translate-x-[10px]",
-          perspective === "left" && "perspective-origin-[calc(50%-100px)_50%] translate-x-[-10px]",
+          perspective === "right" &&
+            "perspective-origin-[calc(50%+6.25rem)_50%] translate-x-[0.625rem]",
+          perspective === "left" &&
+            "perspective-origin-[calc(50%-6.25rem)_50%] translate-x-[-0.625rem]",
         )}
         ref={sliderRef}
       >
         <div
-          className="z-5 relative left-0 -mt-[2px] h-[calc(42%+2px)] w-full border-b border-white/30 bg-gradient-to-b from-black/90 to-black/50"
+          className="z-5 relative left-0 -mt-[0.125rem] h-[calc(42%+0.125rem)] w-full border-b border-white/30 bg-gradient-to-b from-black/90 to-black/50"
           style={{
-            transform: `translateZ(${radius}px)`,
-            WebkitTransform: `translateZ(${radius}px)`,
+            transform: `translateZ(${convertPxToRem(radius)}rem)`,
+            WebkitTransform: `translateZ(${convertPxToRem(radius)}rem)`,
           }}
         />
-        <div className="perspective-[1000px] transform-style-preserve-3d flex h-[16%] w-full items-center justify-center">
-          <div className="relative h-full w-full" style={{ width: width + "px" }}>
+        <div className="perspective-[62.5rem] transform-style-preserve-3d flex h-[16%] w-full items-center justify-center">
+          <div className="relative h-full w-full" style={{ width: convertPxToRem(width) + "rem" }}>
             {getValues().map(({ style, value }, idx) => (
               <div
-                className="backface-hidden absolute flex h-full w-full items-center justify-end text-[20px] font-normal"
+                className="backface-hidden absolute flex h-full w-full items-center justify-end text-[1.25rem] font-normal"
                 style={style}
                 key={`${value}-${idx}`}
               >
@@ -144,8 +152,8 @@ const TimePicker = forwardRef<number | string, TimePickerProps>(
             <div
               className="ml-1 mt-1 text-sm font-medium leading-tight"
               style={{
-                transform: `translateZ(${radius}px)`,
-                WebkitTransform: `translateZ(${radius}px)`,
+                transform: `translateZ(${convertPxToRem(radius)}rem)`,
+                WebkitTransform: `translateZ(${convertPxToRem(radius)}rem)`,
               }}
             >
               {label}
@@ -153,10 +161,10 @@ const TimePicker = forwardRef<number | string, TimePickerProps>(
           )}
         </div>
         <div
-          className="border-b-none z-5 relative left-0 mt-[2px] h-[calc(42%+2px)] w-full border-t border-t-white/30 bg-gradient-to-b from-black/90 to-black/50"
+          className="border-b-none z-5 relative left-0 mt-[0.125rem] h-[calc(42%+0.125rem)] w-full border-t border-t-white/30 bg-gradient-to-b from-black/50 to-black/90"
           style={{
-            transform: `translateZ(${radius}px)`,
-            WebkitTransform: `translateZ(${radius}px)`,
+            transform: `translateZ(${convertPxToRem(radius)}rem)`,
+            WebkitTransform: `translateZ(${convertPxToRem(radius)}rem)`,
           }}
         />
       </div>

--- a/packages/ui/src/components/TimePicker.tsx
+++ b/packages/ui/src/components/TimePicker.tsx
@@ -1,0 +1,155 @@
+/* eslint-disable no-magic-numbers */
+import { KeenSliderOptions, TrackDetails, useKeenSlider } from "keen-slider/react";
+import { forwardRef, useEffect, useRef, useState } from "react";
+
+import { cn } from "../lib/utils";
+
+type TimePickerProps = {
+  startNumber?: number;
+  initIdx?: number;
+  label?: string;
+  length: number;
+  loop?: boolean;
+  viewPerspective?: "left" | "right" | "center";
+  setValue?: (relative: number, absolute: number) => string;
+  width: number;
+};
+
+const TimePicker = forwardRef<number | string, TimePickerProps>(
+  ({ startNumber, initIdx, label, length, loop, viewPerspective, setValue, width }, ref) => {
+    const perspective = viewPerspective || "center";
+    const wheelSize = 20;
+    const slides = length;
+    const slideDegree = 360 / wheelSize;
+    const slidesPerView = loop ? 9 : 1;
+    const [sliderState, setSliderState] = useState<TrackDetails | null>(null);
+    const size = useRef(0);
+    const options = useRef<KeenSliderOptions>({
+      slides: {
+        number: slides,
+        origin: loop ? "center" : "auto",
+        perView: slidesPerView,
+      },
+
+      vertical: true,
+
+      initial: initIdx || 0,
+      loop: loop,
+      dragSpeed: (val) => {
+        const height = size.current;
+
+        return (
+          val * (height / ((height / 2) * Math.tan(slideDegree * (Math.PI / 180))) / slidesPerView)
+        );
+      },
+      created: (s) => {
+        size.current = s.size;
+      },
+      updated: (s) => {
+        size.current = s.size;
+      },
+      detailsChanged: (s) => {
+        setSliderState(s.track.details);
+      },
+      rubberband: !loop,
+      mode: "free-snap",
+    });
+
+    const [sliderRef, slider] = useKeenSlider<HTMLDivElement>(options.current);
+
+    const [radius, setRadius] = useState(0);
+
+    useEffect(() => {
+      if (sliderState && ref && "current" in ref) {
+        const getValue = slideValues()[sliderState.abs].value;
+
+        ref.current = getValue;
+      }
+    }, [sliderState, ref]);
+
+    useEffect(() => {
+      if (slider.current) setRadius(slider.current.size / 2);
+    }, [slider]);
+
+    function slideValues() {
+      if (!sliderState) return [];
+      const offset = loop ? 1 / 2 - 1 / slidesPerView / 2 : 0;
+
+      const values = [];
+      for (let i = 0; i < slides; i += 1) {
+        const distance = sliderState
+          ? (sliderState.slides[i].distance - offset) * slidesPerView
+          : 0;
+        const rotate = Math.abs(distance) > wheelSize / 2 ? 180 : distance * (360 / wheelSize) * -1;
+        const style = {
+          transform: `rotateX(${rotate}deg) translateZ(${radius}px)`,
+          WebkitTransform: `rotateX(${rotate}deg) translateZ(${radius}px)`,
+        };
+        const currentValue = i + (startNumber || 0);
+        const value = setValue
+          ? setValue(i, sliderState.abs + Math.round(distance))
+          : Math.floor(currentValue / 10) < 1
+            ? `0${currentValue}`
+            : currentValue;
+
+        values.push({ style, value });
+      }
+
+      return values;
+    }
+
+    return (
+      <div
+        className={cn(
+          "text-text-primary h-full w-full overflow-visible",
+          perspective === "right" && "perspective-origin-[calc(50%+100px)_50%] translate-x-[10px]",
+          perspective === "left" && "perspective-origin-[calc(50%-100px)_50%] translate-x-[-10px]",
+        )}
+        ref={sliderRef}
+      >
+        <div
+          className="z-5 relative left-0 -mt-[2px] h-[calc(42%+2px)] w-full border-b border-white/30 bg-gradient-to-b from-black/90 to-black/50"
+          style={{
+            transform: `translateZ(${radius}px)`,
+            WebkitTransform: `translateZ(${radius}px)`,
+          }}
+        />
+        <div className="perspective-[1000px] transform-style-preserve-3d flex h-[16%] w-full items-center justify-center">
+          <div className="relative h-full w-full" style={{ width: width + "px" }}>
+            {slideValues().map(({ style, value }, idx) => (
+              <div
+                className="backface-hidden absolute flex h-full w-full items-center justify-end text-[20px] font-normal"
+                style={style}
+                key={`${value}-${idx}`}
+              >
+                <span className="font-mono">{value}</span>
+              </div>
+            ))}
+          </div>
+          {label && (
+            <div
+              className="ml-1 mt-1 text-sm font-medium leading-tight"
+              style={{
+                transform: `translateZ(${radius}px)`,
+                WebkitTransform: `translateZ(${radius}px)`,
+              }}
+            >
+              {label}
+            </div>
+          )}
+        </div>
+        <div
+          className="border-b-none z-5 relative left-0 mt-[2px] h-[calc(42%+2px)] w-full border-t border-t-white/30 bg-gradient-to-b from-black/90 to-black/50"
+          style={{
+            transform: `translateZ(${radius}px)`,
+            WebkitTransform: `translateZ(${radius}px)`,
+          }}
+        />
+      </div>
+    );
+  },
+);
+
+TimePicker.displayName = "TimePicker";
+
+export default TimePicker;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 1.7.9
       next:
         specifier: 14.2.20
-        version: 14.2.20(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.20(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -125,7 +125,7 @@ importers:
         version: 1.7.9
       next:
         specifier: 14.2.20
-        version: 14.2.20(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.20(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -368,6 +368,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      keen-slider:
+        specifier: ^6.8.6
+        version: 6.8.6
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -3954,6 +3957,9 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  keen-slider@6.8.6:
+    resolution: {integrity: sha512-dcEQ7GDBpCjUQA8XZeWh3oBBLLmyn8aoeIQFGL/NTVkoEOsmlnXqA4QykUm/SncolAZYGsEk/PfUhLZ7mwMM2w==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -9837,6 +9843,8 @@ snapshots:
       object.assign: 4.1.5
       object.values: 1.2.0
 
+  keen-slider@6.8.6: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -10079,7 +10087,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@14.2.20(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.20(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.20
       '@swc/helpers': 0.5.5
@@ -10089,7 +10097,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react@18.3.1)
+      styled-jsx: 5.1.1(babel-plugin-macros@3.1.0)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.20
       '@next/swc-darwin-x64': 14.2.20
@@ -10867,12 +10875,11 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.1(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react@18.3.1):
+  styled-jsx@5.1.1(babel-plugin-macros@3.1.0)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
     optionalDependencies:
-      '@babel/core': 7.26.0
       babel-plugin-macros: 3.1.0
 
   stylis@4.2.0: {}


### PR DESCRIPTION
<!-- 작업 패키지: root, ui, trainer, user, config-eslint, config-typescript, config-tailwind, storybook -->

## 📝 작업 내용

## TimePicker 공통 컴포넌트 구현
- keen-slider 오픈소스 라이브러리를 바탕으로 TimePicker 공통 컴포넌트를 구현하였습니다.
   - [keen-slider TimePicker 컴포넌트 레퍼런스](https://codesandbox.io/p/sandbox/great-hermann-9xglw8?file=/src/Wheel.tsx)
   - [keen-slider API 레퍼런스](https://keen-slider.io/docs#properties)
- Interface
```ts
type TimePickerProps = {
  startNumber?: number; // 기본값이 0 이며, 이 값부터 슬라이더의 숫자가 시작됨
  initIdx?: number; // 슬라이더의 초기 선택 위치 선정
  label?: string; // 슬라이더 옆에 표시되는 라벨 텍스트
  length: number; // 슬라이더에 표시될 전체 항목 수
  loop?: boolean; // 슬라이더의 순환 여부 결정
  viewPerspective?: "left" | "right" | "center"; // 슬라이더의 3D 시점을 설정
  setValue?: (relative: number, absolute: number) => string; // 슬라이더 값의 커스텀 포맷팅을 위한 함수
  width: number; // 슬라이더의 너비 지정
  ref: // 현재 선택된 값을 외부에서 참조하기 위한 ref
};
```
- 제어 컴포넌트 설계의 한계
   - 해당 컴포넌트는 휠 슬라이드가 돌아갈 때마다 엄청난 리렌더링을 일으킵니다. 따라서 `TimePicker`에서 선택된 값을 상위에서 제어 컴포넌트 형태로 핸들링하기에는 상위의 컴포넌트도 모두 엄청난 리렌더링이 발생할 것 입니다.
   - 따라서 비제어 컴포넌트 방식으로 상위에서 ref를 전달하고, `TimePicker`는 내부적으로 계산되어 선택된 값을 `ref.current`에 주입하여 상위에서 참조할 수 있도록 구현하였습니다. 따라서 상위의 `sibling component`간 데이터 공유도 가능할 수 있도록 설계하였습니다.
- setValue를 사용한 커스텀
   - 우리가 원하는 값을 집어넣어 슬라이드를 돌리려면 커스텀이 필요합니다. 상위에서 `setValue`, `length`, `startNumber`, `initIdx`등 다양하게 사용하여 `TimePicker` 컴포넌트를 커스텀 할 수 있는데 그 예시중 하나를 아래 코드로 보여드리겠습니다.
```ts
    const setHalfHours = (relative: number) => {
      return relative ? "30" : "00";
    };
    const setTimePeriods = (relative: number) => {
      return relative ? "오후" : "오전";
    };
    return (
      <>
        <div className="h-[180px] w-[70px]">
          <TimePicker
            initIdx={0}
            length={2}
            width={40}
            loop={false}
            viewPerspective="right"
            setValue={setTimePeriods}
          />
        </div>
        <div className="h-[180px] w-[70px]">
          <TimePicker startNumber={1} initIdx={0} length={12} width={23} loop={false} />
        </div>
        <div className="h-[180px] w-[70px]">
          <TimePicker
            initIdx={0}
            length={2}
            width={23}
            loop={false}
            viewPerspective="left"
            setValue={setHalfHours}
          />
        </div>
      </>
    );
```

## 디자인 제한 사항
현재 TimePicker에 대한 디자인 명세가 나오지 않아 대략적인 디자인과 기능만 구현되어있습니다. 명확한 디자인은 디자인 명세가 나온 후 다시 수정 할 예정입니다.

### 📷 스크린샷 (선택)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/352803d5-e939-474d-9d56-5e514d224573" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/b838c44e-9ad9-4d6e-a8ba-cbcd4fc8a51c" />


## 💬 리뷰 요구사항(선택)
- 해당 컴포넌트 특성상 매직넘버가 굉장히 많이 사용되고 있습니다. 매직 넘버 하나하나에 이름을 부여하여 하는 것이 좋을지 매직 넘버 그대로 두는 것이 읽는 사람 입장에서 가독성이 좋을지 고민이 되는 와중에 우선 매직 넘버를 그대로 사용하도록 해당 파일에서만 eslint를 제거하였습니다. 위 코드를 보시고 매직넘버에 이름을 부여하는 것이 가독성에 좋다고 판단되면 피드백해주세요!