### PR TITLE
[FLIZ-42/root] fix: build.sh 스크립트 수정

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,3 +6,4 @@ mkdir output
 
 # Copy necessary content to the output directory
 cp -R ./FitLink-FE/* ./output
+cp -R ./output ./FitLink-FE/


### PR DESCRIPTION
# [FLIZ-42/root] fix: build.sh 스크립트 수정

## 📝 작업 내용

Deploy pipeline의 Pushes to another repository 단계에서` ls: output: No such file or directory` 오류를 해결하기 위해 build.sh 스크립트를 수정했습니다. 

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)