### PR TITLE
[FLIZ-20/ui] feat: DayPicker 공통 컴포넌트 구현

### DIFF
--- a/docs/storybook/stories/DayPicker.stories.tsx
+++ b/docs/storybook/stories/DayPicker.stories.tsx
@@ -16,10 +16,10 @@ const meta: Meta<typeof DayPicker> = {
   },
   argTypes: {
     selected: {
-      description: "상위에서 주입 할 Date 타입의 상태",
+      description: "상위에서 제어할 수 있도록 주입 할 Date 타입의 상태",
     },
     onSelect: {
-      description: "상위에서 주입 할 Date 타입의 상태를 변경 할 함수",
+      description: "상위에서 제어할 수 있도록 주입 할 Date 타입의 상태를 변경 할 함수",
     },
     onDayClick: {
       description: "특정 날짜를 선택하면 해당 날짜의 데이터를 참조할 수 있는 콜백 함수",

--- a/docs/storybook/stories/DayPicker.stories.tsx
+++ b/docs/storybook/stories/DayPicker.stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof DayPicker> = {
     },
     mode: {
       control: "select",
-      options: ["single", "range", "multiple"],
+      options: ["single"],
     },
   },
 };

--- a/docs/storybook/stories/DayPicker.stories.tsx
+++ b/docs/storybook/stories/DayPicker.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { DayPicker } from "@5unwan/ui/components/DayPicker";
+import { useState } from "react";
+
+const meta: Meta<typeof DayPicker> = {
+  component: DayPicker,
+  tags: ["autodocs"],
+  args: {
+    selected: undefined,
+    onSelect: undefined,
+    onDayClick: undefined,
+    fixedWeeks: false,
+    mode: "single",
+    className: "border",
+  },
+  argTypes: {
+    selected: {
+      description: "상위에서 주입 할 Date 타입의 상태",
+    },
+    onSelect: {
+      description: "상위에서 주입 할 Date 타입의 상태를 변경 할 함수",
+    },
+    onDayClick: {
+      description: "특정 날짜를 선택하면 해당 날짜의 데이터를 참조할 수 있는 콜백 함수",
+    },
+    fixedWeeks: {
+      control: "boolean",
+      description: "달력의 크기를 6주로 고정할 것인지 결정하는 props",
+    },
+    mode: {
+      control: "select",
+      options: ["single", "range", "multiple"],
+    },
+  },
+};
+
+export default meta;
+
+type DayPickerStory = StoryObj<typeof DayPicker>;
+
+export const Default: DayPickerStory = {
+  render: () => {
+    const [date, setDate] = useState<Date | undefined>(new Date());
+
+    return (
+      <div className="bg-background-primary flex h-[700px] w-full items-center justify-center">
+        <DayPicker
+          mode="single"
+          fixedWeeks={false}
+          selected={date}
+          onSelect={setDate}
+          className="w-[358px]"
+        />
+      </div>
+    );
+  },
+};
+
+export const FixedWeeks: DayPickerStory = {
+  render: () => {
+    const [date, setDate] = useState<Date | undefined>(new Date());
+
+    return (
+      <div className="bg-background-primary flex h-[700px] w-full items-center justify-center">
+        <DayPicker
+          mode="single"
+          fixedWeeks
+          selected={date}
+          onSelect={setDate}
+          className="w-[358px]"
+        />
+      </div>
+    );
+  },
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,6 +54,9 @@
     "@radix-ui/react-dialog": "^1.1.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
+    "lucide-react": "^0.471.1",
+    "react-day-picker": "8.10.1",
     "tailwind-merge": "^2.6.0"
   },
   "exports": {

--- a/packages/ui/src/components/DayPicker.tsx
+++ b/packages/ui/src/components/DayPicker.tsx
@@ -10,10 +10,13 @@ import { currentYearWithMonth, isWeekend } from "../utils/DayPickerUtils";
 
 const MONTH_OFFSET = 1;
 
-export type DayPickerProps = ComponentProps<typeof Calendar>;
+export type DayPickerProps = ComponentProps<typeof Calendar> & {
+  mode: "single";
+};
 
 function DayPicker({ className, classNames, showOutsideDays = true, ...props }: DayPickerProps) {
   const [month, setMonth] = useState(new Date());
+  const [date, setDate] = useState(new Date());
 
   const handlePrevMonth = () => {
     setMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() - MONTH_OFFSET));
@@ -23,10 +26,19 @@ function DayPicker({ className, classNames, showOutsideDays = true, ...props }: 
     setMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() + MONTH_OFFSET));
   };
 
+  const handleChangeMonth = (date: Date | undefined) => {
+    if (date) {
+      setDate(date);
+    }
+  };
+
   return (
     <Calendar
       month={month}
+      fixedWeeks
       onMonthChange={setMonth}
+      selected={date}
+      onSelect={handleChangeMonth}
       locale={ko}
       showOutsideDays={showOutsideDays}
       modifiers={{ weekend: isWeekend }}

--- a/packages/ui/src/components/DayPicker.tsx
+++ b/packages/ui/src/components/DayPicker.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { ko } from "date-fns/locale";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ComponentProps, useState } from "react";
+import { DayPicker as Calendar } from "react-day-picker";
+
+import { cn } from "../lib/utils";
+import { currentYearWithMonth, isWeekend } from "../utils/DayPickerUtils";
+
+const MONTH_OFFSET = 1;
+
+export type DayPickerProps = ComponentProps<typeof Calendar>;
+
+function DayPicker({ className, classNames, showOutsideDays = true, ...props }: DayPickerProps) {
+  const [month, setMonth] = useState(new Date());
+
+  const handlePrevMonth = () => {
+    setMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() - MONTH_OFFSET));
+  };
+
+  const handleNextMonth = () => {
+    setMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() + MONTH_OFFSET));
+  };
+
+  return (
+    <Calendar
+      month={month}
+      onMonthChange={setMonth}
+      locale={ko}
+      showOutsideDays={showOutsideDays}
+      modifiers={{ weekend: isWeekend }}
+      modifiersClassNames={{
+        weekend: "text-brand-secondary-500",
+      }}
+      className={cn("w-full p-1", className)}
+      classNames={{
+        months: "flex flex-col h-full space-y-4 text-title-2 text-text-primary",
+        month: "flex flex-col space-y-5 h-full",
+        caption: "flex justify-center relative items-center",
+        caption_label: "text-sm font-medium",
+        nav: "space-x-1 flex items-center",
+        nav_button: "h-7 w-7 text-white bg-transparent p-0 opacity-50 hover:opacity-100",
+        nav_button_previous: "absolute left-1",
+        nav_button_next: "absolute right-1",
+        table: "w-full h-full flex flex-col border-collapse",
+        tbody: "flex flex-col justify-between flex-1 pt-1",
+        head_row: "flex",
+        head_cell:
+          "rounded-md text-sm w-full font-normal [&:first-child]:text-brand-secondary-500 [&:last-child]:text-brand-secondary-500",
+        row: "flex w-full h-full mt-2",
+        cell: "w-full h-[40px] relative text-center",
+        day: "h-8 w-8 rounded-full hover:bg-brand-primary-500 text-sm font-normal",
+        day_selected: "bg-brand-primary-500 hover:bg-brand-primary-500",
+        day_today: "bg-white text-text-sub5",
+        day_outside: "text-text-sub4",
+        ...classNames,
+      }}
+      components={{
+        Caption: () => (
+          <div className="flex items-center justify-center gap-3 text-center">
+            <button onClick={handlePrevMonth}>
+              <ChevronLeft className={"cursor-pointer"} />
+            </button>
+            <span className="font-mono">{currentYearWithMonth(month)}</span>
+            <button onClick={handleNextMonth}>
+              <ChevronRight className={"cursor-pointer"} />
+            </button>
+          </div>
+        ),
+      }}
+      {...props}
+    />
+  );
+}
+DayPicker.displayName = "DayPicker";
+
+export { DayPicker };

--- a/packages/ui/src/utils/DayPickerUtils.ts
+++ b/packages/ui/src/utils/DayPickerUtils.ts
@@ -1,0 +1,19 @@
+const SUNDAY_INDEX = 0;
+const SATURDAY_INDEX = 6;
+const MONTH_OFFSET = 1;
+const SINGLE_DIGIT_MONTH_THRESHOLD = 10;
+
+export const currentYearWithMonth = (month: Date) => {
+  const currentMonth = month.getMonth() + MONTH_OFFSET;
+
+  const paddedMonth =
+    currentMonth < SINGLE_DIGIT_MONTH_THRESHOLD ? `0${currentMonth}` : currentMonth;
+
+  return `${month.getFullYear()}. ${paddedMonth}`;
+};
+
+export const isWeekend = (date: Date) => {
+  const day = date.getDay();
+
+  return day === SUNDAY_INDEX || day === SATURDAY_INDEX;
+};

--- a/packages/ui/src/utils/__tests__/DayPickerUtils.spec.tsx
+++ b/packages/ui/src/utils/__tests__/DayPickerUtils.spec.tsx
@@ -1,0 +1,72 @@
+/* eslint-disable no-magic-numbers */
+import { currentYearWithMonth, isWeekend } from "../DayPickerUtils";
+
+describe("날짜 유틸리티 함수 테스트", () => {
+  describe("currentYearWithMonth 함수는", () => {
+    it("한 자리 월을 앞에 0을 붙여서 포맷팅해야 한다", () => {
+      const testDate = new Date(2024, 0, 1);
+      expect(currentYearWithMonth(testDate)).toBe("2024. 01");
+
+      const testDate2 = new Date(2024, 8, 1);
+      expect(currentYearWithMonth(testDate2)).toBe("2024. 09");
+    });
+
+    it("두 자리 월은 그대로 표시해야 한다", () => {
+      const testDate = new Date(2024, 9, 1);
+      expect(currentYearWithMonth(testDate)).toBe("2024. 10");
+
+      const testDate2 = new Date(2024, 11, 1);
+      expect(currentYearWithMonth(testDate2)).toBe("2024. 12");
+    });
+
+    it("연도가 다른 경우도 올바르게 처리해야 한다", () => {
+      const testDate = new Date(2023, 0, 1);
+      expect(currentYearWithMonth(testDate)).toBe("2023. 01");
+
+      const testDate2 = new Date(2025, 11, 1);
+      expect(currentYearWithMonth(testDate2)).toBe("2025. 12");
+    });
+
+    it("다양한 방식으로 생성된 Date 객체를 처리할 수 있어야 한다", () => {
+      const testDate = new Date("2024-01-15");
+      expect(currentYearWithMonth(testDate)).toBe("2024. 01");
+
+      const testDate2 = new Date(2024, 0, 15);
+      expect(currentYearWithMonth(testDate2)).toBe("2024. 01");
+    });
+  });
+
+  describe("isWeekend 함수는", () => {
+    it("토요일을 주말로 인식해야 한다", () => {
+      const saturday = new Date(2024, 0, 6);
+      expect(isWeekend(saturday)).toBe(true);
+    });
+
+    it("일요일을 주말로 인식해야 한다", () => {
+      const sunday = new Date(2024, 0, 7);
+      expect(isWeekend(sunday)).toBe(true);
+    });
+
+    it("평일은 주말로 인식하지 않아야 한다", () => {
+      const weekdays = [
+        new Date(2024, 0, 1),
+        new Date(2024, 0, 2),
+        new Date(2024, 0, 3),
+        new Date(2024, 0, 4),
+        new Date(2024, 0, 5),
+      ];
+
+      weekdays.forEach((date) => {
+        expect(isWeekend(date)).toBe(false);
+      });
+    });
+
+    it("월과 연도가 바뀌는 경우도 올바르게 처리해야 한다", () => {
+      const newYearsSunday = new Date(2024, 0, 7);
+      expect(isWeekend(newYearsSunday)).toBe(true);
+
+      const lastDayOfYear = new Date(2024, 11, 31);
+      expect(isWeekend(lastDayOfYear)).toBe(false);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,9 +368,18 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
+      lucide-react:
+        specifier: ^0.471.1
+        version: 0.471.1(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
+      react-day-picker:
+        specifier: 8.10.1
+        version: 8.10.1(date-fns@4.1.0)(react@18.3.1)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -2643,6 +2652,9 @@ packages:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
 
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
@@ -4079,6 +4091,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@0.471.1:
+    resolution: {integrity: sha512-syOxwPhf62gg2YOsz72HRn+CIpeudFy67AeKnSR8Hn/fIIF4ubhNbRF+pQ2CaJrl+X9Os4PL87z2DXQi3DVeDA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -4600,6 +4617,12 @@ packages:
     engines: {node: '>=10.18'}
     peerDependencies:
       react: ^16.3.0 || ^17.0.1 || ^18.0.0
+
+  react-day-picker@8.10.1:
+    resolution: {integrity: sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==}
+    peerDependencies:
+      date-fns: ^2.28.0 || ^3.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
   react-docgen-typescript@2.2.2:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
@@ -5570,7 +5593,7 @@ snapshots:
       '@babel/traverse': 7.26.4
       '@babel/types': 7.26.3
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5738,7 +5761,7 @@ snapshots:
       '@babel/parser': 7.26.3
       '@babel/template': 7.25.9
       '@babel/types': 7.26.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -6099,7 +6122,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -6144,7 +6167,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7450,7 +7473,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8074,6 +8097,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  date-fns@4.1.0: {}
+
   dayjs@1.11.13: {}
 
   debug@3.2.7(supports-color@8.1.1):
@@ -8081,6 +8106,10 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
+
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
 
   debug@4.4.0(supports-color@8.1.1):
     dependencies:
@@ -8655,7 +8684,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -9121,7 +9150,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9134,7 +9163,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9379,7 +9408,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -9967,6 +9996,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lucide-react@0.471.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   lz-string@1.5.0: {}
 
   magic-string@0.27.0:
@@ -10404,6 +10437,11 @@ snapshots:
     dependencies:
       react: 18.3.1
       tween-functions: 1.2.0
+
+  react-day-picker@8.10.1(date-fns@4.1.0)(react@18.3.1):
+    dependencies:
+      date-fns: 4.1.0
+      react: 18.3.1
 
   react-docgen-typescript@2.2.2(typescript@5.6.3):
     dependencies:


### PR DESCRIPTION
<!-- 작업 패키지: root, ui, trainer, user, config-eslint, config-typescript, config-tailwind, storybook -->

## 📝 작업 내용

## DayPicker 공통 컴포넌트 구현
`react-day-picker` 라이브러리를 사용하여 `DayPicker` 공통 컴포넌트를 구현하였습니다.
- 하나의 DayPicker 컴포넌트로 여러 상황의 달력을 모두 대응 할 수 있도록 커스텀하여 추상화하려 하였으나, `react-day-picker` 라이브러리 자체가 이미 여러 상황의 달력에 대응 할 수 있도록 추상화 되어 있기 때문에 `ui` 모듈 내부에서는 `react-day-picker` 라이브러리를 import 하는 컴포넌트에서는 하나의 상황의 달력에만 대응하도록 구현하였습니다. 따라서 제가 생각한 방향은 아래와 같습니다.
   - `react-day-picker` -> `packages/ui` -> `각 도메인에서 커스텀하여 각각의 상황에 맞는 달력 구현` X
   - `react-day-picker` -> `packages/ui 에서 커스텀하여 각각의 상황에 맞는 달력 구현` O
      - 즉, `packages/ui` 내부에서 `DayPicker`, `TwoWeekDayPicker`, `DayPickerWithItem` 등 이미 추상화 되어있는 `react-day-picker`를 `ui` 모듈 내부에서 각 상황에 맞게 대응하도록 구현하는 방향으로 판단했습니다.
- 제어/비제어 방식을 상위에서 핸들링 할 수 있도록 구현
   - 해당 컴포넌트는 상위에서 `Date` 타입의 상태를 내려주는 제어 방식과 내부적으로 관리되고 있는 상태를 참조하여 사용할 수 있는 비제어 방식을 상위에서 핸들링 할 수 있도록 구현되었습니다.
   - 내부의 선택된 날짜 데이터를 참조할 때는 `onDayClick` props를 사용할 수 있습니다.  
- 내부 utils 함수 구현
   - 내부 utils 함수를 `utils` 폴더 아래에 `DayPickerUtils`라는 파일로 정의하였습니다. 각각의 utils 함수를 함수 네이밍 별로 파일을 만들어 구현하면 네이밍만 보고 어디에서 쓰이는지 바로 찾기 어려울 것 같아 해당 유틸함수가 쓰이는 파일 명을 사용하였습니다.
   - **따라서 공통 utils 함수 같은 경우에는 함수명으로 파일명을 지으면 되지 않을까? 라고 개인적으로 고민하였는데 해당 부분에 대해 논의하면 좋을 것 같아요**
- 캘린더를 6주로 고정하여 구현
   - 캘린더를 6주로 고정하여 구현하지 않으면 달마다 주(week)의 반복 횟수가 다르기 떄문에 layout shift가 발생합니다. 따라서 최대 많은 주(week)가 6주이기 때문에 6주로 고정하여 캘린더를 구현하였습니다.
 
## 테스트 작성 및 스토리 작성
- `DayPicker` 공통 컴포넌트의 util 함수의 안정성 검증을 위해 단위 테스트를 진행하였습니다.
- `DayPicker` 공통 컴포넌트의 스토리를 작성하였습니다.
   - 해당 컴포넌트를 다양한 스타일링으로 사용할 경우는 적다고 예상되어 비교적 간단한 상황의 스토리만 작성하였습니다.  

### 📷 스크린샷 (선택)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/9e7b00eb-bbdf-49c4-a1ed-b61f4fbedde1" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
