### PR TITLE
[FLIZ-69/trainer] feat: 트레이너 도메인 BottomNavigation 컴포넌트 구현

### DIFF
--- a/apps/trainer/components/BottomNavigation.tsx
+++ b/apps/trainer/components/BottomNavigation.tsx
@@ -1,0 +1,23 @@
+import { Bell, Calendar, ContactRound, UserRound } from "lucide-react";
+
+export default function BottomNavigation() {
+  const navigationItems = [
+    { icon: Calendar, label: "캘린더" },
+    { icon: ContactRound, label: "회원" },
+    { icon: Bell, label: "알림" },
+    { icon: UserRound, label: "마이페이지" },
+  ];
+
+  return (
+    <nav className="bg-background-primary flex h-[5.063rem] w-full items-center justify-around border-t border-gray-400">
+      {navigationItems.map(({ icon: Icon, label }, index) => (
+        <div key={`${label}-${index}`} className="flex flex-1 items-center justify-center">
+          <button className="text-background-sub4 hover:text-background-sub5 flex w-12 flex-col items-center justify-center gap-1">
+            <Icon />
+            <div className="text-body-5">{label}</div>
+          </button>
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/apps/trainer/components/BottomNavigation.tsx
+++ b/apps/trainer/components/BottomNavigation.tsx
@@ -1,4 +1,5 @@
 import { Bell, Calendar, ContactRound, UserRound } from "lucide-react";
+import Link from "next/link";
 
 export default function BottomNavigation() {
   const navigationItems = [
@@ -14,7 +15,10 @@ export default function BottomNavigation() {
         <div key={`${label}-${index}`} className="flex flex-1 items-center justify-center">
           <button className="text-background-sub4 hover:text-background-sub5 flex w-12 flex-col items-center justify-center gap-1">
             <Icon />
-            <div className="text-body-5">{label}</div>
+            {/* TODO: 각 페이지 경로 네이밍이 정해지면 이동할 경로명 href 작성 */}
+            <Link href="" className="text-body-5">
+              {label}
+            </Link>
           </button>
         </div>
       ))}

--- a/docs/storybook/stories/trainer/BottomNavigation.stories.tsx
+++ b/docs/storybook/stories/trainer/BottomNavigation.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from "@storybook/react";
+import BottomNavigation from "trainer/components/BottomNavigation";
+
+const meta: Meta<typeof BottomNavigation> = {
+  component: BottomNavigation,
+  tags: ["autodocs"],
+  decorators: (Story) => (
+    <div className="w-[24.563rem]">
+      <Story />
+    </div>
+  ),
+};
+
+export default meta;
+
+type BottomNavigationStory = StoryObj<typeof BottomNavigation>;
+
+export const Default: BottomNavigationStory = {
+  render: () => <BottomNavigation />,
+};

--- a/docs/storybook/tailwind.config.ts
+++ b/docs/storybook/tailwind.config.ts
@@ -4,7 +4,7 @@ import type { Config } from "tailwindcss";
 
 const config: Config = {
   content: [
-    "./stories/*.{js,ts,jsx,tsx,mdx}",
+    "./stories/**/*.{js,ts,jsx,tsx,mdx}",
     "node_modules/@5unwan/ui/**/*.tsx",
     "node_modules/trainer/components/**",
   ],


### PR DESCRIPTION
## 📝 작업 내용

### 컴포넌트 용도
- 트레이너 도메인에서 공통으로 사용 될 바텀 네비게이션으로 `캘린더/회원/알람/마이페이지` 로 이동할 수 있습니다.

아직 정해진 페이지 네이밍이 없는 상태라 라우팅 기능 같은 핸들러는아직 작성하지 않은 상태이며, 포커싱 색상 처리는 추후 `url state`를 사용할 예정입니다.

또한 단순히 view만 보여지고 있는 형태이기 때문에 테스트는 작성하지 않았으며 스토리만 작성된 상태입니다.

### 📷 스크린샷 (선택)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/08f51083-401a-4b6e-b94b-16bfb83df123" />
