### PR TITLE
[FLIZ-29/trainer] feat: CalendarHintGroup 컴포넌트 구현

### DIFF
--- a/apps/trainer/components/CalendarHintGroup.tsx
+++ b/apps/trainer/components/CalendarHintGroup.tsx
@@ -1,0 +1,43 @@
+import { Badge } from "@ui/components/Badge";
+import React from "react";
+
+const CalendarHintInfo = [
+  {
+    color: "brand-primary-500",
+    content: "예약 완료",
+  },
+  {
+    color: "brand-secondary-500",
+    content: "예약 대기중",
+  },
+  {
+    color: "text-sub3",
+    content: "예약 불가",
+  },
+] as const;
+
+type CalendarHintProps = {
+  content: string;
+  color: string;
+};
+function CalendarHint({ content, color }: CalendarHintProps) {
+  return (
+    <Badge variant="sub1" size="sm" className="px-3">
+      <div className="flex items-center gap-[0.25rem]">
+        <div className={`h-[0.5rem] w-[0.5rem] bg-${color}`} />
+        <span className={`text-${color}`}>{content}</span>
+      </div>
+    </Badge>
+  );
+}
+function CalendarHintGroup() {
+  return (
+    <div className="flex items-center gap-[0.5rem]">
+      {CalendarHintInfo.map(({ color, content }, idx) => (
+        <CalendarHint key={`${color}-${content}-${idx}`} color={color} content={content} />
+      ))}
+    </div>
+  );
+}
+
+export default CalendarHintGroup;

--- a/apps/trainer/components/CalendarHintGroup.tsx
+++ b/apps/trainer/components/CalendarHintGroup.tsx
@@ -30,6 +30,7 @@ function CalendarHint({ content, color }: CalendarHintProps) {
     </Badge>
   );
 }
+
 function CalendarHintGroup() {
   return (
     <div className="flex items-center gap-[0.5rem]">

--- a/docs/storybook/stories/trainer/Calendar.stories.tsx
+++ b/docs/storybook/stories/trainer/Calendar.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import Calendar from "trainer/components/Calendar/index.tsx";
+import Calendar from "trainer/components/Calendar/index";
 
 const meta: Meta<typeof Calendar> = {
   component: Calendar,

--- a/docs/storybook/stories/trainer/CalendarHintGroup.stories.tsx
+++ b/docs/storybook/stories/trainer/CalendarHintGroup.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from "@storybook/react";
+import CalendarHintGroup from "trainer/components/CalendarHintGroup";
+
+const meta: Meta<typeof CalendarHintGroup> = {
+  component: CalendarHintGroup,
+  tags: ["autodocs"],
+  decorators: (Story) => (
+    <div className="bg-background-primary flex h-full w-full items-center justify-center p-10">
+      <Story />
+    </div>
+  ),
+};
+export default meta;
+
+type Story = StoryObj<typeof CalendarHintGroup>;
+
+export const Default: Story = {
+  
+}

--- a/docs/storybook/stories/trainer/CalendarHintGroup.stories.tsx
+++ b/docs/storybook/stories/trainer/CalendarHintGroup.stories.tsx
@@ -14,6 +14,4 @@ export default meta;
 
 type Story = StoryObj<typeof CalendarHintGroup>;
 
-export const Default: Story = {
-  
-}
+export const Default: Story = {};


### PR DESCRIPTION
# [FLIZ-29/trainer] feat: CalendarHintGroup 컴포넌트 구현

## 📝 작업 내용

CalendarHintGroup 컴포넌트를 구현했습니다

### Anatomy
```tsx
<div>
   {CalendarHintInfo.map(({ color, content }, idx) => (
       <CalendarHint key={`${color}-${content}-${idx}`} color={color} content={content} />
    ))}
</div>
```

### CalendarHInt

CalendarHintGroup을 구성하는 단위입니다. ui/components/Badge 컴포넌트를 사용하여 구현했습니다

#### props
- content: CalendarHint의 텍스트 내용을 지정합니다
- color: CalendarHint가 설명하는 색상을 지정합니다

### 📷 스크린샷 (선택)

<img width="1212" alt="스크린샷 2025-02-04 오후 3 24 58" src="https://github.com/user-attachments/assets/c189e326-6f3b-493d-b4b0-74cc683e7d1d" />

## 💬 리뷰 요구사항(선택)

