### PR TITLE
[FILZ-55/root] ci: test 자동화를 위한 CI/CD 구축

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
+          cache: "pnpm"
 
       - name: Install dependencies
-        run: |
-          npm install -g pnpm
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests
         run: pnpm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Run Tests on Push
 
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - "dev"
+      - "FILZ-*"
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Run Tests on Push
+
+on: pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: |
+          npm install -g pnpm
+          pnpm install
+
+      - name: Run tests
+        run: pnpm run test
+        env:
+          CI: true

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "type-check": "turbo type-check",
     "clean": "turbo clean",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test": "pnpm -r run test"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean": "turbo clean",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "prepare": "husky",
-    "test": "pnpm -r run test"
+    "test": "turbo run test"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,10 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**", "storybook-static/**"]
     },
+    "test": {
+      "cache": true,
+      "persistent": true
+    },
     "lint": {},
     "type-check": {},
     "dev": {


### PR DESCRIPTION
## 📝 작업 내용

### 각 패키지에 작성된 테스트 코드 실행 자동화
- 각 패키지에 작성된 테스트 코드 실행 자동화를 위해 CI/CD를 작성하였습니다.
- 루트 환경에서 재귀적으로 각 패키지들을 돌며 테스트를 실행하기 위해 루트 package.json에 스크립트를 추가하였습니다.
   - turbo.json의 task에 test를 캐싱하도록 설정하여 테스트 관련 파일들이 변경되지 않는 한 캐싱된 결과가 나타나도록 작성하였습니다. 
- `dev`, `FILZ-*` 브랜치에서 PR이 생성될 경우 CI/CD가 실행됩니다.
- Settings -> Require status checks to pass before merging 설정도 추가하여 테스트가 통과되지 않을 시 Merge 할 수 없도록 수정하였습니다.
- pnpm 관련 의존성을 github action에서 캐싱하도록 하여 lock파일의 변경이 없다면 기존 pnpm 설치시간 16분 -> 55초로 단축하도록 최적화하였습니다.

