### PR TITLE
[FLIZ-24/ui] feat: Button 컴포넌트 구현

### DIFF
--- a/docs/storybook/stories/Button.stories.tsx
+++ b/docs/storybook/stories/Button.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Button } from "@5unwan/ui/components/Button";
+
+const meta: Meta<typeof Button> = {
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['brand', 'negative', 'dark', 'destructive']
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg', 'icon']
+    }
+  },
+  decorators: [
+    (Story) => (<div className="bg-background-primary p-[10px] w-full flex items-center justify-center"><Story/></div>)
+  ]
+};
+export default meta;
+
+type Story = StoryObj<typeof Button>
+
+export const Default: Story = {
+  render: (args) => (<Button {...args}>Button</Button>)
+}

--- a/docs/storybook/stories/DayofWeekPicker.stories.tsx
+++ b/docs/storybook/stories/DayofWeekPicker.stories.tsx
@@ -1,4 +1,4 @@
-import DayOfWeekPicker from "@5unwan/ui/components/DayOfWeekPicker/DayOfWeekPicker";
+import DayOfWeekPicker from "@5unwan/ui/components/DayOfWeekPicker/index";
 import { Meta, StoryObj } from "@storybook/react";
 import { useArgs } from "@storybook/preview-api";
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,6 +52,7 @@
     "@mui/material": "^6.3.0",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.4",
+    "@radix-ui/react-slot": "^1.1.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "tailwind-merge": "^2.6.0"

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,0 +1,48 @@
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "../lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[10px] text-headline transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        brand: "bg-brand-primary-500 text-text-primary shadow hover:bg-brand-primary-500/90",
+        negative: "bg-background-sub5 text-text-sub5 shadow hover:bg-background-sub5/90",
+        dark: "bg-background-sub1 text-text-primary shadow hover:bg-background-sub2",
+        destructive: "bg-notification text-text-primary shadow hover:bg-notification/90",
+      },
+      size: {
+        sm: "h-[2rem] text-body-1 px-[1rem]",
+        md: "h-[2.5rem] text-headline px-[2.625rem]",
+        lg: "h-[3.375rem] text-headline px-[4.5rem]",
+        icon: "h-[2.8125rem] w-[2.8125rem]",
+      },
+    },
+    defaultVariants: {
+      variant: "brand",
+      size: "md",
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  },
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/packages/ui/src/components/DayOfWeekPicker/index.tsx
+++ b/packages/ui/src/components/DayOfWeekPicker/index.tsx
@@ -2,7 +2,7 @@
 
 import React, { forwardRef, useCallback } from "react";
 
-import DayOfWeekPickerContext from "./Context";
+import DayOfWeekPickerContext from "./context";
 import { Days } from "./Days";
 import useControllableState from "../../hooks/useControllableState";
 import useDayOfWeekPickerContext from "../../hooks/useDayOfWeekPickerContext";

--- a/packages/ui/src/hooks/useDayOfWeekPickerContext.ts
+++ b/packages/ui/src/hooks/useDayOfWeekPickerContext.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 
-import DayOfWeekPickerContext from "../components/DayOfWeekPicker/Context";
+import DayOfWeekPickerContext from "../components/DayOfWeekPicker/context";
 
 export const useDayOfWeekPickerContext = () => {
   const context = useContext(DayOfWeekPickerContext);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 1.7.9
       next:
         specifier: 14.2.20
-        version: 14.2.20(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.20(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -125,7 +125,7 @@ importers:
         version: 1.7.9
       next:
         specifier: 14.2.20
-        version: 14.2.20(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.20(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -362,6 +362,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.4
         version: 1.1.4(@types/react-dom@18.3.5(@types/react@18.3.17))(@types/react@18.3.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot':
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react@18.3.17)(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -10079,7 +10082,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@14.2.20(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.20(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.20
       '@swc/helpers': 0.5.5
@@ -10089,7 +10092,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react@18.3.1)
+      styled-jsx: 5.1.1(babel-plugin-macros@3.1.0)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.20
       '@next/swc-darwin-x64': 14.2.20
@@ -10867,12 +10870,11 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.1(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react@18.3.1):
+  styled-jsx@5.1.1(babel-plugin-macros@3.1.0)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
     optionalDependencies:
-      '@babel/core': 7.26.0
       babel-plugin-macros: 3.1.0
 
   stylis@4.2.0: {}


### PR DESCRIPTION
# [FLIZ-24/ui] feat: Button 컴포넌트 구현

## 📝 작업 내용

@radix-ui/react-slot을 사용하여 Button 공통 컴포넌트를 구현했습니다

### API Reference
- `variant:` 버튼 종류(주로 색상)를 지정할 수 있습니다. 
- `size:` 버튼의 크기를 (높이, padding, 글씨 크기) 지정할 수 있습니다.
