### PR TITLE
[FILZ-31/root] chore: 각 패키지별 path Alias 설정

### DIFF
--- a/apps/trainer/next.config.mjs
+++ b/apps/trainer/next.config.mjs
@@ -1,7 +1,21 @@
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@5unwan/ui"],
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@ui": path.resolve(__dirname, "../../packages/ui/src"), // __dirname 사용
+    };
+
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/apps/trainer/tsconfig.json
+++ b/apps/trainer/tsconfig.json
@@ -4,9 +4,10 @@
     "plugins": [{ "name": "next" }],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@trainer/*": ["./*"],
+      "@ui/*": ["../../packages/ui/src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "next.config.js"],
   "exclude": ["node_modules"]
 }

--- a/apps/trainer/tsconfig.json
+++ b/apps/trainer/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "@5unwan/typescript-config/nextjs.json",
   "compilerOptions": {
-    "plugins": [{ "name": "next" }]
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/user/next.config.mjs
+++ b/apps/user/next.config.mjs
@@ -1,7 +1,21 @@
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@5unwan/ui"],
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@ui": path.resolve(__dirname, "../../packages/ui/src"), // __dirname 사용
+    };
+
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/apps/user/tsconfig.json
+++ b/apps/user/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "@5unwan/typescript-config/nextjs.json",
   "compilerOptions": {
-    "plugins": [{ "name": "next" }]
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/user/tsconfig.json
+++ b/apps/user/tsconfig.json
@@ -4,9 +4,10 @@
     "plugins": [{ "name": "next" }],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@user/*": ["./*"],
+      "@ui/*": ["../../packages/ui/src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "next.config.mjs"],
   "exclude": ["node_modules"]
 }

--- a/docs/storybook/vite.config.ts
+++ b/docs/storybook/vite.config.ts
@@ -1,7 +1,13 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "../../packages/ui/src"),
+    },
+  },
+});

--- a/docs/storybook/vite.config.ts
+++ b/docs/storybook/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "../../packages/ui/src"),
+      "@ui": path.resolve(__dirname, "../../packages/ui/src"),
     },
   },
 });

--- a/packages/config-typescript/nextjs.json
+++ b/packages/config-typescript/nextjs.json
@@ -12,7 +12,11 @@
     "module": "esnext",
     "resolveJsonModule": true,
     "strict": true,
-    "target": "es5"
+    "target": "es5",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["../../packages/ui/src/*"]
+    }
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]

--- a/packages/config-typescript/nextjs.json
+++ b/packages/config-typescript/nextjs.json
@@ -12,11 +12,7 @@
     "module": "esnext",
     "resolveJsonModule": true,
     "strict": true,
-    "target": "es5",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["../../packages/ui/src/*"]
-    }
+    "target": "es5"
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "@5unwan/typescript-config/react-library.json",
   "compilerOptions": {
-    "baseUrl": "src",
+    "baseUrl": ".",
     "paths": {
+      "@/*": ["src/*"],
       "test-utils": ["./lib/test/test-utils.tsx"]
     },
     "types": ["node", "jest", "@testing-library/jest-dom"]

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
+      "@ui/*": ["src/*"],
       "test-utils": ["./lib/test/test-utils.tsx"]
     },
     "types": ["node", "jest", "@testing-library/jest-dom"]


### PR DESCRIPTION
## 📝 작업 내용

### 각 패키지별 path Alias를 설정(ui, trainer, user)

원래 용재님과 이야기했던 path alias 컨벤션과 살짝 다르게 구현하였습니다.

기존 컨벤션에서는 u 패키지에서는 src를 `@`로, apps 패키지에서의 trainer와 user는 각 패키지의 Root를 `@`로 네이밍 짓기로 했었는데, 네이밍 충돌로 인해 해당 컨벤션을 사용하지 못했습니다.

네이밍 충돌의 이유는 아래와 같습니다.
- ui 패키지에서 src를 @로 설정하면 ui 패키지를 사용하는 곳에서도(trainer, user) ui에서 지정한 Path alias를 동일한 네이밍으로 지정해주어야합니다.([문제 해결에 참고한 깃헙 discussions](https://github.com/vercel/turborepo/discussions/620)) 말씀드린 해결 방법이 best practice인지는 아직 정확하게 모르겠으나, 현재까지 제가 조사한 방법중에선 최선의 방법이었습니다. 좀 더 효율적인 방법이 있는지는 좀 더 찾아봐야 할 것 같아요.
- 따라서 위처럼 진행한 뒤, trainer와 user 도메인에서 루트를 `@` alias로 설정하면 충돌이 발생하여 `@` alias를 사용할 수가 없습니다.

위와 같은 이유로 각각의 alias 네이밍을 아래와 같이 변경하게 되었습니다.
- `@ui/` = ui 패키지의 src
- `@trainer/` = trainer 패키지의 루트
- `@user/` = user 패키지의 루트

### 스토리북의 vite.config와 trainer, user의 webpack 설정

- 스토리북의 경우 tsconfig 설정만으로는 ui 패키지를 import 하여 사용할 때 ui의 alias를 parsing 하지 못하는 이슈가 있어 vite.config 내부 설정으로 ui의 alias를 parsing할 수 있도록 작성하였습니다.
- trainer, user의 경우 dev 환경에서는 이상이 없지만 build 후 프로덕션 환경에서는 tsconfig 설정만으로는 ui의 alias를 parsing 하지 못하는 이슈가 있어 next.config.mjs webpack 설정으로 빌드시에도 ui의 alias를 parsing 할 수 있도록 해주었습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
모노레포 환경에서의 path alias에 대해 더 효율적인 방법을 아신다면 피드백 부탁드립니다.