### PR TITLE
[FLIZ-77/feat/ui] feat: 사용자 마이페이지 ProfileItem 구현

### DIFF
--- a/docs/storybook/stories/ProfileItem.stories.tsx
+++ b/docs/storybook/stories/ProfileItem.stories.tsx
@@ -7,7 +7,7 @@ import {
 } from "@5unwan/ui/components/ProfileItem";
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { ChevronRight, User } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 
 const meta: Meta<typeof ProfileItem> = {
   component: ProfileItem,
@@ -18,61 +18,35 @@ export default meta;
 type Story = StoryObj<typeof ProfileItem>;
 
 export const Default: Story = {
-  render: () => (
-    <ProfileItem>
-      <ProfileItemHeader>
-        <ProfileItemIcon iconName="User" />
-        이름
-      </ProfileItemHeader>
-      <ProfileItemContent>홍길동</ProfileItemContent>
-    </ProfileItem>
-  ),
+  render: () => <ProfileItem variant="name">홍길동</ProfileItem>,
 };
 
 export const OneContent: Story = {
   render: () => (
-    <ProfileItem>
-      <ProfileItemHeader>
-        <ProfileItemIcon iconName="Code" />
-        트레이너 코드
-      </ProfileItemHeader>
-      <ProfileItemContent>
-        <div className="flex items-center">
-          <ChevronRight className="h-[1.563rem] w-[1.563rem]" />
-        </div>
-      </ProfileItemContent>
+    <ProfileItem variant="code">
+      <div className="flex items-center">
+        <ChevronRight className="h-[1.563rem] w-[1.563rem]" />
+      </div>
     </ProfileItem>
   ),
 };
 
 export const OneContent2: Story = {
   render: () => (
-    <ProfileItem>
-      <ProfileItemHeader>
-        <ProfileItemIcon iconName="Dumbbell" />
-        PT 횟수
-      </ProfileItemHeader>
-      <ProfileItemContent>
-        <Badge>00/20</Badge>
-      </ProfileItemContent>
+    <ProfileItem variant="dumbbell">
+      <Badge>00/20</Badge>
     </ProfileItem>
   ),
 };
 
 export const TwoContent: Story = {
   render: () => (
-    <ProfileItem>
-      <ProfileItemHeader>
-        <ProfileItemIcon iconName="Phone" />
-        전화번호
-      </ProfileItemHeader>
-      <ProfileItemContent>
-        010 1234 5678
-        <div className="text-text-sub4 flex text-[0.938rem] leading-[1.375rem]">
-          <div className="flex items-center">변경</div>
-          <ChevronRight className="h-[1.563rem] w-[1.563rem]" />
-        </div>
-      </ProfileItemContent>
+    <ProfileItem variant="phone">
+      010 1234 5678
+      <div className="text-text-sub4 flex text-[0.938rem] leading-[1.375rem]">
+        <div className="flex items-center">변경</div>
+        <ChevronRight className="h-[1.563rem] w-[1.563rem]" />
+      </div>
     </ProfileItem>
   ),
 };

--- a/docs/storybook/stories/ProfileItem.stories.tsx
+++ b/docs/storybook/stories/ProfileItem.stories.tsx
@@ -1,0 +1,24 @@
+import { ProfileItem, ProfileItemIcon, ProfileItemTitle, ProfileItemContent } from "@5unwan/ui/components/ProfileItem";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { User } from "lucide-react";
+
+const meta: Meta<typeof ProfileItem> = {
+  component: ProfileItem,
+  tags: ["autodocs"],
+};
+export default meta;
+
+type Story = StoryObj<typeof ProfileItem>;
+
+export const Default: Story = {
+  render: () => (
+    <ProfileItem>
+      <ProfileItemIcon>
+        <User />
+      </ProfileItemIcon>
+      <ProfileItemTitle>이름</ProfileItemTitle>
+      <ProfileItemContent>홍길동</ProfileItemContent>
+    </ProfileItem>
+  ),
+};

--- a/docs/storybook/stories/ProfileItem.stories.tsx
+++ b/docs/storybook/stories/ProfileItem.stories.tsx
@@ -1,10 +1,5 @@
 import { Badge } from "@5unwan/ui/components/Badge";
-import {
-  ProfileItem,
-  ProfileItemIcon,
-  ProfileItemContent,
-  ProfileItemHeader,
-} from "@5unwan/ui/components/ProfileItem";
+import { ProfileItem } from "@5unwan/ui/components/ProfileItem";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { ChevronRight } from "lucide-react";

--- a/docs/storybook/stories/ProfileItem.stories.tsx
+++ b/docs/storybook/stories/ProfileItem.stories.tsx
@@ -1,7 +1,13 @@
-import { ProfileItem, ProfileItemIcon, ProfileItemTitle, ProfileItemContent } from "@5unwan/ui/components/ProfileItem";
+import { Badge } from "@5unwan/ui/components/Badge";
+import {
+  ProfileItem,
+  ProfileItemIcon,
+  ProfileItemContent,
+  ProfileItemHeader,
+} from "@5unwan/ui/components/ProfileItem";
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { User } from "lucide-react";
+import { ChevronRight, User } from "lucide-react";
 
 const meta: Meta<typeof ProfileItem> = {
   component: ProfileItem,
@@ -14,11 +20,59 @@ type Story = StoryObj<typeof ProfileItem>;
 export const Default: Story = {
   render: () => (
     <ProfileItem>
-      <ProfileItemIcon>
-        <User />
-      </ProfileItemIcon>
-      <ProfileItemTitle>이름</ProfileItemTitle>
+      <ProfileItemHeader>
+        <ProfileItemIcon iconName="User" />
+        이름
+      </ProfileItemHeader>
       <ProfileItemContent>홍길동</ProfileItemContent>
+    </ProfileItem>
+  ),
+};
+
+export const OneContent: Story = {
+  render: () => (
+    <ProfileItem>
+      <ProfileItemHeader>
+        <ProfileItemIcon iconName="Code" />
+        트레이너 코드
+      </ProfileItemHeader>
+      <ProfileItemContent>
+        <div className="flex items-center">
+          <ChevronRight className="h-[1.563rem] w-[1.563rem]" />
+        </div>
+      </ProfileItemContent>
+    </ProfileItem>
+  ),
+};
+
+export const OneContent2: Story = {
+  render: () => (
+    <ProfileItem>
+      <ProfileItemHeader>
+        <ProfileItemIcon iconName="Dumbbell" />
+        PT 횟수
+      </ProfileItemHeader>
+      <ProfileItemContent>
+        <Badge>00/20</Badge>
+      </ProfileItemContent>
+    </ProfileItem>
+  ),
+};
+
+export const TwoContent: Story = {
+  render: () => (
+    <ProfileItem>
+      <ProfileItemHeader>
+        <ProfileItemIcon iconName="Phone" />
+        전화번호
+      </ProfileItemHeader>
+      <ProfileItemContent>
+        010 1234 5678
+        <div className="text-text-sub4 flex text-[0.938rem] leading-[1.375rem]">
+          <div className="flex items-center">변경</div>
+          <ChevronRight className="h-[1.563rem] w-[1.563rem]" />
+        </div>
+      </ProfileItemContent>
     </ProfileItem>
   ),
 };

--- a/packages/ui/src/components/ProfileItem.tsx
+++ b/packages/ui/src/components/ProfileItem.tsx
@@ -1,39 +1,39 @@
-import { Cake, CalendarMinus2, Code, Dumbbell, Phone, User, UserRoundX } from "lucide-react";
-import { ComponentProps, ReactNode } from "react";
+import { icons } from "lucide-react";
+import { ComponentProps } from "react";
 
 import { cn } from "@ui/lib/utils";
 
 const ProfileItemVariants = {
   calendar: {
-    icon: <CalendarMinus2 />,
+    icon: "CalendarMinus2",
     content: "휴무일 설정",
   },
   birthday: {
-    icon: <Cake />,
+    icon: "Cake",
     content: "생년월일",
   },
   name: {
-    icon: <User />,
+    icon: "User",
     content: "이름",
   },
   trainer: {
-    icon: <User />,
+    icon: "User",
     content: "트레이너",
   },
   dumbbell: {
-    icon: <Dumbbell />,
+    icon: "Dumbbell",
     content: "PT 횟수",
   },
   phone: {
-    icon: <Phone />,
+    icon: "Phone",
     content: "휴대폰 번호",
   },
   code: {
-    icon: <Code />,
+    icon: "Code",
     content: "트레이너 코드",
   },
   unlink: {
-    icon: <UserRoundX />,
+    icon: "UserRoundX",
     content: "트레이너 연동 해제",
   },
 };
@@ -60,11 +60,15 @@ function ProfileItem({ className, variant, ...props }: ProfileItemProps) {
   );
 }
 
+type Icon = keyof typeof icons;
+
 type ProfileItemIconProps = {
-  icon: ReactNode;
+  icon: Icon;
 } & ComponentProps<"div">;
 
 function ProfileItemIcon({ icon, className, ...props }: ProfileItemIconProps) {
+  const Icon = icons[icon];
+
   return (
     <div
       className={cn(
@@ -73,7 +77,7 @@ function ProfileItemIcon({ icon, className, ...props }: ProfileItemIconProps) {
       )}
       {...props}
     >
-      {icon}
+      <Icon />
     </div>
   );
 }

--- a/packages/ui/src/components/ProfileItem.tsx
+++ b/packages/ui/src/components/ProfileItem.tsx
@@ -88,13 +88,7 @@ type ProfileItemHeaderProps = {
 
 function ProfileItemHeader({ content, className, ...props }: ProfileItemHeaderProps) {
   return (
-    <div
-      className={cn(
-        `text-headline text-text-primary flex items-center text-[1.063rem] leading-[1.375rem]`,
-        className,
-      )}
-      {...props}
-    >
+    <div className={cn(`text-headline text-text-primary flex items-center`, className)} {...props}>
       {content}
     </div>
   );

--- a/packages/ui/src/components/ProfileItem.tsx
+++ b/packages/ui/src/components/ProfileItem.tsx
@@ -1,11 +1,48 @@
-import { Cake, CalendarMinus2, Clock, Code, Dumbbell, Phone, User, UserRoundX } from "lucide-react";
-import { ComponentProps } from "react";
+import { Cake, CalendarMinus2, Code, Dumbbell, Phone, User, UserRoundX } from "lucide-react";
+import { ComponentProps, ReactNode } from "react";
 
 import { cn } from "@ui/lib/utils";
 
-type ProfileItemProps = ComponentProps<"div">;
+const ProfileItemVariants = {
+  calendar: {
+    icon: <CalendarMinus2 />,
+    content: "휴무일 설정",
+  },
+  birthday: {
+    icon: <Cake />,
+    content: "생년월일",
+  },
+  name: {
+    icon: <User />,
+    content: "이름",
+  },
+  trainer: {
+    icon: <User />,
+    content: "트레이너",
+  },
+  dumbbell: {
+    icon: <Dumbbell />,
+    content: "PT 횟수",
+  },
+  phone: {
+    icon: <Phone />,
+    content: "휴대폰 번호",
+  },
+  code: {
+    icon: <Code />,
+    content: "트레이너 코드",
+  },
+  unlink: {
+    icon: <UserRoundX />,
+    content: "트레이너 연동 해제",
+  },
+};
 
-function ProfileItem({ className, ...props }: ProfileItemProps) {
+type ProfileItemProps = ComponentProps<"div"> & {
+  variant: keyof typeof ProfileItemVariants;
+};
+
+function ProfileItem({ className, variant, ...props }: ProfileItemProps) {
   return (
     <div
       className={cn(
@@ -14,28 +51,20 @@ function ProfileItem({ className, ...props }: ProfileItemProps) {
       )}
       {...props}
     >
-      {props.children}
+      <section className="flex">
+        <ProfileItemIcon icon={ProfileItemVariants[variant].icon} />
+        <ProfileItemHeader content={ProfileItemVariants[variant].content} />
+      </section>
+      <ProfileItemContent>{props.children}</ProfileItemContent>
     </div>
   );
 }
 
-type iconTypes = "calendar" | "cake" | "user" | "dumbbell" | "phone" | "code" | "clock" | "userX";
 type ProfileItemIconProps = {
-  icon: iconTypes;
+  icon: ReactNode;
 } & ComponentProps<"div">;
 
 function ProfileItemIcon({ icon, className, ...props }: ProfileItemIconProps) {
-  const ICON_MAP = {
-    calendar: <CalendarMinus2 />,
-    cake: <Cake />,
-    user: <User />,
-    dumbbell: <Dumbbell />,
-    phone: <Phone />,
-    code: <Code />,
-    clock: <Clock />,
-    userX: <UserRoundX />,
-  };
-
   return (
     <div
       className={cn(
@@ -44,17 +73,16 @@ function ProfileItemIcon({ icon, className, ...props }: ProfileItemIconProps) {
       )}
       {...props}
     >
-      {ICON_MAP[icon]}
+      {icon}
     </div>
   );
 }
 
 type ProfileItemHeaderProps = {
-  icon: iconTypes;
-  title: string;
+  content: string;
 } & ComponentProps<"div">;
 
-function ProfileItemHeader({ icon, className, title, ...props }: ProfileItemHeaderProps) {
+function ProfileItemHeader({ content, className, ...props }: ProfileItemHeaderProps) {
   return (
     <div
       className={cn(
@@ -63,8 +91,7 @@ function ProfileItemHeader({ icon, className, title, ...props }: ProfileItemHead
       )}
       {...props}
     >
-      <ProfileItemIcon icon={icon} />
-      {title}
+      {content}
     </div>
   );
 }

--- a/packages/ui/src/components/ProfileItem.tsx
+++ b/packages/ui/src/components/ProfileItem.tsx
@@ -48,7 +48,7 @@ function ProfileItemContent({ children, className, ...props }: HTMLAttributes<HT
   return (
     <div
       className={cn(
-        `text-text-sub2 grow-1 align-center absolute right-0 flex gap-[0.625rem] text-[0.938rem] leading-[1.375rem]`,
+        `text-text-sub2 absolute right-0 flex items-center gap-[0.625rem] text-[0.938rem] leading-[1.375rem]`,
         className,
       )}
       {...props}

--- a/packages/ui/src/components/ProfileItem.tsx
+++ b/packages/ui/src/components/ProfileItem.tsx
@@ -1,12 +1,56 @@
-import { HTMLAttributes } from "react";
+import { icons } from "lucide-react";
+import { ComponentProps } from "react";
 
 import { cn } from "@ui/lib/utils";
 
-function ProfileItem({ className, children, ...props }: HTMLAttributes<HTMLDivElement>) {
+type ProfileItemProps = {
+  children: React.ReactNode;
+} & ComponentProps<"div">;
+
+function ProfileItem({ className, children, ...props }: ProfileItemProps) {
   return (
     <div
       className={cn(
-        `bg-background-primary relative flex min-h-[2.813rem] min-w-[22.375rem] items-center`,
+        `bg-background-primary relative flex min-h-[2.813rem] min-w-[22.375rem] items-center justify-between`,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+type Icon = keyof typeof icons;
+
+type ProfileItemIconProps = {
+  iconName: Icon;
+} & ComponentProps<"div">;
+
+function ProfileItemIcon({ iconName, className, ...props }: ProfileItemIconProps) {
+  const Icon = icons[iconName];
+
+  return (
+    <div
+      className={cn(
+        `text-text-primary mr-[0.938rem] aspect-square h-[1.563rem] w-[1.563rem]`,
+        className,
+      )}
+      {...props}
+    >
+      <Icon />
+    </div>
+  );
+}
+
+type ProfileItemHeaderProps = {
+  children: React.ReactNode;
+} & ComponentProps<"div">;
+
+function ProfileItemHeader({ children, className, ...props }: ProfileItemHeaderProps) {
+  return (
+    <div
+      className={cn(
+        `text-headline text-text-primary flex items-center text-[1.063rem] leading-[1.375rem]`,
         className,
       )}
       {...props}
@@ -16,11 +60,11 @@ function ProfileItem({ className, children, ...props }: HTMLAttributes<HTMLDivEl
   );
 }
 
-function ProfileItemIcon({ children, className, ...props }: HTMLAttributes<HTMLDivElement>) {
+function ProfileItemContent({ children, className, ...props }: ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        `text-text-primary mr-[0.938rem] aspect-square min-h-[1.563rem] min-w-[1.563rem]`,
+        `text-text-sub2 flex items-center gap-[0.625rem] text-[0.938rem] leading-[1.375rem]`,
         className,
       )}
       {...props}
@@ -30,32 +74,4 @@ function ProfileItemIcon({ children, className, ...props }: HTMLAttributes<HTMLD
   );
 }
 
-function ProfileItemTitle({ children, className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      className={cn(
-        `text-headline text-text-primary text-[1.063rem] leading-[1.375rem]`,
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </div>
-  );
-}
-
-function ProfileItemContent({ children, className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      className={cn(
-        `text-text-sub2 absolute right-0 flex items-center gap-[0.625rem] text-[0.938rem] leading-[1.375rem]`,
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </div>
-  );
-}
-
-export { ProfileItem, ProfileItemIcon, ProfileItemTitle, ProfileItemContent };
+export { ProfileItem, ProfileItemIcon, ProfileItemHeader, ProfileItemContent };

--- a/packages/ui/src/components/ProfileItem.tsx
+++ b/packages/ui/src/components/ProfileItem.tsx
@@ -1,0 +1,61 @@
+import { HTMLAttributes } from "react";
+
+import { cn } from "@ui/lib/utils";
+
+function ProfileItem({ className, children, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        `bg-background-primary relative flex min-h-[2.813rem] min-w-[22.375rem] items-center`,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ProfileItemIcon({ children, className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        `text-text-primary mr-[0.938rem] aspect-square min-h-[1.563rem] min-w-[1.563rem]`,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ProfileItemTitle({ children, className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        `text-headline text-text-primary text-[1.063rem] leading-[1.375rem]`,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ProfileItemContent({ children, className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        `text-text-sub2 grow-1 align-center absolute right-0 flex gap-[0.625rem] text-[0.938rem] leading-[1.375rem]`,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export { ProfileItem, ProfileItemIcon, ProfileItemTitle, ProfileItemContent };

--- a/packages/ui/src/components/ProfileItem.tsx
+++ b/packages/ui/src/components/ProfileItem.tsx
@@ -51,9 +51,10 @@ function ProfileItemIcon({ icon, className, ...props }: ProfileItemIconProps) {
 
 type ProfileItemHeaderProps = {
   icon: iconTypes;
+  title: string;
 } & ComponentProps<"div">;
 
-function ProfileItemHeader({ icon, className, ...props }: ProfileItemHeaderProps) {
+function ProfileItemHeader({ icon, className, title, ...props }: ProfileItemHeaderProps) {
   return (
     <div
       className={cn(
@@ -63,7 +64,7 @@ function ProfileItemHeader({ icon, className, ...props }: ProfileItemHeaderProps
       {...props}
     >
       <ProfileItemIcon icon={icon} />
-      {props.children}
+      {title}
     </div>
   );
 }

--- a/packages/ui/src/components/ProfileItem.tsx
+++ b/packages/ui/src/components/ProfileItem.tsx
@@ -1,13 +1,11 @@
-import { icons } from "lucide-react";
+import { Cake, CalendarMinus2, Clock, Code, Dumbbell, Phone, User, UserRoundX } from "lucide-react";
 import { ComponentProps } from "react";
 
 import { cn } from "@ui/lib/utils";
 
-type ProfileItemProps = {
-  children: React.ReactNode;
-} & ComponentProps<"div">;
+type ProfileItemProps = ComponentProps<"div">;
 
-function ProfileItem({ className, children, ...props }: ProfileItemProps) {
+function ProfileItem({ className, ...props }: ProfileItemProps) {
   return (
     <div
       className={cn(
@@ -16,18 +14,27 @@ function ProfileItem({ className, children, ...props }: ProfileItemProps) {
       )}
       {...props}
     >
-      {children}
+      {props.children}
     </div>
   );
 }
-type Icon = keyof typeof icons;
 
+type iconTypes = "calendar" | "cake" | "user" | "dumbbell" | "phone" | "code" | "clock" | "userX";
 type ProfileItemIconProps = {
-  iconName: Icon;
+  icon: iconTypes;
 } & ComponentProps<"div">;
 
-function ProfileItemIcon({ iconName, className, ...props }: ProfileItemIconProps) {
-  const Icon = icons[iconName];
+function ProfileItemIcon({ icon, className, ...props }: ProfileItemIconProps) {
+  const ICON_MAP = {
+    calendar: <CalendarMinus2 />,
+    cake: <Cake />,
+    user: <User />,
+    dumbbell: <Dumbbell />,
+    phone: <Phone />,
+    code: <Code />,
+    clock: <Clock />,
+    userX: <UserRoundX />,
+  };
 
   return (
     <div
@@ -37,16 +44,16 @@ function ProfileItemIcon({ iconName, className, ...props }: ProfileItemIconProps
       )}
       {...props}
     >
-      <Icon />
+      {ICON_MAP[icon]}
     </div>
   );
 }
 
 type ProfileItemHeaderProps = {
-  children: React.ReactNode;
+  icon: iconTypes;
 } & ComponentProps<"div">;
 
-function ProfileItemHeader({ children, className, ...props }: ProfileItemHeaderProps) {
+function ProfileItemHeader({ icon, className, ...props }: ProfileItemHeaderProps) {
   return (
     <div
       className={cn(
@@ -55,12 +62,15 @@ function ProfileItemHeader({ children, className, ...props }: ProfileItemHeaderP
       )}
       {...props}
     >
-      {children}
+      <ProfileItemIcon icon={icon} />
+      {props.children}
     </div>
   );
 }
 
-function ProfileItemContent({ children, className, ...props }: ComponentProps<"div">) {
+type ProfileItemContentProps = ComponentProps<"div">;
+
+function ProfileItemContent({ className, ...props }: ProfileItemContentProps) {
   return (
     <div
       className={cn(
@@ -69,7 +79,7 @@ function ProfileItemContent({ children, className, ...props }: ComponentProps<"d
       )}
       {...props}
     >
-      {children}
+      {props.children}
     </div>
   );
 }


### PR DESCRIPTION
## 📝 작업 내용

사용자의 마이페이지에 표시될 프로필 아이템을 구현하였습니다.
컴포넌트의 스토리북을 작성하였습니다.
해당 컴포넌트는 회원과 트레이너 모두 사용되므로 공통 컴포넌트로 구현하였습니다.

`{children}`으로 주입하여 컴포넌트를 사용합니다.

의견 있으시면 리뷰에 남겨주시면 감사하겠습니다.

### 📷 스크린샷 (선택)

스크린샷은 figma에 사이드 공간이 있어 배경색을 통일하여 촬영하였으며,
실제 데이터에는 사이드에 margin없이 작성하였습니다.

<img width="540" alt="image" src="https://github.com/user-attachments/assets/ef68ccab-3933-4c09-90b9-b33945d6b9e3" />

## 💬 리뷰 요구사항(선택)

div를 Icon, Title, Content로 나누었는데
Content는 기본 `flex text-sub2 ...`  값을 가지는데 페이지 이동에 대한 버튼이 주어지면 `text-sub3`를 주어야하는데
따로 `ContentRouter` 혹은 `ContentOption`와 같은 컴포넌트를 하나 더 넣어 사용자가 상위에서 컴포넌트를 주입할 때 **스타일링에 조금 더 신경이 덜 쓰이도록** 하면도 어떨까 하였습니다.


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
