### PR TITLE
[FLIZ-80/ui] feat: Header 컴포넌트 구현

### DIFF
--- a/docs/storybook/stories/Header.stories.tsx
+++ b/docs/storybook/stories/Header.stories.tsx
@@ -1,0 +1,25 @@
+import Header from "@5unwan/ui/components/Header";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Header> = {
+  component: () => (
+    <Header>
+      <Header.Left>LEFT</Header.Left>
+      <Header.Title content="TITLE" />
+      <Header.Right>RIGHT</Header.Right>
+    </Header>
+  ),
+};
+export default meta;
+type Story = StoryObj<typeof Header>;
+
+export const Default: Story = {};
+export const WithBack: Story = {
+  render: () => (
+    <Header>
+      <Header.Back onClick={() => alert("clicked")} />
+      <Header.Title content="TITLE" />
+      <Header.Right>RIGHT</Header.Right>
+    </Header>
+  ),
+};

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -11,14 +11,14 @@ type HeaderRootProps = {
 };
 function HeaderRoot({ children, className }: HeaderRootProps) {
   return (
-    <div
+    <header
       className={cn(
         "text-text-primary text-title-2 grid w-full grid-cols-3 items-center",
         className,
       )}
     >
       {children}
-    </div>
+    </header>
   );
 }
 

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -1,0 +1,78 @@
+import { ChevronLeft } from "lucide-react";
+import React, { MouseEventHandler } from "react";
+
+import { cn } from "@ui/lib/utils";
+
+import { Text } from "./Text";
+
+type HeaderRootProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+function HeaderRoot({ children, className }: HeaderRootProps) {
+  return (
+    <div
+      className={cn(
+        "text-text-primary text-title-2 grid w-full grid-cols-3 items-center",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type HeaderSectionProps = {
+  position: "left" | "right";
+  children: React.ReactNode;
+  className?: string;
+};
+function HeaderSection({ position, children, className }: HeaderSectionProps) {
+  return (
+    <div
+      className={cn(
+        {
+          "col-start-1 col-end-2 justify-self-start": position === "left",
+          "col-start-3 col-end-4 justify-self-end": position === "right",
+        },
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type HeaderTitleProps = {
+  content: string;
+  className?: string;
+};
+function HeaderTitle({ content, className }: HeaderTitleProps) {
+  return (
+    <Text.Title2 className={cn("col-start-2 col-end-3 justify-self-center", className)}>
+      {content}
+    </Text.Title2>
+  );
+}
+
+type HeaderBackProps = { onClick: MouseEventHandler };
+function HeaderBack({ onClick }: HeaderBackProps) {
+  return (
+    <HeaderSection position="left">
+      <ChevronLeft size={25} onClick={onClick} className="cursor-pointer" />
+    </HeaderSection>
+  );
+}
+
+const HeaderSectionPicker = (position: "left" | "right") =>
+  function HeaderSectionMaker(props: Omit<HeaderSectionProps, "position">) {
+    return <HeaderSection position={position} {...props}></HeaderSection>;
+  };
+
+const Header = Object.assign(HeaderRoot, {
+  Back: HeaderBack,
+  Left: HeaderSectionPicker("left"),
+  Right: HeaderSectionPicker("right"),
+  Title: HeaderTitle,
+});
+export default Header;


### PR DESCRIPTION
# [FLIZ-80/ui] feat: Header 컴포넌트 구현

## 📝 작업 내용

Header 컴포넌트를 구현했습니다
- 페이지마다 왼쪽, 오른쪽 버튼의 아이콘 및 비즈니스 로직이 달라 컴파운드 컴포넌트 패턴을 사용하여 조금 더 확장이 용이하도록 설계했습니다

### Anatomy
```tsx
   <Header>
      <Header.Left>LEFT</Header.Left>.  // 또는 <Header.Back />
      <Header.Title content="TITLE" />
      <Header.Right>RIGHT</Header.Right>
    </Header>
```
- Header : 컴포넌트의 Root. 3열 그리드 레이아웃입니다
- Left: justify-self: flex-start 인 div
- Right: justify-self: flex-right인 div
- Back: Left 대신 사용할 수 있습니다. 뒤로가기 버튼이 추가된 Left입니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

