### PR TITLE
[FLIZ-41/root] fix: build.sh 오류 해결

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+cd ../
 # Ensure a clean slate
 rm -rf output
 mkdir output


### PR DESCRIPTION
# [FLIZ-41/root] fix: build.sh 오류 해결

## 📝 작업 내용

build.sh에서 `cd ../` 커맨드가 없어 FitLink-FE 폴더가 없는 오류를 해결하기 위해 build.sh를 수정했습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
