### PR TITLE
[FILZ-75/ui] chore: ui 패키지 테스트 파일 path alias 적용

### DIFF
--- a/packages/ui/jest.config.js
+++ b/packages/ui/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   moduleDirectories: ["node_modules", "lib/test", __dirname],
   moduleNameMapper: {
+    "^@ui/(.*)$": "<rootDir>/src/$1",
     "^lucide-react$": require.resolve("lucide-react"),
   },
 };

--- a/packages/ui/src/components/__tests__/Dropdown.spec.tsx
+++ b/packages/ui/src/components/__tests__/Dropdown.spec.tsx
@@ -2,7 +2,7 @@ import { userEvent } from "@testing-library/user-event";
 
 import { render, screen } from "test-utils";
 
-import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from "../Dropdown";
+import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from "@ui/components/Dropdown";
 
 describe("Dropdown Component", () => {
   describe("상호작용 테스트", () => {

--- a/packages/ui/src/components/__tests__/RequestStatus.spec.tsx
+++ b/packages/ui/src/components/__tests__/RequestStatus.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "test-utils";
 
-import RequestStatus from "../RequestStatus";
+import RequestStatus from "@ui/components/RequestStatus";
 
 describe("RequestStatus Component", () => {
   const contentPerStatus = {

--- a/packages/ui/src/components/__tests__/Stepper.spec.tsx
+++ b/packages/ui/src/components/__tests__/Stepper.spec.tsx
@@ -2,7 +2,7 @@ import userEvent from "@testing-library/user-event";
 
 import { render, screen } from "test-utils";
 
-import Stepper from "../Stepper";
+import Stepper from "@ui/components/Stepper";
 
 describe("Stepper Component", () => {
   const mockGetChangeValue = jest.fn();

--- a/packages/ui/src/components/__tests__/TimeCellToggleGroup.spec.tsx
+++ b/packages/ui/src/components/__tests__/TimeCellToggleGroup.spec.tsx
@@ -3,9 +3,9 @@ import userEvent from "@testing-library/user-event";
 
 import { render, screen, within } from "test-utils";
 
-import { TimeCell } from "@ui/utils/timeCellUtils";
+import TimeCellToggleGroup from "@ui/components/TimeCellToggleGroup";
 
-import TimeCellToggleGroup from "../TimeCellToggleGroup";
+import { TimeCell } from "@ui/utils/timeCellUtils";
 
 const mockTimeCells: TimeCell[] = [
   { dayOfWeek: "MON", time: "08:00", disabled: false },

--- a/packages/ui/src/hooks/__tests__/useCallbackRef.spec.tsx
+++ b/packages/ui/src/hooks/__tests__/useCallbackRef.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers */
 import { renderHook, act } from "@testing-library/react";
 
-import useCallbackRef from "../useCallbackRef";
+import useCallbackRef from "@ui/hooks/useCallbackRef";
 
 describe("useCallbackRef", () => {
   it("콜백이 변경되어도 동일한 함수 참조를 유지하면서 최신 콜백을 실행해야 한다", () => {

--- a/packages/ui/src/hooks/__tests__/useControllableState.spec.tsx
+++ b/packages/ui/src/hooks/__tests__/useControllableState.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers */
 import { renderHook, act } from "@testing-library/react";
 
-import useControllableState from "../useControllableState";
+import useControllableState from "@ui/hooks/useControllableState";
 
 describe("useControllableState 훅 테스트", () => {
   describe("제어 모드", () => {

--- a/packages/ui/src/utils/__tests__/DayPickerUtils.spec.ts
+++ b/packages/ui/src/utils/__tests__/DayPickerUtils.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import { currentYearWithMonth, isWeekend } from "../DayPickerUtils";
+import { currentYearWithMonth, isWeekend } from "@ui/utils/DayPickerUtils";
 
 describe("날짜 유틸리티 함수 테스트", () => {
   describe("currentYearWithMonth 함수는", () => {

--- a/packages/ui/src/utils/__tests__/timeCellUtils.spec.ts
+++ b/packages/ui/src/utils/__tests__/timeCellUtils.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import { splitTimeCellByAMPM, TimeCell } from "../timeCellUtils";
+import { splitTimeCellByAMPM, TimeCell } from "@ui/utils/timeCellUtils";
 
 describe("splitTimeCellByAMPM", () => {
   it("자정과 정오를 기준으로 time cell을 AM, PM으로 분류한다", () => {


### PR DESCRIPTION
## 📝 작업 내용

### ui 패키지 테스트 파일 path alias 적용
- 기존의 `tsconfig.json`에 작성된 path alias를 Jest에서 인식하지 못하는 문제를 `jest.config.js` 파일의 `moduleNameMapper`를 사용하여 해결하였습니다.
- 각 패키지별 테스트 환경의 `tsconfig.json`에 작성된 path alias는 `jest.config.js` 파일의 `moduleNameMapper`에도 똑같이 적용해 주어야 jest가 경로를 인식할 수 있습니다.