### PR TITLE
[FLIZ-21/ui] Spinner 공통 컴포넌트 구현

### DIFF
--- a/docs/storybook/stories/Spinner.stories.tsx
+++ b/docs/storybook/stories/Spinner.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-
 import Spinner from "@5unwan/ui/components/Spinner";
 
 const meta: Meta<typeof Spinner> = {
@@ -12,10 +11,6 @@ const meta: Meta<typeof Spinner> = {
       options: ["small", "middle"],
       description: "스피너 크기",
     },
-    loading: {
-      control: "boolean",
-      description: "스피너 로딩 여부",
-    },
     className: {
       control: "text",
       description: "스피너 클래스",
@@ -23,7 +18,6 @@ const meta: Meta<typeof Spinner> = {
   },
   args: {
     size: "small",
-    loading: true,
     className: "",
   },
 };
@@ -34,18 +28,17 @@ type Story = StoryObj<typeof Spinner>;
 export const Default: Story = {
   args: {
     size: "small",
-    loading: true,
   },
 };
+
 export const Small: Story = {
   args: {
     size: "small",
-    loading: true,
   },
 };
+
 export const Middle: Story = {
   args: {
     size: "middle",
-    loading: true,
   },
 };

--- a/docs/storybook/stories/Spinner.stories.tsx
+++ b/docs/storybook/stories/Spinner.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+
+import Spinner from "@5unwan/ui/components/Spinner";
+
+const meta: Meta<typeof Spinner> = {
+  component: Spinner,
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["small", "middle"],
+      description: "스피너 크기",
+    },
+    loading: {
+      control: "boolean",
+      description: "스피너 로딩 여부",
+    },
+    className: {
+      control: "text",
+      description: "스피너 클래스",
+    },
+  },
+  args: {
+    size: "small",
+    loading: true,
+    className: "",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Spinner>;
+
+export const Default: Story = {
+  args: {
+    size: "small",
+    loading: true,
+  },
+};
+export const Small: Story = {
+  args: {
+    size: "small",
+    loading: true,
+  },
+};
+export const Middle: Story = {
+  args: {
+    size: "middle",
+    loading: true,
+  },
+};

--- a/packages/ui/src/components/Spinner.tsx
+++ b/packages/ui/src/components/Spinner.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { cva, VariantProps } from "class-variance-authority";
+import { useEffect, useRef } from "react";
+
+import { cn } from "../lib/utils";
+
+const ROTATION_SPEED: number = 100;
+const ROTATION_DEGREE: number = 45;
+const OPACITY_STEPS: Readonly<Array<string>> = [
+  "1",
+  "0.87",
+  "0.75",
+  "0.63",
+  "0.51",
+  "0.39",
+  "0.27",
+  "0.15",
+];
+const OPACITY_STEP: number = 1;
+
+const SPINNER_KEYS: Readonly<Array<string>> = [
+  "spinner-spin-0",
+  "spinner-spin-1",
+  "spinner-spin-2",
+  "spinner-spin-3",
+  "spinner-spin-4",
+  "spinner-spin-5",
+  "spinner-spin-6",
+  "spinner-spin-7",
+];
+
+const spinnerVariants = cva("bg-text-sub2 absolute h-[10px] w-[4px] rounded-lg", {
+  variants: {
+    size: {
+      small: "h-[7px] w-[3px]",
+      middle: "h-[10px] w-[4px]",
+    },
+  },
+  defaultVariants: {
+    size: "small",
+  },
+});
+
+interface SpinnerProps extends VariantProps<typeof spinnerVariants> {
+  loading?: boolean;
+  className?: string;
+}
+
+export default function Spinner({ size, loading, className }: Readonly<SpinnerProps>) {
+  const spinnerRefs = useRef<HTMLSpanElement[] | null[]>([]);
+
+  useEffect(() => {
+    const intervalIds = spinnerRefs.current.map((ref, index) => {
+      let opacityIndex: number = index;
+
+      return setInterval(() => {
+        if (ref) {
+          ref.style.opacity = `${OPACITY_STEPS[opacityIndex]}`;
+          opacityIndex = (opacityIndex + OPACITY_STEP) % OPACITY_STEPS.length;
+        }
+      }, ROTATION_SPEED);
+    });
+
+    return () => {
+      intervalIds.forEach(clearInterval);
+    };
+  }, []);
+
+  if (!loading) {
+    return null;
+  }
+
+  return (
+    <div className="relative flex h-fit w-fit items-center justify-center">
+      {Array.from({ length: 8 }).map((_, index) => (
+        <span
+          key={SPINNER_KEYS[index]}
+          ref={(el) => (spinnerRefs.current[index] = el)}
+          className={cn(spinnerVariants({ size }), className)}
+          style={{
+            transform: `rotate(${index * -ROTATION_DEGREE}deg) ${size === "small" ? "translateY(-8px)" : "translateY(-10px)"}`,
+            opacity: `${OPACITY_STEPS[index]}`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/Spinner.tsx
+++ b/packages/ui/src/components/Spinner.tsx
@@ -43,11 +43,10 @@ const spinnerVariants = cva("bg-text-sub2 absolute h-[10px] w-[4px] rounded-lg",
 });
 
 interface SpinnerProps extends VariantProps<typeof spinnerVariants> {
-  loading?: boolean;
   className?: string;
 }
 
-export default function Spinner({ size, loading, className }: Readonly<SpinnerProps>) {
+export default function Spinner({ size, className }: SpinnerProps) {
   const spinnerRefs = useRef<HTMLSpanElement[] | null[]>([]);
 
   useEffect(() => {
@@ -66,10 +65,6 @@ export default function Spinner({ size, loading, className }: Readonly<SpinnerPr
       intervalIds.forEach(clearInterval);
     };
   }, []);
-
-  if (!loading) {
-    return null;
-  }
 
   return (
     <div className="relative flex h-fit w-fit items-center justify-center">

--- a/packages/ui/src/components/Spinner.tsx
+++ b/packages/ui/src/components/Spinner.tsx
@@ -5,21 +5,12 @@ import { useEffect, useRef } from "react";
 
 import { cn } from "../lib/utils";
 
-const ROTATION_SPEED: number = 100;
-const ROTATION_DEGREE: number = 45;
-const OPACITY_STEPS: Readonly<Array<string>> = [
-  "1",
-  "0.87",
-  "0.75",
-  "0.63",
-  "0.51",
-  "0.39",
-  "0.27",
-  "0.15",
-];
-const OPACITY_STEP: number = 1;
+const ROTATION_SPEED = 100;
+const ROTATION_DEGREE = 45;
+const OPACITY_STEPS = ["1", "0.87", "0.75", "0.63", "0.51", "0.39", "0.27", "0.15"];
+const OPACITY_STEP = 1;
 
-const SPINNER_KEYS: Readonly<Array<string>> = [
+const SPINNER_KEYS = [
   "spinner-spin-0",
   "spinner-spin-1",
   "spinner-spin-2",
@@ -30,11 +21,11 @@ const SPINNER_KEYS: Readonly<Array<string>> = [
   "spinner-spin-7",
 ];
 
-const spinnerVariants = cva("bg-text-sub2 absolute h-[10px] w-[4px] rounded-lg", {
+const spinnerVariants = cva("bg-text-sub2 absolute h-[0.625rem] w-[0.25rem] rounded-lg", {
   variants: {
     size: {
-      small: "h-[7px] w-[3px]",
-      middle: "h-[10px] w-[4px]",
+      small: "h-[0.438rem] w-[0.188rem]",
+      middle: "h-[0.625rem] w-[0.25rem]",
     },
   },
   defaultVariants: {
@@ -74,7 +65,7 @@ export default function Spinner({ size, className }: SpinnerProps) {
           ref={(el) => (spinnerRefs.current[index] = el)}
           className={cn(spinnerVariants({ size }), className)}
           style={{
-            transform: `rotate(${index * -ROTATION_DEGREE}deg) ${size === "small" ? "translateY(-8px)" : "translateY(-10px)"}`,
+            transform: `rotate(${index * -ROTATION_DEGREE}deg) ${size === "small" ? "translateY(-0.5rem)" : "translateY(-0.625rem)"}`,
             opacity: `${OPACITY_STEPS[index]}`,
           }}
         />


### PR DESCRIPTION
## 📝 작업 내용
스피너 컴포넌트를 구현하고, 스토리북을 작성하였습니다.

cva()를 통해 사이즈를 조절할 수 있으며 아래 코드와 같이 컴포넌트를 호출할 수 있습니다.
```typescript
// size: default(small)
// loading: required
<Spinner size={"small" | "middle"} loading={true | false}/>
```


> ReadOnly로 props를 주지 않으면 lint 경고가 나타나 ReadOnly를 주었더니 loading을 초기화하면 Storybook description 타입에 unknown이 발생하여 loading은 required로 설정하였습니다.
### 📷 스크린샷 (선택)
<img width="200" alt="image" src="https://github.com/user-attachments/assets/e32d08b1-e380-4295-9caf-1cf0c65cb31d" />


## 💬 리뷰 요구사항(선택)
코드와 구조적으로 괜찮은지 봐주시면 감사하겠습니다.

