### PR TITLE
[FILZ-67/trainer] feat: 트레이너 도메인 알림 카테고리 사이드바 구현

### DIFF
--- a/apps/trainer/components/NotificationAccordion.tsx
+++ b/apps/trainer/components/NotificationAccordion.tsx
@@ -1,0 +1,82 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@ui/components/Accordion";
+import { Bell, Calendar, Dumbbell, HeartHandshake } from "lucide-react";
+
+const VISIBILITY_COUNT = 0;
+
+// TODO: 아코디언 클릭 시 이동할 경로의 네이밍이 정해지면 핸들러 붙히기
+export default function NotificationAccordion() {
+  // TODO: API가 만들어지고 나면 해당 API로 교체
+  const DUMMY_NOTIFICATION_ITEMS = [
+    {
+      title: "회원 연동",
+      contents: [
+        {
+          content: "연동 승인",
+          contentCount: 3,
+        },
+        {
+          content: "연동 해제",
+          contentCount: 2,
+        },
+      ],
+      icon: <HeartHandshake />,
+      titleCount: 5,
+    },
+    {
+      title: "PT 수업",
+      contents: [],
+      icon: <Dumbbell />,
+      titleCount: 0,
+    },
+    {
+      title: "PT 예약",
+      contents: [
+        {
+          content: "예약 요청",
+          contentCount: 0,
+        },
+        {
+          content: "예약 변경/취소",
+          contentCount: 0,
+        },
+      ],
+      icon: <Calendar />,
+      titleCount: 0,
+    },
+  ];
+
+  return (
+    <Accordion type="multiple">
+      <AccordionItem value="전체 알림">
+        <AccordionTrigger icon={<Bell />} className="border-0">
+          <span>전체 알림</span>
+        </AccordionTrigger>
+      </AccordionItem>
+      {DUMMY_NOTIFICATION_ITEMS.map(({ title, contents, titleCount, icon }, index) => (
+        <AccordionItem value={String(index)} key={`${index}-${title}`}>
+          <AccordionTrigger icon={icon}>
+            <span>{title}</span>
+            {titleCount > VISIBILITY_COUNT && (
+              <span className="bg-background-sub4 w-7 rounded-full text-center">{titleCount}</span>
+            )}
+          </AccordionTrigger>
+          {contents.map(({ content, contentCount }) => (
+            <AccordionContent key={`${content}-${contentCount}`}>
+              <span>{content}</span>
+              {contentCount > VISIBILITY_COUNT && (
+                <span className="bg-background-sub4 w-7 rounded-full text-center">
+                  {contentCount}
+                </span>
+              )}
+            </AccordionContent>
+          ))}
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+}

--- a/apps/trainer/components/NotificationSideBar.tsx
+++ b/apps/trainer/components/NotificationSideBar.tsx
@@ -1,0 +1,34 @@
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@ui/components/Drawer";
+import { Menu, X } from "lucide-react";
+
+import NotificationAccordion from "./NotificationAccordion";
+
+export default function NotificationSideBar() {
+  return (
+    <Drawer>
+      <DrawerTrigger asChild>
+        <Menu className="text-text-primary" />
+      </DrawerTrigger>
+      <DrawerContent className="w-[20.313rem] py-[1.5rem]">
+        <DrawerHeader>
+          <DrawerTitle className="m-0">
+            <div className="text-title-1 flex items-center justify-between">
+              알림
+              <DrawerClose className="text-[20px]">
+                <X />
+              </DrawerClose>
+            </div>
+          </DrawerTitle>
+        </DrawerHeader>
+        <NotificationAccordion />
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/apps/trainer/components/NotificationSideBar.tsx
+++ b/apps/trainer/components/NotificationSideBar.tsx
@@ -21,7 +21,7 @@ export default function NotificationSideBar() {
           <DrawerTitle className="m-0">
             <div className="text-title-1 flex items-center justify-between">
               알림
-              <DrawerClose className="text-[20px]">
+              <DrawerClose className="text-[1.25rem]">
                 <X />
               </DrawerClose>
             </div>

--- a/docs/storybook/stories/trainer/Calendar.stories.tsx
+++ b/docs/storybook/stories/trainer/Calendar.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import Calendar from "trainer/components/Calendar/index.tsx";
+import Calendar from "trainer/components/Calendar/index";
 
 const meta: Meta<typeof Calendar> = {
   component: Calendar,

--- a/docs/storybook/stories/trainer/NotificationSideBar.stories.tsx
+++ b/docs/storybook/stories/trainer/NotificationSideBar.stories.tsx
@@ -15,6 +15,4 @@ export default meta;
 
 type NotificationSideBarStory = StoryObj<typeof NotificationSideBar>;
 
-export const Default: NotificationSideBarStory = {
-  render: () => <NotificationSideBar />,
-};
+export const Default: NotificationSideBarStory = {};

--- a/docs/storybook/stories/trainer/NotificationSideBar.stories.tsx
+++ b/docs/storybook/stories/trainer/NotificationSideBar.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from "@storybook/react";
+import NotificationSideBar from "trainer/components/NotificationSideBar";
+
+const meta: Meta<typeof NotificationSideBar> = {
+  component: NotificationSideBar,
+  tags: ["autodocs"],
+  decorators: (Story) => (
+    <div className="bg-background-primary flex h-full w-full items-center justify-center p-10">
+      <Story />
+    </div>
+  ),
+};
+
+export default meta;
+
+type NotificationSideBarStory = StoryObj<typeof NotificationSideBar>;
+
+export const Default: NotificationSideBarStory = {
+  render: () => <NotificationSideBar />,
+};


### PR DESCRIPTION
## 📝 작업 내용

### 컴포넌트 용도
- 해당 컴포넌트는 트레이너 도메인의 알림 페이지에서 햄버거 버튼 클릭시 나타나는 알림 카테고리 사이드바입니다.
- 사이드바에 나타나는 카테고리별로 클릭을 하게 되면 카테고리별 페이지로 이동하게 됩니다(아직 페이지 네이밍이 정해지지 않았기 때문에 구현 X)

### 컴포넌트 설계
- 상위 `NotificationSideBar`에서 `NotificationAccordion`을 포함하여 알림 카테고리를 나타냅니다.
- `NotificationAccordion`의 경우 확인하지 않은 알림의 개수를 API로 받아와야 하는데, BE 쪽에서 어떤식으로 데이터를 넘겨줄지 아직 나와있는 문서가 없어 더미 데이터로 먼저 작성하였습니다.

해당 컴포넌트의 스토리를 작성하였으며, 테스트의 경우 각각 이미 테스트가 검증된 Drawer, Accordion 공통 컴포넌트를 사용 하였기에 테스트 코드를 작성하지 않았습니다. 하지만 추후 비즈니스 로직을 작성하게 되면 테스트 코드를 작성할 예정입니다.

### 📷 스크린샷 (선택)
<img width="200" alt="image" src="https://github.com/user-attachments/assets/21406da2-bb91-4cd5-aafb-a74234e04154" />
