### PR TITLE
[FLIZ-81/ui] feat: PTHistoryItem 컴포넌트 구현

### DIFF
--- a/docs/storybook/stories/PTHistory.stories.tsx
+++ b/docs/storybook/stories/PTHistory.stories.tsx
@@ -1,0 +1,33 @@
+import PTHistoryItem from "@5unwan/ui/components/PTHistoryItem";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof PTHistoryItem> = {
+  component: ({ reservationDate, ...args }) => (
+    <PTHistoryItem reservationDate={reservationDate && new Date(reservationDate)} {...args} />
+  ),
+  tags: ["autodocs"],
+  argTypes: {
+    reservationDate: {
+      control: "date",
+    },
+    status: {
+      control: "select",
+      options: ["COMPLETED", "NO_SHOW", "NONE"],
+    },
+  },
+  args: {
+    status: "COMPLETED",
+    reservationDate: new Date()
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof PTHistoryItem>;
+
+export const Default: Story = {};
+export const Clickable: Story = {
+  args: {
+    status: 'NONE',
+    onClick: () => alert('clicked')
+  }
+}

--- a/packages/ui/src/components/PTHistoryItem.tsx
+++ b/packages/ui/src/components/PTHistoryItem.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+import { cn } from "@ui/lib/utils";
+
+import { Badge } from "./Badge";
+import { Text } from "./Text";
+import DateController from "../lib/DateController";
+
+const PTHistoryStatusMap = {
+  COMPLETED: () => "PT 완료",
+  NO_SHOW: () => "불참석",
+  NONE: (isClickable?: boolean) => (isClickable ? "PT가 완료되었나요?" : "미처리"),
+} as const;
+
+type PTHistoryItemProps = {
+  reservationDate: string | Date;
+  status: keyof typeof PTHistoryStatusMap;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+};
+function PTHistoryItem({ reservationDate, status, onClick }: PTHistoryItemProps) {
+  try {
+    const validatedController = DateController(reservationDate).validate();
+    const isClickable = onClick && status === "NONE";
+    if (validatedController === undefined) throw new Error("유효하지 않은 날짜 형식입니다");
+
+    return (
+      <div
+        className={cn(
+          "text-text-primary bg-background-sub1 flex h-[3.375rem] items-center justify-between rounded-[10px] px-[0.9375rem]",
+          {
+            "bg-background-sub2": isClickable,
+          },
+        )}
+      >
+        {validatedController.toServiceFormat().untilMinutes}
+        {
+          <Badge
+            variant={isClickable ? "brand" : "sub2"}
+            size="sm"
+            onClick={isClickable ? onClick : undefined}
+            className={cn("px-[10px]", {
+              "hover:bg-brand-primary-500/90 cursor-pointer transition-colors": isClickable,
+            })}
+          >
+            <Text.Headline1>{PTHistoryStatusMap[status](isClickable)}</Text.Headline1>
+          </Badge>
+        }
+      </div>
+    );
+  } catch (e) {
+    console.error(e);
+
+    return;
+  }
+}
+
+export default PTHistoryItem;


### PR DESCRIPTION
# [FLIZ-81/ui] feat: PTHistoryItem 컴포넌트 구현

## 📝 작업 내용

PTHistoryItem 컴포넌트를 구현했습니다
- `reservationDate === 'NONE'` 인 경우 UI 및 상호작용 여부가 도메인 종류에 따라 구분되는 것을 고려하여 설계했습니다. 
- REST API로 주어지는 날짜 형식을 format하기 위해 `@ui/libs/DateController` 를 활용했습니다
- `try...catch`문으로 감싸 컴포넌트 렌더링 중 에러가 발생할 경우 undefined를 반환합니다
### props
- `reservationDate`: PT 내역 날짜를 지정합니다
- `status`: PT 내역의 처리 상태를 지정합니다 (`'COMPLETED' | 'NO_SHOW' | 'NONE'`)
### 📷 스크린샷 (선택)

<img width="415" alt="스크린샷 2025-02-09 오전 12 00 33" src="https://github.com/user-attachments/assets/452b3824-f96b-4e3a-a7eb-66ff2103da86" />

<img width="432" alt="스크린샷 2025-02-09 오전 12 00 11" src="https://github.com/user-attachments/assets/c6d0f047-f046-4b9e-aab9-53ea767d32f6" />

## 💬 리뷰 요구사항(선택)

컴포넌트 렌더링 중 에러 발생 시 `undefined`를 반환하게 한 이유는 ListItem 하나에서 발생한 오류가 전체 List에 까지 영향을 미치지 않게 하기 위해서입니다. 각 Item을 `ErrorBoundary`로 감싸는 방법도 있겠지만, 
- 에러 발생 시, 각 Item에 대한 재요청을 제공하지 않으며 
- 사용자에게 정상적인 Item과 오류가 있는 Item을 동일한 리스트 안에 보여주는 것이 UX측면에서 안 좋다고 생각하여
해당 방식을 선택했습니다. 
에러 처리에 대한 피드백 부탁드립니다.
