### PR TITLE
[FLIZ-57/ui] fix: Dropdown 컴포넌트 바깥쪽 클릭시 닫히지 않는 버그 수정

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -60,7 +60,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "input-otp": "^1.4.2",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
     "keen-slider": "^6.8.6",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.471.1",

--- a/packages/ui/src/components/Dropdown/index.tsx
+++ b/packages/ui/src/components/Dropdown/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ChevronDown } from "lucide-react";
 import React, {
   useRef,
@@ -65,7 +67,7 @@ function Dropdown({ open, onChangeOpen, defaultOpen, className, children }: Drop
     document.addEventListener("mousedown", handleClickOutside);
 
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+  }, [isOpen]);
 
   return (
     <DropdownContext.Provider

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "@ui/*": ["src/*"],
-      "test-utils": ["./lib/test/test-utils.tsx"]
+      "test-utils": ["src/lib/test/test-utils.tsx"]
     },
     "types": ["node", "jest", "@testing-library/jest-dom"]
   },


### PR DESCRIPTION
## 📝 작업 내용

### Dropdown 컴포넌트 바깥쪽 클릭시 닫히지 않는 버그 수정
![image](https://github.com/user-attachments/assets/62a0a3d3-9399-4c6f-85c5-f1f0812fc0f4)

- 위 첨부한 이미지 처럼 드랍다운 컴포넌트의 바깥을 클릭해도 드랍다운이 닫히지 않는 버그를 발견하여 드랍다운이 올바르게 동작하도록 버그를 수정하였습니다.
- handleClickOutside 함수가 isOpen을 초기 값으로 기억(클로저로 캡처)하여 제대로 드랍다운 컴포넌트가 닫히지 않는 문제로, useEffect의 의존성 배열에 isOpen을 주입하여 handleClickOutside 함수가 새로운 isOpen 상태를 기억하게 함으로써 버그를 해결하였습니다.

### test-utils 경로 수정
test-utils path alias를 ui 패키지에서 제대로 인식하지 못하는 버그가 발생하여 절대경로를 사용하는 방향으로 경로를 수정하였습니다.