### PR TITLE
[FLIZ-88/u] feat: Icon 컴포넌트 구현 및 Button에 Icon 기능 추가

### DIFF
--- a/docs/storybook/stories/Button.stories.tsx
+++ b/docs/storybook/stories/Button.stories.tsx
@@ -68,3 +68,9 @@ export const Pill: Story = {
     corners: "pill",
   },
 };
+export const OnDanger: Story = {
+  args: {
+    variant: 'outline',
+    danger: true
+  }
+}

--- a/docs/storybook/stories/Button.stories.tsx
+++ b/docs/storybook/stories/Button.stories.tsx
@@ -1,28 +1,70 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { Button } from "@5unwan/ui/components/Button";
+import { icons } from "lucide-react";
 
 const meta: Meta<typeof Button> = {
   component: Button,
-  tags: ['autodocs'],
+  tags: ["autodocs"],
   argTypes: {
     variant: {
-      control: 'select',
-      options: ['brand', 'negative', 'dark', 'destructive']
+      control: "select",
+      options: ["brand", "negative", "secondary", "outline", "ghost", "destructive"],
     },
     size: {
-      control: 'select',
-      options: ['sm', 'md', 'lg', 'icon']
-    }
+      control: "select",
+      options: ["sm", "md", "lg", "xl"],
+    },
+    corners: {
+      control: "select",
+      options: ["rounded", "pill"],
+    },
+    icon: {
+      control: "select",
+      options: Object.keys(icons),
+    },
+    iconRight: {
+      control: "select",
+      options: Object.keys(icons),
+    },
+    disabled: {
+      control: "boolean",
+    },
+  },
+  args: {
+    children: "Button",
   },
   decorators: [
-    (Story) => (<div className="bg-background-primary p-[10px] w-full flex items-center justify-center"><Story/></div>)
-  ]
+    (Story) => (
+      <div className="bg-background-primary flex w-full items-center justify-center p-[10px]">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
-type Story = StoryObj<typeof Button>
+type Story = StoryObj<typeof Button>;
 
-export const Default: Story = {
-  render: (args) => (<Button {...args}>Button</Button>)
-}
+export const Default: Story = {};
+export const WithIcon: Story = {
+  args: {
+    icon: "Pencil",
+  },
+};
+export const WithIconRight: Story = {
+  args: {
+    iconRight: "ChevronRight",
+  },
+};
+export const WithIconOnly: Story = {
+  args: {
+    children: undefined,
+    icon: "Pencil",
+  },
+};
+export const Pill: Story = {
+  args: {
+    corners: "pill",
+  },
+};

--- a/docs/storybook/stories/Icon.stories.tsx
+++ b/docs/storybook/stories/Icon.stories.tsx
@@ -1,0 +1,46 @@
+import Icon from "@5unwan/ui/components/Icon";
+import { Meta, StoryObj } from "@storybook/react";
+import { icons } from "lucide-react";
+import { cn } from "../../../packages/ui/src/lib/utils";
+
+const meta: Meta<typeof Icon> = {
+  component: ({ className, ...args }) => (
+    <Icon className={cn("text-text-primary", className)} {...args} />
+  ),
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg", "xl"],
+    },
+    name: {
+      control: "select",
+      options: Object.keys(icons),
+    },
+    background: {
+      control: "select",
+      options: ["brand", "sub1", "sub2", "sub3", "sub4", "sub5", "notification"],
+    },
+  },
+  args: {
+    name: "AArrowDown",
+    size: "md",
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-background-primary flex w-full items-center justify-center p-[10px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof Icon>;
+
+export const Default: Story = {};
+export const WithBackground: Story = {
+  args: {
+    background: "brand",
+  },
+};

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -41,7 +41,7 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
-  icon?: IconNames;
+  iconLeft?: IconNames;
   iconRight?: IconNames;
   danger?: boolean;
 }
@@ -54,7 +54,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       size,
       corners,
       asChild = false,
-      icon,
+      iconLeft,
       iconRight,
       danger,
       children,
@@ -73,7 +73,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         {...props}
       >
-        {icon && <Icon name={icon} size={size || "md"} />}
+        {iconLeft && <Icon name={iconLeft} size={size || "md"} />}
         {children}
         {iconRight && <Icon name={iconRight} size={size || "md"} />}
       </Comp>

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -73,9 +73,13 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         {...props}
       >
-        {iconLeft && <Icon name={iconLeft} size={size || "md"} />}
+        {iconLeft && (
+          <Icon name={iconLeft} size={size || "md"} aria-hidden={children !== undefined} />
+        )}
         {children}
-        {iconRight && <Icon name={iconRight} size={size || "md"} />}
+        {iconRight && (
+          <Icon name={iconRight} size={size || "md"} aria-hidden={children !== undefined} />
+        )}
       </Comp>
     );
   },

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -2,28 +2,37 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
+import Icon, { IconNames } from "./Icon";
 import { cn } from "../lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[10px] text-headline transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center gap-1 px-4 justify-center whitespace-nowrap text-headline transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:bg-background-sub2 disabled:text-text-sub3 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         brand: "bg-brand-primary-500 text-text-primary shadow hover:bg-brand-primary-500/90",
         negative: "bg-background-sub5 text-text-sub5 shadow hover:bg-background-sub5/90",
-        dark: "bg-background-sub1 text-text-primary shadow hover:bg-background-sub2",
+        secondary: "bg-background-sub1 text-text-primary shadow hover:bg-background-sub2",
+        outline:
+          "bg-transparent text-text-sub2 border border-solid border-background-sub4 hover:border-background-sub5 hover:bg-background-sub5 hover:text-text-sub5",
+        ghost: "bg-transparent text-text-primary hover:bg-background-sub3",
         destructive: "bg-notification text-text-primary shadow hover:bg-notification/90",
       },
       size: {
-        sm: "h-[2rem] text-body-1 px-[1rem]",
-        md: "h-[2.5rem] text-headline px-[2.625rem]",
-        lg: "h-[3.375rem] text-headline px-[4.5rem]",
-        icon: "h-[2.8125rem] w-[2.8125rem]",
+        sm: "h-[2rem] text-body-3",
+        md: "h-[2.5rem] text-body-1",
+        lg: "h-[2.8125rem] text-headline",
+        xl: "h-[3.375rem] text-headline",
+      },
+      corners: {
+        rounded: "rounded-[0.625rem]",
+        pill: "rounded-full",
       },
     },
     defaultVariants: {
       variant: "brand",
       size: "md",
+      corners: "rounded",
     },
   },
 );
@@ -32,14 +41,42 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  icon?: IconNames;
+  iconRight?: IconNames;
+  danger?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  (
+    {
+      className,
+      variant,
+      size,
+      corners,
+      asChild = false,
+      icon,
+      iconRight,
+      danger,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
     const Comp = asChild ? Slot : "button";
 
     return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+      <Comp
+        className={cn(buttonVariants({ variant, size, corners, className }), {
+          "text-notification": danger,
+          "border-notification": variant === "outline" && danger,
+        })}
+        ref={ref}
+        {...props}
+      >
+        {icon && <Icon name={icon} size={size || "md"} />}
+        {children}
+        {iconRight && <Icon name={iconRight} size={size || "md"} />}
+      </Comp>
     );
   },
 );

--- a/packages/ui/src/components/Icon.tsx
+++ b/packages/ui/src/components/Icon.tsx
@@ -1,0 +1,47 @@
+import { icons, LucideProps } from "lucide-react";
+
+import { cn } from "@ui/lib/utils";
+
+export type IconNames = keyof typeof icons;
+
+type IconProps = Omit<LucideProps, "size"> & {
+  name: IconNames;
+  className?: string;
+  background?: keyof typeof backgroundValues;
+  size?: keyof typeof iconSizes;
+};
+
+const iconSizes = {
+  sm: 18,
+  md: 20,
+  lg: 24,
+  xl: 28,
+} as const;
+const backgroundValues = {
+  brand: "bg-brand-primary-500",
+  sub1: "bg-background-sub1",
+  sub2: "bg-background-sub2",
+  sub3: "bg-background-sub3",
+  sub4: "bg-background-sub4",
+  sub5: "bg-background-sub5",
+  notification: "bg-notification",
+};
+
+function Icon({ name, className, background, size = "md", ...props }: IconProps) {
+  const SelectedLucideIcon = icons[name];
+
+  return !background ? (
+    <SelectedLucideIcon name={name} className={cn(className)} size={iconSizes[size]} {...props} />
+  ) : (
+    <div
+      className={cn(
+        "flex items-center justify-center rounded-full p-2",
+        backgroundValues[background],
+      )}
+    >
+      <SelectedLucideIcon name={name} className={cn(className)} size={iconSizes[size]} {...props} />
+    </div>
+  );
+}
+
+export default Icon;

--- a/packages/ui/src/components/Icon.tsx
+++ b/packages/ui/src/components/Icon.tsx
@@ -12,8 +12,8 @@ type IconProps = Omit<LucideProps, "size"> & {
 };
 
 const iconSizes = {
-  sm: 18,
-  md: 20,
+  sm: 13,
+  md: 15,
   lg: 24,
   xl: 28,
 } as const;


### PR DESCRIPTION
# [FLIZ-88/u] feat: Icon 컴포넌트 구현 및 Button에 Icon 기능 추가

## 📝 작업 내용

Icon 컴포넌트를 구현한 뒤, 기존 @ui/Button 컴포넌트에 Icon 기능을 추가하였습니다.

### Icon
- 프로젝트에서 모든 Lucide Icon을 사용할 시에 사용하는 제네릭한 Icon입니다

#### props

- `name`: 사용할 Lucide Icon 이름을 지정합니다
- `background`: `Icon`을 배경 circle 안에 nest하고 싶을 시에 지정합니다. 지정된 값 (`brand`, `sub1`, `sub2`, `sub3`, `sub4`, `sub5`, `notification`)을 `background-color`로 설정합니다
- `size:` Icon의 크기를 지정합니다. 지정된 값 (`sm`, `md`, `lg`, `xl`)을 LucideIcon `size` props로 설정합니다

### Button

기존 Button에 다음 기능을 추가했습니다
- `icon`, `iconRight` props로 `Button` 내 `Icon` 렌더링
- `variant`에 `secondary`, `outline`, `ghost` 추가
- `variant`에 `dark` 제거
- `size`에 `xl` 추가
- `size`에 `icon` 제거
- `corners` prop을 추가하여 `Button`의` border-radius `값 지정
 
#### props

- `icon` : `Icon`의 `name` props 값을 주입 시 해당 `Icon`을 `Button` `children`의 왼쪽에 렌더링합니다
- `iconRight`: `Icon`의 `name` props 값을 주입 시 해당 `Icon`을 `Button` `children`의 오른쪽에 렌더링합니다
- `corners`
   - `rounded`: 'rounded-[10px]'
   - `pill`: 'rounded-full' 

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
