### PR TITLE
[FLIZ-86/ui, trainer] feat: PTSchedule, PTPreference 컴포넌트 구현

### DIFF
--- a/apps/trainer/components/PTSchedule.tsx
+++ b/apps/trainer/components/PTSchedule.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@ui/components/Badge";
+import { Days } from "@ui/components/DayOfWeekPicker/Days";
 import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from "@ui/components/Dropdown";
 import { Text } from "@ui/components/Text";
 import DateController from "@ui/lib/DateController";
@@ -47,7 +48,7 @@ function PTScheduleItem({ current, applyAt, schedules }: PTScheduleItemProps) {
   const weekSchedule = Object.entries(
     makeWeekSchedule({ type: "span", schedule: schedules }),
   ) as ObjectEntries<Record<DaysOfWeek, string>>;
-  const mondaySchedule = weekSchedule[0];
+  const mondaySchedule = weekSchedule[Days.Monday];
 
   const handleEditClick = () => {
     alert("clicked");

--- a/apps/trainer/components/PTSchedule.tsx
+++ b/apps/trainer/components/PTSchedule.tsx
@@ -1,0 +1,93 @@
+import { Badge } from "@ui/components/Badge";
+import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from "@ui/components/Dropdown";
+import { Text } from "@ui/components/Text";
+import DateController from "@ui/lib/DateController";
+import {
+  DAYS_OF_WEEK,
+  DaysOfWeek,
+  makeWeekSchedule,
+  ObjectEntries,
+} from "@ui/utils/makeWeekSchedule";
+import { Ellipsis } from "lucide-react";
+import React from "react";
+
+type SpanScheduleUnit = {
+  dayOfWeek: DaysOfWeek;
+  isHoliday: boolean;
+  startTime: string;
+  endTime: string;
+};
+type PTScheduleProps = {
+  currentSchedules: SpanScheduleUnit[];
+  scheduleChanges: {
+    applyAt: string;
+    schedules: SpanScheduleUnit[];
+  }[];
+};
+function PTSchedule({ currentSchedules, scheduleChanges }: PTScheduleProps) {
+  return (
+    <div className="flex flex-col items-center gap-[0.5rem]">
+      <PTScheduleItem current={true} schedules={currentSchedules} />
+      {scheduleChanges.map(({ applyAt, schedules }, index) => (
+        <PTScheduleItem key={`scheduled-${index}`} applyAt={applyAt} schedules={schedules} />
+      ))}
+    </div>
+  );
+}
+
+export default PTSchedule;
+
+type PTScheduleItemProps = {
+  current?: boolean;
+  applyAt?: string;
+  schedules: SpanScheduleUnit[];
+};
+function PTScheduleItem({ current, applyAt, schedules }: PTScheduleItemProps) {
+  const isCurrent = current && !applyAt;
+  const weekSchedule = Object.entries(
+    makeWeekSchedule({ type: "span", schedule: schedules }),
+  ) as ObjectEntries<Record<DaysOfWeek, string>>;
+  const mondaySchedule = weekSchedule[0];
+
+  const handleEditClick = () => {
+    alert("clicked");
+
+    //TODO: ellipsis 클릭 핸들러 로직 추가
+  };
+
+  return (
+    <div className="bg-background-sub1 text-text-primary w-full rounded-[10px] p-4 ">
+      <div className="relative flex items-center gap-[1rem]">
+        {isCurrent ? (
+          <Badge size="sm" variant="default" className="px-3">
+            현재 적용중
+          </Badge>
+        ) : (
+          <Badge size="sm" variant="sub2">
+            예정
+          </Badge>
+        )}
+        {applyAt && (
+          <Text.Body3>
+            {`${DateController(new Date(applyAt)).validate()?.toServiceFormat().untilDate}부터 적용`}
+          </Text.Body3>
+        )}
+        <Ellipsis
+          onClick={handleEditClick}
+          className="text-background-sub4 absolute right-0 top-0 cursor-pointer"
+        />
+      </div>
+      <Dropdown>
+        <DropdownTrigger className="flex">
+          <Text.Body1>{`${DAYS_OF_WEEK[mondaySchedule[0]]} ${mondaySchedule[1] === "-" ? "휴무일" : mondaySchedule[1]}`}</Text.Body1>
+        </DropdownTrigger>
+        <DropdownContent>
+          {/* eslint-disable-next-line no-magic-numbers */}
+          {weekSchedule.slice(1).map(([dayOfWeek, schedule]: [DaysOfWeek, string | null]) => (
+            <DropdownItem key={dayOfWeek}>{`${DAYS_OF_WEEK[dayOfWeek]} ${schedule}`}</DropdownItem>
+          ))}
+        </DropdownContent>
+      </Dropdown>
+    </div>
+  );
+}

--- a/docs/storybook/stories/PTPreference.stories.tsx
+++ b/docs/storybook/stories/PTPreference.stories.tsx
@@ -1,0 +1,57 @@
+import { Meta, StoryObj } from "@storybook/react";
+import PTPreference from "@5unwan/ui/components/PTPreference";
+import { Accordion } from "@5unwan/ui/components/Accordion/index";
+
+const meta: Meta<typeof PTPreference> = {
+  component: (args) => (
+    <Accordion type="multiple">
+      <PTPreference {...args} />
+    </Accordion>
+  ),
+  decorators: [
+    (Story) => (
+      <div className="bg-background-primary p-5">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: {
+    workoutSchedule: [
+      {
+        dayOfWeek: "MON",
+        preferenceTimes: ["10:00", "11:00", "12:00"],
+      },
+      {
+        dayOfWeek: "TUE",
+        preferenceTimes: ["10:00", "11:00", "12:00", "14:00", "15:00"],
+      },
+      {
+        dayOfWeek: "WED",
+        preferenceTimes: ["10:00", "11:00", "12:00"],
+      },
+      {
+        dayOfWeek: "THU",
+        preferenceTimes: ["10:00", "11:00", "12:00", "14:00", "15:00"],
+      },
+      {
+        dayOfWeek: "FRI",
+        preferenceTimes: ["10:00", "11:00", "12:00"],
+      },
+      {
+        dayOfWeek: "SAT",
+        preferenceTimes: ["10:00", "11:00", "12:00", "18:00"],
+      },
+      {
+        dayOfWeek: "SUN",
+        preferenceTimes: ["10:00", "11:00", "12:00", "18:00"],
+      },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PTPreference>;
+
+export const Default: Story = {};

--- a/docs/storybook/stories/trainer/PTSchedule.stories.tsx
+++ b/docs/storybook/stories/trainer/PTSchedule.stories.tsx
@@ -1,0 +1,108 @@
+import { Meta, StoryObj } from "@storybook/react";
+import PTSchedule from "trainer/components/PTSchedule";
+
+const meta: Meta<typeof PTSchedule> = {
+  component: PTSchedule,
+  tags: ["autodocs"],
+  args: {
+    currentSchedules: [
+      {
+        dayOfWeek: "MON",
+        isHoliday: true,
+        startTime: "09:00",
+        endTime: "19:00",
+      },
+      {
+        dayOfWeek: "TUE",
+        isHoliday: false,
+        startTime: "09:00",
+        endTime: "19:00",
+      },
+      {
+        dayOfWeek: "WED",
+        isHoliday: false,
+        startTime: "09:00",
+        endTime: "19:00",
+      },
+      {
+        dayOfWeek: "THU",
+        isHoliday: false,
+        startTime: "09:00",
+        endTime: "19:00",
+      },
+      {
+        dayOfWeek: "FRI",
+        isHoliday: false,
+        startTime: "09:00",
+        endTime: "19:00",
+      },
+      {
+        dayOfWeek: "SAT",
+        isHoliday: false,
+        startTime: "09:00",
+        endTime: "19:00",
+      },
+      {
+        dayOfWeek: "SUN",
+        isHoliday: false,
+        startTime: "09:00",
+        endTime: "19:00",
+      },
+    ],
+    scheduleChanges: [
+      {
+        applyAt: "2025-12-12",
+        schedules: [
+          {
+            dayOfWeek: "MON",
+            isHoliday: false,
+            startTime: "09:00",
+            endTime: "19:00",
+          },
+          {
+            dayOfWeek: "TUE",
+            isHoliday: false,
+            startTime: "09:00",
+            endTime: "19:00",
+          },
+          {
+            dayOfWeek: "WED",
+            isHoliday: false,
+            startTime: "09:00",
+            endTime: "19:00",
+          },
+          {
+            dayOfWeek: "THU",
+            isHoliday: false,
+            startTime: "09:00",
+            endTime: "19:00",
+          },
+          {
+            dayOfWeek: "FRI",
+            isHoliday: false,
+            startTime: "09:00",
+            endTime: "19:00",
+          },
+          {
+            dayOfWeek: "SAT",
+            isHoliday: false,
+            startTime: "09:00",
+            endTime: "19:00",
+          },
+          {
+            dayOfWeek: "SUN",
+            isHoliday: false,
+            startTime: "09:00",
+            endTime: "19:00",
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PTSchedule>;
+
+export const Default: Story = {};

--- a/packages/ui/src/components/PTPreference.tsx
+++ b/packages/ui/src/components/PTPreference.tsx
@@ -1,0 +1,52 @@
+import { Ellipsis } from "lucide-react";
+import React from "react";
+
+import { AccordionItem, AccordionTrigger, AccordionContent } from "@ui/components/Accordion";
+import { Text } from "@ui/components/Text";
+
+import {
+  DAYS_OF_WEEK,
+  DaysOfWeek,
+  makeWeekSchedule,
+  ObjectEntries,
+} from "../utils/makeWeekSchedule";
+
+type WorkoutSchedule = {
+  dayOfWeek: DaysOfWeek;
+  preferenceTimes: string[];
+}[];
+type PTPreferenceProps = {
+  workoutSchedule: WorkoutSchedule;
+};
+function PTPreference({ workoutSchedule }: PTPreferenceProps) {
+  const weekSchedule = Object.entries(
+    makeWeekSchedule({ type: "block", schedule: workoutSchedule }),
+  ) as ObjectEntries<Record<DaysOfWeek, string>>;
+
+  const handleEditClick = () => {
+    return;
+
+    //TODO: ellipsis 클릭 핸들러 로직 추가
+  };
+
+  return (
+    <AccordionItem value="item-1">
+      <AccordionTrigger>
+        <Text.Headline1>PT 희망시간</Text.Headline1>
+      </AccordionTrigger>
+      <AccordionContent className="bg-background-sub1 flex items-start rounded-[10px] p-4 ">
+        <div className="flex flex-col items-start">
+          {weekSchedule.map(([dayOfWeek, schedule]: [DaysOfWeek, string | null]) => (
+            <Text.Body1
+              key={dayOfWeek}
+              className="block"
+            >{`${DAYS_OF_WEEK[dayOfWeek]} ${schedule}`}</Text.Body1>
+          ))}
+        </div>
+        <Ellipsis onClick={handleEditClick} className="cursor-pointer" />
+      </AccordionContent>
+    </AccordionItem>
+  );
+}
+
+export default PTPreference;

--- a/packages/ui/src/utils/makeWeekSchedule.ts
+++ b/packages/ui/src/utils/makeWeekSchedule.ts
@@ -1,0 +1,92 @@
+/* eslint-disable no-magic-numbers */
+export type DaysOfWeek = "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN";
+export type ObjectEntries<T> = {
+  [K in keyof T]: [K, T[K]];
+}[keyof T][];
+
+export const DAYS_OF_WEEK = {
+  MON: "월",
+  TUE: "화",
+  WED: "수",
+  THU: "목",
+  FRI: "금",
+  SAT: "토",
+  SUN: "일",
+};
+
+type TimeBlockSchedule = {
+  type: "block";
+  schedule: {
+    dayOfWeek: DaysOfWeek;
+    preferenceTimes: string[];
+  }[];
+};
+type TimeSpanSchedule = {
+  type: "span";
+  schedule: {
+    dayOfWeek: DaysOfWeek;
+    isHoliday: boolean;
+    startTime: string;
+    endTime: string;
+  }[];
+};
+export const makeWeekSchedule = (timeSchedule: TimeBlockSchedule | TimeSpanSchedule) => {
+  const weekScheduleMap: Record<DaysOfWeek, string | null> = {
+    MON: null,
+    TUE: null,
+    WED: null,
+    THU: null,
+    FRI: null,
+    SAT: null,
+    SUN: null,
+  };
+  if (timeSchedule.type === "span") {
+    timeSchedule.schedule.forEach(({ dayOfWeek, startTime, endTime, isHoliday }) => {
+      if (isHoliday || !startTime || !endTime) weekScheduleMap[dayOfWeek] = "-";
+      else weekScheduleMap[dayOfWeek] = `${startTime} - ${endTime}`;
+    });
+
+    return weekScheduleMap;
+  }
+
+  timeSchedule.schedule.forEach(({ dayOfWeek, preferenceTimes }) => {
+    weekScheduleMap[dayOfWeek] = groupContinuousTimes(preferenceTimes).join(", ");
+  });
+
+  return weekScheduleMap;
+};
+
+const groupContinuousTimes = function groupContinuousTimes(timeList: string[]): string[] {
+  if (timeList.length === 0) {
+    return [];
+  }
+
+  const times = timeList
+    .map((time) => new Date(`1970-01-01T${time}:00Z`))
+    .sort((a, b) => a.getTime() - b.getTime());
+
+  const result: string[] = [];
+  let start = times[0];
+  let prev = start;
+
+  times.slice(1).forEach((time) => {
+    const nextTime = new Date(prev.getTime() + 60 * 60 * 1000);
+    if (time.getTime() !== nextTime.getTime()) {
+      result.push(
+        start.getTime() === prev.getTime()
+          ? start.toISOString().substring(11, 16)
+          : `${start.toISOString().substring(11, 16)} - ${prev.toISOString().substring(11, 16)}`,
+      );
+      start = time;
+    }
+    prev = time;
+  });
+
+  result.push(
+    start.getTime() === prev.getTime()
+      ? start.toISOString().substring(11, 16)
+      : `${start.toISOString().substring(11, 16)} - ${prev.toISOString().substring(11, 16)}`,
+  );
+
+  return result;
+};

--- a/packages/ui/src/utils/makeWeekSchedule.ts
+++ b/packages/ui/src/utils/makeWeekSchedule.ts
@@ -56,7 +56,7 @@ export const makeWeekSchedule = (timeSchedule: TimeBlockSchedule | TimeSpanSched
   return weekScheduleMap;
 };
 
-const groupContinuousTimes = function groupContinuousTimes(timeList: string[]): string[] {
+const groupContinuousTimes = (timeList: string[]): string[] => {
   if (timeList.length === 0) {
     return [];
   }


### PR DESCRIPTION
# [FLIZ-86/ui, trainer] feat: PTSchedule, PTPreference 컴포넌트 구현

## 📝 작업 내용

makeWeekSchedule 유틸 모듈을 구현하고, 이를 활용하여 PTSchedule 및 PTPreference 컴포넌트를 구현했습니다

- makeWeekSchedule: `TimeBlockSchedule | TimeSpanSchedule` 타입의 인자를 받아 요일별로 연속된 시간들을 묶어 'HH:mm - HH:mm' 문자열 배열로 변환해주는 함수입니다
```tsx
type TimeBlockSchedule = {
  type: "block";
  schedule: {
    dayOfWeek: DaysOfWeek;
    preferenceTimes: string[];
  }[];
};
type TimeSpanSchedule = {
  type: "span";
  schedule: {
    dayOfWeek: DaysOfWeek;
    isHoliday: boolean;
    startTime: string;
    endTime: string;
  }[];
};
```

### 📷 스크린샷 (선택)

- PTSchedule
![스크린샷 2025-02-10 오전 4 08 47](https://github.com/user-attachments/assets/34b4b480-1a1c-42ff-8c03-ca6c94f5e40a)

- PTPreference
![스크린샷 2025-02-10 오전 4 07 43](https://github.com/user-attachments/assets/fc0eb895-8e52-4a0f-b037-8625a7edd35f)

## 💬 리뷰 요구사항(선택)

