### PR TITLE
[FILZ-53/trainer] feat: 트레이너 도메인 TimeOption 공통 컴포넌트 구현

### DIFF
--- a/apps/trainer/components/TimeOption.tsx
+++ b/apps/trainer/components/TimeOption.tsx
@@ -1,19 +1,28 @@
-import { forwardRef, HTMLAttributes, ReactNode } from "react";
+import { cn } from "@ui/lib/utils";
+import { forwardRef, HTMLAttributes } from "react";
 
 type TimeOptionProps = HTMLAttributes<HTMLDivElement> & {
-  optionIcon: ReactNode;
+  className?: string;
+};
+type TimeOptionIconProps = HTMLAttributes<HTMLElement> & {
+  className?: string;
+};
+type TimeOptionContentProps = HTMLAttributes<HTMLElement> & {
+  className?: string;
 };
 
 const TimeOption = forwardRef<HTMLDivElement, TimeOptionProps>(
-  ({ optionIcon, children, ...props }, ref) => {
+  ({ className, children, ...props }, ref) => {
     return (
       <div
-        className="bg-background-sub1 hover:bg-brand-primary-500 flex h-[6.875rem] w-[6.24rem] cursor-pointer flex-col justify-between rounded-[0.625rem] p-[0.75rem] leading-[1.125rem]"
+        className={cn(
+          "bg-background-sub1 hover:bg-brand-primary-500 flex h-[6.875rem] w-[6.24rem] flex-shrink-0 cursor-pointer flex-col justify-between rounded-[0.625rem] p-[0.75rem] leading-[1.125rem]",
+          className,
+        )}
         {...props}
         ref={ref}
       >
-        {optionIcon}
-        <span className="text-body-2 text-text-primary">{children}</span>
+        {children}
       </div>
     );
   },
@@ -21,4 +30,28 @@ const TimeOption = forwardRef<HTMLDivElement, TimeOptionProps>(
 
 TimeOption.displayName = "TimeOption";
 
-export default TimeOption;
+const TimeOptionIcon = forwardRef<HTMLDivElement, TimeOptionIconProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <div className={cn(className)} ref={ref} {...props}>
+        {children}
+      </div>
+    );
+  },
+);
+
+TimeOptionIcon.displayName = "TimeOptionIcon";
+
+const TimeOptionContent = forwardRef<HTMLDivElement, TimeOptionContentProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <div className={cn("text-body-2 text-text-primary", className)} ref={ref} {...props}>
+        {children}
+      </div>
+    );
+  },
+);
+
+TimeOptionContent.displayName = "TimeOptionContent";
+
+export { TimeOption, TimeOptionContent, TimeOptionIcon };

--- a/apps/trainer/components/TimeOption.tsx
+++ b/apps/trainer/components/TimeOption.tsx
@@ -1,13 +1,15 @@
 import { cn } from "@ui/lib/utils";
-import { forwardRef, HTMLAttributes } from "react";
+import { icons } from "lucide-react";
+import { ComponentProps, forwardRef } from "react";
 
-type TimeOptionProps = HTMLAttributes<HTMLDivElement> & {
+type TimeOptionProps = ComponentProps<"div"> & {
   className?: string;
 };
-type TimeOptionIconProps = HTMLAttributes<HTMLElement> & {
+type TimeOptionIconProps = ComponentProps<"div"> & {
+  iconName: keyof typeof icons;
   className?: string;
 };
-type TimeOptionContentProps = HTMLAttributes<HTMLElement> & {
+type TimeOptionContentProps = ComponentProps<"div"> & {
   className?: string;
 };
 
@@ -31,10 +33,12 @@ const TimeOption = forwardRef<HTMLDivElement, TimeOptionProps>(
 TimeOption.displayName = "TimeOption";
 
 const TimeOptionIcon = forwardRef<HTMLDivElement, TimeOptionIconProps>(
-  ({ className, children, ...props }, ref) => {
+  ({ className, iconName, ...props }, ref) => {
+    const Icon = icons[iconName];
+
     return (
-      <div className={cn(className)} ref={ref} {...props}>
-        {children}
+      <div className={cn("text-text-primary", className)} ref={ref} {...props}>
+        <Icon />
       </div>
     );
   },

--- a/apps/trainer/components/TimeOption.tsx
+++ b/apps/trainer/components/TimeOption.tsx
@@ -16,7 +16,7 @@ const TimeOption = forwardRef<HTMLDivElement, TimeOptionProps>(
     return (
       <div
         className={cn(
-          "bg-background-sub1 hover:bg-brand-primary-500 flex h-[6.875rem] w-[6.24rem] flex-shrink-0 cursor-pointer flex-col justify-between rounded-[0.625rem] p-[0.75rem] leading-[1.125rem]",
+          "bg-background-sub1 hover:bg-brand-primary-500 flex h-[6.875rem] w-[6.24rem] flex-shrink-0 cursor-pointer flex-col justify-between rounded-[0.625rem] p-[0.75rem] leading-[1.125rem] transition-colors",
           className,
         )}
         {...props}

--- a/apps/trainer/components/TimeOption.tsx
+++ b/apps/trainer/components/TimeOption.tsx
@@ -13,7 +13,7 @@ type TimeOptionContentProps = ComponentProps<"div"> & {
   className?: string;
 };
 
-const TimeOption = forwardRef<HTMLDivElement, TimeOptionProps>(
+const TimeOptionRoot = forwardRef<HTMLDivElement, TimeOptionProps>(
   ({ className, children, ...props }, ref) => {
     return (
       <div
@@ -30,7 +30,7 @@ const TimeOption = forwardRef<HTMLDivElement, TimeOptionProps>(
   },
 );
 
-TimeOption.displayName = "TimeOption";
+TimeOptionRoot.displayName = "TimeOptionRoot";
 
 const TimeOptionIcon = forwardRef<HTMLDivElement, TimeOptionIconProps>(
   ({ className, iconName, ...props }, ref) => {
@@ -58,4 +58,9 @@ const TimeOptionContent = forwardRef<HTMLDivElement, TimeOptionContentProps>(
 
 TimeOptionContent.displayName = "TimeOptionContent";
 
-export { TimeOption, TimeOptionContent, TimeOptionIcon };
+const TimeOption = Object.assign(TimeOptionRoot, {
+  Icon: TimeOptionIcon,
+  Content: TimeOptionContent,
+});
+
+export default TimeOption;

--- a/apps/trainer/components/TimeOption.tsx
+++ b/apps/trainer/components/TimeOption.tsx
@@ -1,0 +1,24 @@
+import { forwardRef, HTMLAttributes, ReactNode } from "react";
+
+type TimeOptionProps = HTMLAttributes<HTMLDivElement> & {
+  optionIcon: ReactNode;
+};
+
+const TimeOption = forwardRef<HTMLDivElement, TimeOptionProps>(
+  ({ optionIcon, children, ...props }, ref) => {
+    return (
+      <div
+        className="bg-background-sub1 hover:bg-brand-primary-500 flex h-[6.875rem] w-[6.24rem] cursor-pointer flex-col justify-between rounded-[0.625rem] p-[0.75rem] leading-[1.125rem]"
+        {...props}
+        ref={ref}
+      >
+        {optionIcon}
+        <span className="text-body-2 text-text-primary">{children}</span>
+      </div>
+    );
+  },
+);
+
+TimeOption.displayName = "TimeOption";
+
+export default TimeOption;

--- a/apps/trainer/package.json
+++ b/apps/trainer/package.json
@@ -18,6 +18,7 @@
     "@5unwan/ui": "workspace:*",
     "@tanstack/react-query": "^5.62.7",
     "axios": "^1.7.9",
+    "lucide-react": "^0.471.1",
     "next": "14.2.20",
     "react": "^18",
     "react-dom": "^18",

--- a/apps/trainer/package.json
+++ b/apps/trainer/package.json
@@ -44,5 +44,8 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
+  },
+  "exports": {
+    "./components/*": "./components/*"
   }
 }

--- a/apps/trainer/package.json
+++ b/apps/trainer/package.json
@@ -46,6 +46,6 @@
     "typescript": "^5"
   },
   "exports": {
-    "./components/*": "./components/*"
+    "./components/*": "./components/*.tsx"
   }
 }

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "trainer": "workspace:*",
     "@5unwan/ui": "workspace:*",
     "lucide-react": "^0.471.1",
     "@storybook/preview-api": "^8.4.7",

--- a/docs/storybook/stories/trainer/TimeOption.stories.tsx
+++ b/docs/storybook/stories/trainer/TimeOption.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { CalendarClock, CalendarMinus2, CalendarX2, Dumbbell } from "lucide-react";
 
-import TimeOption from "trainer/components/TimeOption.js";
+import TimeOption from "trainer/components/TimeOption";
 
 const meta: Meta<typeof TimeOption> = {
   component: TimeOption,
@@ -26,4 +26,40 @@ export default meta;
 
 type TimeOptionStory = StoryObj<typeof TimeOption>;
 
-export const Default: TimeOptionStory = {};
+export const PtReservation: TimeOptionStory = {};
+
+export const PtFixedReservation: TimeOptionStory = {
+  args: {
+    optionIcon: <CalendarClock className="text-text-primary" />,
+  },
+  render: (args) => (
+    <TimeOption {...args}>
+      <div>PT</div>
+      <div>고정 예약</div>
+    </TimeOption>
+  ),
+};
+
+export const PtReservationNotPossible: TimeOptionStory = {
+  args: {
+    optionIcon: <CalendarX2 className="text-text-primary" />,
+  },
+  render: (args) => (
+    <TimeOption {...args}>
+      <div>예약 불가</div>
+      <div>시간대 등록</div>
+    </TimeOption>
+  ),
+};
+
+export const HolidaySettings: TimeOptionStory = {
+  args: {
+    optionIcon: <CalendarMinus2 className="text-text-primary" />,
+  },
+  render: (args) => (
+    <TimeOption {...args}>
+      <div>휴무일</div>
+      <div>설정</div>
+    </TimeOption>
+  ),
+};

--- a/docs/storybook/stories/trainer/TimeOption.stories.tsx
+++ b/docs/storybook/stories/trainer/TimeOption.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { CalendarClock, CalendarMinus2, CalendarX2, Dumbbell } from "lucide-react";
 
-import { TimeOption, TimeOptionContent, TimeOptionIcon } from "trainer/components/TimeOption";
+import TimeOption from "trainer/components/TimeOption";
 
 const meta: Meta<typeof TimeOption> = {
   component: TimeOption,
@@ -15,12 +15,10 @@ type TimeOptionStory = StoryObj<typeof TimeOption>;
 export const PtReservation: TimeOptionStory = {
   render: () => (
     <TimeOption>
-      <TimeOptionIcon>
-        <Dumbbell className="text-text-primary" />
-      </TimeOptionIcon>
-      <TimeOptionContent>
+      <TimeOption.Icon iconName={"Dumbbell"} />
+      <TimeOption.Content>
         <div>PT 예약</div>
-      </TimeOptionContent>
+      </TimeOption.Content>
     </TimeOption>
   ),
 };
@@ -28,13 +26,11 @@ export const PtReservation: TimeOptionStory = {
 export const PtFixedReservation: TimeOptionStory = {
   render: () => (
     <TimeOption>
-      <TimeOptionIcon>
-        <CalendarClock className="text-text-primary" />
-      </TimeOptionIcon>
-      <TimeOptionContent>
+      <TimeOption.Icon iconName={"CalendarClock"} />
+      <TimeOption.Content>
         <div>PT</div>
         <div>고정 예약</div>
-      </TimeOptionContent>
+      </TimeOption.Content>
     </TimeOption>
   ),
 };
@@ -42,13 +38,11 @@ export const PtFixedReservation: TimeOptionStory = {
 export const PtReservationNotPossible: TimeOptionStory = {
   render: () => (
     <TimeOption>
-      <TimeOptionIcon>
-        <CalendarX2 className="text-text-primary" />
-      </TimeOptionIcon>
-      <TimeOptionContent>
+      <TimeOption.Icon iconName={"CalendarX2"} />
+      <TimeOption.Content>
         <div>예약 불가</div>
         <div>시간대 등록</div>
-      </TimeOptionContent>
+      </TimeOption.Content>
     </TimeOption>
   ),
 };
@@ -56,13 +50,11 @@ export const PtReservationNotPossible: TimeOptionStory = {
 export const HolidaySettings: TimeOptionStory = {
   render: () => (
     <TimeOption>
-      <TimeOptionIcon>
-        <CalendarMinus2 className="text-text-primary" />
-      </TimeOptionIcon>
-      <TimeOptionContent>
+      <TimeOption.Icon iconName={"CalendarMinus"} />
+      <TimeOption.Content>
         <div>휴무일</div>
         <div>설정</div>
-      </TimeOptionContent>
+      </TimeOption.Content>
     </TimeOption>
   ),
 };

--- a/docs/storybook/stories/trainer/TimeOption.stories.tsx
+++ b/docs/storybook/stories/trainer/TimeOption.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CalendarClock, CalendarMinus2, CalendarX2, Dumbbell } from "lucide-react";
+
+import TimeOption from "trainer/components/TimeOption.js";
+
+const meta: Meta<typeof TimeOption> = {
+  component: TimeOption,
+  tags: ["autodocs"],
+  args: {
+    optionIcon: <Dumbbell className="text-text-primary" />,
+    children: <div>PT 예약</div>,
+  },
+  argTypes: {
+    optionIcon: {
+      control: "object",
+      description: "TimeOption의 icon으로 사용할 icon components prop",
+    },
+    children: {
+      control: "object",
+      description: "TimeOption의 상위에서 주입 받아 텍스트로 활용될 children prop",
+    },
+  },
+};
+
+export default meta;
+
+type TimeOptionStory = StoryObj<typeof TimeOption>;
+
+export const Default: TimeOptionStory = {};

--- a/docs/storybook/stories/trainer/TimeOption.stories.tsx
+++ b/docs/storybook/stories/trainer/TimeOption.stories.tsx
@@ -1,65 +1,68 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { CalendarClock, CalendarMinus2, CalendarX2, Dumbbell } from "lucide-react";
 
-import TimeOption from "trainer/components/TimeOption";
+import { TimeOption, TimeOptionContent, TimeOptionIcon } from "trainer/components/TimeOption";
 
 const meta: Meta<typeof TimeOption> = {
   component: TimeOption,
   tags: ["autodocs"],
-  args: {
-    optionIcon: <Dumbbell className="text-text-primary" />,
-    children: <div>PT 예약</div>,
-  },
-  argTypes: {
-    optionIcon: {
-      control: "object",
-      description: "TimeOption의 icon으로 사용할 icon components prop",
-    },
-    children: {
-      control: "object",
-      description: "TimeOption의 상위에서 주입 받아 텍스트로 활용될 children prop",
-    },
-  },
 };
 
 export default meta;
 
 type TimeOptionStory = StoryObj<typeof TimeOption>;
 
-export const PtReservation: TimeOptionStory = {};
+export const PtReservation: TimeOptionStory = {
+  render: () => (
+    <TimeOption>
+      <TimeOptionIcon>
+        <Dumbbell className="text-text-primary" />
+      </TimeOptionIcon>
+      <TimeOptionContent>
+        <div>PT 예약</div>
+      </TimeOptionContent>
+    </TimeOption>
+  ),
+};
 
 export const PtFixedReservation: TimeOptionStory = {
-  args: {
-    optionIcon: <CalendarClock className="text-text-primary" />,
-  },
-  render: (args) => (
-    <TimeOption {...args}>
-      <div>PT</div>
-      <div>고정 예약</div>
+  render: () => (
+    <TimeOption>
+      <TimeOptionIcon>
+        <CalendarClock className="text-text-primary" />
+      </TimeOptionIcon>
+      <TimeOptionContent>
+        <div>PT</div>
+        <div>고정 예약</div>
+      </TimeOptionContent>
     </TimeOption>
   ),
 };
 
 export const PtReservationNotPossible: TimeOptionStory = {
-  args: {
-    optionIcon: <CalendarX2 className="text-text-primary" />,
-  },
-  render: (args) => (
-    <TimeOption {...args}>
-      <div>예약 불가</div>
-      <div>시간대 등록</div>
+  render: () => (
+    <TimeOption>
+      <TimeOptionIcon>
+        <CalendarX2 className="text-text-primary" />
+      </TimeOptionIcon>
+      <TimeOptionContent>
+        <div>예약 불가</div>
+        <div>시간대 등록</div>
+      </TimeOptionContent>
     </TimeOption>
   ),
 };
 
 export const HolidaySettings: TimeOptionStory = {
-  args: {
-    optionIcon: <CalendarMinus2 className="text-text-primary" />,
-  },
-  render: (args) => (
-    <TimeOption {...args}>
-      <div>휴무일</div>
-      <div>설정</div>
+  render: () => (
+    <TimeOption>
+      <TimeOptionIcon>
+        <CalendarMinus2 className="text-text-primary" />
+      </TimeOptionIcon>
+      <TimeOptionContent>
+        <div>휴무일</div>
+        <div>설정</div>
+      </TimeOptionContent>
     </TimeOption>
   ),
 };

--- a/docs/storybook/tailwind.config.ts
+++ b/docs/storybook/tailwind.config.ts
@@ -3,7 +3,11 @@ import sharedConfig from "@5unwan/tailwind-config";
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  content: ["./stories/*.{js,ts,jsx,tsx,mdx}", "node_modules/@5unwan/ui/**/*.tsx"],
+  content: [
+    "./stories/*.{js,ts,jsx,tsx,mdx}",
+    "node_modules/@5unwan/ui/**/*.tsx",
+    "node_modules/trainer/components/**",
+  ],
   presets: [sharedConfig],
 };
 export default config;

--- a/docs/storybook/vite.config.ts
+++ b/docs/storybook/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@ui": path.resolve(__dirname, "../../packages/ui/src"),
+      "@trainer": path.resolve(__dirname, "../../apps/trainer"),
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       axios:
         specifier: ^1.7.9
         version: 1.7.9
+      lucide-react:
+        specifier: ^0.471.1
+        version: 0.471.1(react@18.3.1)
       next:
         specifier: 14.2.20
         version: 14.2.20(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      trainer:
+        specifier: workspace:*
+        version: link:../../apps/trainer
     devDependencies:
       '@5unwan/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
## 📝 작업 내용

### 컴포넌트 용도
해당 컴포넌트는 trainer 도메인에서 사용되는 공통 컴포넌트로 예약/일정 관리 페이지에서 특정 시간 블록을 선택했을 때 나타나는 바텀 시트에 주로 사용이되는 컴포넌트입니다.

### 컴포넌트 설계
- 해당 컴포넌트는 아이콘과 컨텐츠(텍스트)로 이루어진 컴포넌트로 상위에서 보다 자유롭게 합성하여 핸들링 할 수 있도록 합성 컴포넌트 패턴으로 설계하여 구현하였습니다.

### 스토리 작성 및 테스트 미 작성
- TimeOption 공통 컴포넌트의 스토리를 작성하였으며, 현재 figma에 정의된 네 가지 옵션에 대해 각각 정의해두었습니다.
- 해당 컴포넌트는 아직까지 view 역할만 하고 있고, 이벤트 핸들러도 상위에서 주입받고 있기 때문에 단위 테스팅은 불필요하다고 판단했습니다.

### 기타
- apps/trainer 모듈에서 tailwind를 적용할 수 있게 작성하였습니다.
- apps/trainer 모듈의 컴포넌트를 스토리로 작성할 수 있게 package.json에 export를 작성하였습니다.
- docs/storybook 모듈에서 apps/trainer 모듈의 컴포넌트를 가져올 수 있도록 디펜던시를 추가하였습니다.
- docs/storybook 모듈에서 apps/trainer 모듈의 path alias를 이해할 수 있도록 vite.config를 수정하였고, apps/trainer 모듈에서 가져온 컴포넌트에 tailwind가 적용될 수 있도록 tailwind.config를 수정하였습니다.

### 📷 스크린샷 (선택)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/53684c3e-52d9-48f3-9890-cad39506a492" />

## 💬 리뷰 요구사항(선택)
해당 컴포넌트의 경우 내부적으로 공유되는 상태가 없어 useContext를 사용하지 않았습니다. 따라서 자식 컴포넌트들을 TimeOption에서만 사용하도록 강제할 수가 없는데, useContext를 상태 공유 없이 사용해서 강제하도록 하는 것이 좋을까요? 제 생각에는 공유되는 상태가 없다면 굳이 안써도 될 것 같기는 한데 다른 분들의 의견이 궁금합니다.
