### PR TITLE
[FLIZ-76/config-tailwind] chore: 변경된 Typography와 동일하게 tailwind config TypoGraphy 토큰 재정의

### DIFF
--- a/packages/config-tailwind/tailwind.config.ts
+++ b/packages/config-tailwind/tailwind.config.ts
@@ -53,63 +53,84 @@ const config: Omit<Config, "content"> = {
         "title-1": [
           "22px",
           {
-            lineHeight: "1.3",
+            lineHeight: "3.125rem",
             fontWeight: "500",
           },
         ],
         "title-2": [
           "20px",
           {
-            lineHeight: "1.3",
+            lineHeight: "3.125rem",
             fontWeight: "500",
+          },
+        ],
+        "title-3": [
+          "20px",
+          {
+            lineHeight: "3.125rem",
+            fontWeight: "400",
           },
         ],
         headline: [
           "17px",
           {
-            lineHeight: "1.4",
+            lineHeight: "3.125rem",
             fontWeight: "500",
           },
         ],
         "subhead-1": [
           "17px",
           {
-            lineHeight: "1.4",
+            lineHeight: "1.875rem",
             fontWeight: "400",
           },
         ],
         "subhead-2": [
           "15px",
           {
-            lineHeight: "1.4",
+            lineHeight: "1.875rem",
             fontWeight: "600",
           },
         ],
         "body-1": [
           "15px",
           {
-            lineHeight: "1.5",
+            lineHeight: "3.125rem",
             fontWeight: "500",
           },
         ],
         "body-2": [
           "13px",
           {
-            lineHeight: "1.5",
+            lineHeight: "3.125rem",
             fontWeight: "600",
           },
         ],
         "body-3": [
           "13px",
           {
-            lineHeight: "1.5",
+            lineHeight: "3.125rem",
             fontWeight: "500",
           },
         ],
         "body-4": [
           "12px",
           {
-            lineHeight: "1.5",
+            lineHeight: "3.125rem",
+            fontWeight: "400",
+          },
+        ],
+        "body-5": [
+          "10px",
+          {
+            lineHeight: "0.746rem",
+            fontWeight: "500",
+          },
+        ],
+        "body-6": [
+          "10px",
+          {
+            lineHeight: "0.746rem",
             fontWeight: "400",
           },
         ],


### PR DESCRIPTION
## 📝 작업 내용

### 변경된 `Typography`와 동일하게 `tailwind config` `TypoGraphy` 토큰 재정의
- 디자인팀에서 변경한 `Typograph`를 반영하였으며, 기존에 잘못 작성된 `line-Height` 토큰의 단위를 `rem`으로 변경하였습니다.

### 📷 스크린샷 (선택)
<img width="259" alt="image" src="https://github.com/user-attachments/assets/023b512f-8097-40c1-be41-2b59f081c5ed" />

