### PR TITLE
[FLIZ-62/ui] feat: ProfileHeader 컴포넌트 구현

### DIFF
--- a/docs/storybook/stories/ProfileHeader.stories.tsx
+++ b/docs/storybook/stories/ProfileHeader.stories.tsx
@@ -1,0 +1,28 @@
+import { Button } from "@5unwan/ui/components/Button";
+import ProfileHeader from "@5unwan/ui/components/ProfileHeader";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof ProfileHeader> = {
+  component: () => (
+    <ProfileHeader>
+      <ProfileHeader.Section
+        onClick={() => {
+          alert("clicked");
+        }}
+      >
+        <ProfileHeader.Avatar name="홍길동" imageSrc="https://picsum.photos/300" />
+        <ProfileHeader.Name name="홍길동" />
+      </ProfileHeader.Section>
+      <ProfileHeader.Section>
+        <Button size="sm" className="bg-background-sub2 rounded-full">
+          로그아웃
+        </Button>
+      </ProfileHeader.Section>
+    </ProfileHeader>
+  ),
+};
+export default meta;
+
+type Story = StoryObj<typeof ProfileHeader>;
+
+export const Default: Story = {};

--- a/packages/ui/src/components/ChevronTrigger.tsx
+++ b/packages/ui/src/components/ChevronTrigger.tsx
@@ -12,7 +12,10 @@ type ChevronTriggerProps = React.ComponentProps<"div"> & {
 };
 
 const ChevronTrigger = React.forwardRef<HTMLDivElement, ChevronTriggerProps>(
-  ({ onClick, children, className, position = "right", size = DEFAULT_ICON_SIZE }, ref) => (
+  (
+    { onClick, children, className, position = "right", size = DEFAULT_ICON_SIZE, ...props },
+    ref,
+  ) => (
     <div
       onClick={onClick}
       className={cn(
@@ -20,6 +23,7 @@ const ChevronTrigger = React.forwardRef<HTMLDivElement, ChevronTriggerProps>(
         className,
       )}
       ref={ref}
+      {...props}
     >
       {position === "left" && <ChevronLeft size={size} />}
       {children}

--- a/packages/ui/src/components/ChevronTrigger.tsx
+++ b/packages/ui/src/components/ChevronTrigger.tsx
@@ -1,0 +1,32 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import React from "react";
+
+import { cn } from "@ui/lib/utils";
+
+const DEFAULT_ICON_SIZE = 24;
+
+type ChevronTriggerProps = React.ComponentProps<"div"> & {
+  position?: "left" | "right";
+  size?: number;
+  onClick: React.MouseEventHandler<HTMLDivElement>;
+};
+
+const ChevronTrigger = React.forwardRef<HTMLDivElement, ChevronTriggerProps>(
+  ({ onClick, children, className, position = "right", size = DEFAULT_ICON_SIZE }, ref) => (
+    <div
+      onClick={onClick}
+      className={cn(
+        "hover:bg-background-sub3 text-text-primary flex w-fit cursor-pointer items-center rounded-md transition-colors",
+        className,
+      )}
+      ref={ref}
+    >
+      {position === "left" && <ChevronLeft size={size} />}
+      {children}
+      {position === "right" && <ChevronRight size={size} />}
+    </div>
+  ),
+);
+ChevronTrigger.displayName = "ChevronTrigger";
+
+export default ChevronTrigger;

--- a/packages/ui/src/components/ChevronTrigger.tsx
+++ b/packages/ui/src/components/ChevronTrigger.tsx
@@ -19,7 +19,7 @@ const ChevronTrigger = React.forwardRef<HTMLDivElement, ChevronTriggerProps>(
     <div
       onClick={onClick}
       className={cn(
-        "hover:bg-background-sub3 text-text-primary flex w-fit cursor-pointer items-center rounded-md transition-colors",
+        "hover:bg-background-sub3 text-text-primary flex w-fit cursor-pointer items-center rounded-md bg-transparent transition-colors",
         className,
       )}
       ref={ref}

--- a/packages/ui/src/components/ProfileHeader.tsx
+++ b/packages/ui/src/components/ProfileHeader.tsx
@@ -1,0 +1,69 @@
+import React, { forwardRef } from "react";
+
+import { cn } from "@ui/lib/utils";
+
+import { Avatar, AvatarFallback, AvatarImage } from "./Avatar";
+import ChevronTrigger from "./ChevronTrigger";
+import { Text } from "./Text";
+
+type ProfileHeaderProps = {
+  children: React.ReactNode;
+};
+const ProfileHeaderRoot = React.forwardRef<HTMLDivElement, ProfileHeaderProps>(
+  ({ children }, ref) => (
+    <div className="flex items-center justify-between" ref={ref}>
+      {children}
+    </div>
+  ),
+);
+ProfileHeaderRoot.displayName = "ProfileHeaderRoot";
+
+type ProfileHeaderSectionProps = {
+  children: React.ReactNode;
+  className?: string;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+};
+const ProfileHeaderSection = React.forwardRef<HTMLDivElement, ProfileHeaderSectionProps>(
+  ({ children, className, onClick }, ref) => {
+    if (onClick)
+      return (
+        <ChevronTrigger onClick={onClick} position="right" ref={ref} className="">
+          <div className={cn("flex w-fit items-center gap-[1rem]", className)}>{children}</div>
+        </ChevronTrigger>
+      );
+
+    return <div className={cn("flex w-fit items-center gap-[1rem]", className)}>{children}</div>;
+  },
+);
+ProfileHeaderSection.displayName = "ProfileHeaderSection";
+
+type ProfileHeaderAvatarProps = {
+  name: string;
+  imageSrc: string;
+};
+const ProfileHeaderAvatar = forwardRef<React.ElementRef<typeof Avatar>, ProfileHeaderAvatarProps>(
+  ({ name, imageSrc }, ref) => {
+    return (
+      <Avatar ref={ref}>
+        <AvatarImage src={imageSrc} alt={`${name}님 프로필`} />
+        <AvatarFallback />
+      </Avatar>
+    );
+  },
+);
+ProfileHeaderAvatar.displayName = "ProfileHeaderAvatar";
+
+type ProfileHeaderNameProps = {
+  name: string;
+};
+function ProfileHeaderName({ name }: ProfileHeaderNameProps) {
+  return <Text.Title2>{name}</Text.Title2>;
+}
+
+const ProfileHeader = Object.assign(ProfileHeaderRoot, {
+  Section: ProfileHeaderSection,
+  Avatar: ProfileHeaderAvatar,
+  Name: ProfileHeaderName,
+});
+
+export default ProfileHeader;


### PR DESCRIPTION
# [FLIZ-62/ui] feat: ProfileHeader 컴포넌트 구현

## 📝 작업 내용

ProfileHeader 컴포넌트를 구현했습니다
- 제공해야 하는 디자인의 종류와 확장성을 고려하여 컴파운드 컴포넌트 기법을 사용했습니다

추가적으로 Chevron을 가지며 클릭 핸들러를 주입하는 div의 재사용성이 높아 ChevronTrigger 컴포넌트로 로직을 분리하였습니다

### Anatomy
```tsx 
   <ProfileHeader>
      <ProfileHeader.Section
        onClick={() => {
          alert("clicked");
        }}
      >
        <ProfileHeader.Avatar name="홍길동" imageSrc="https://picsum.photos/300" />
        <ProfileHeader.Name name="홍길동" />
      </ProfileHeader.Section>
    </ProfileHeader>
```
- `ProfileHeader`: 컴포넌트의 root
- `ProflieHeader.Section`: 컴포넌트 레이아웃의 단위로 onClick 주입 시 ChevronTrigger로 wrapping됩니다
- `ProfileHeader.Avatar`: @ui/Avatar를 사용했습니다
- `ProfileHeader.Name`: @ui/Text.Title2를 사용했습니다

### 📷 스크린샷 (선택)

<img width="356" alt="스크린샷 2025-02-08 오후 3 58 46" src="https://github.com/user-attachments/assets/0d0da241-f3c6-46f3-b242-b14464382deb" />

## 💬 리뷰 요구사항(선택)

