### PR TITLE
[FLIZ-91/trainer] feat: 트레이너 도메인 ProfileCard 공통 컴포넌트 구현

### DIFF
--- a/apps/trainer/components/ProfileCard.tsx
+++ b/apps/trainer/components/ProfileCard.tsx
@@ -1,0 +1,123 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@ui/components/Avatar";
+import { Badge } from "@ui/components/Badge";
+import Icon from "@ui/components/Icon";
+import { cn } from "@ui/lib/utils";
+import { ReactNode } from "react";
+
+import { formatToMeridiem } from "@trainer/utils/ProfileCardUtils";
+
+type ProfileCardProps = {
+  className?: string;
+  imgUrl: string;
+  userName: string;
+  userBirth: Date;
+  phoneNumber: string;
+  PTReservationOtherTime?: string;
+  ellipsIcon?: boolean;
+  children?: ReactNode;
+};
+
+type UserInfoProps = Pick<
+  ProfileCardProps,
+  "imgUrl" | "userName" | "phoneNumber" | "PTReservationOtherTime"
+> & {
+  userAge: number;
+};
+
+type ContentProps = Pick<ProfileCardProps, "PTReservationOtherTime" | "children">;
+
+const AGE_OFFSET_KOREAN = 1;
+const CURRENT_YEAR = new Date().getFullYear();
+
+function UserInfo({
+  imgUrl,
+  userAge,
+  userName,
+  phoneNumber,
+  PTReservationOtherTime,
+}: UserInfoProps) {
+  const parsedPTReservationOtherTime =
+    PTReservationOtherTime && formatToMeridiem(PTReservationOtherTime);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-[3.125rem] w-[11.25rem] items-center">
+        <div className="flex h-full w-[5rem] items-center justify-center">
+          <Avatar>
+            <AvatarImage src={imgUrl} />
+            <AvatarFallback />
+          </Avatar>
+        </div>
+        <div className="flex-1">
+          <div className="flex items-center justify-start gap-[0.438rem]">
+            <span className="text-headline">{userName}</span>
+            <span className="text-body-3 text-text-sub3">{userAge}세</span>
+          </div>
+          <span className="text-body-3">{phoneNumber}</span>
+        </div>
+      </div>
+      {parsedPTReservationOtherTime && (
+        <Badge variant="brand" className="ml-[5rem] mt-[0.625rem] h-[2rem] w-[5.25rem]">
+          {parsedPTReservationOtherTime}
+        </Badge>
+      )}
+    </div>
+  );
+}
+
+function Content({ PTReservationOtherTime, children }: ContentProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-1 justify-end",
+        PTReservationOtherTime ? "min-h-[5.625rem] items-start" : "min-h-[3.125rem] items-center",
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function MenuIcon() {
+  // TODO: MenuIcon 핸들러 추가
+  return (
+    <Icon
+      name="Ellipsis"
+      className="text-text-sub3 absolute right-1 top-0.5"
+      aria-label="프로필 카드 메뉴 버튼"
+      size="lg"
+    />
+  );
+}
+
+export default function ProfileCard({
+  className,
+  imgUrl,
+  userName,
+  userBirth,
+  phoneNumber,
+  PTReservationOtherTime,
+  ellipsIcon,
+  children,
+}: ProfileCardProps) {
+  const userAge = CURRENT_YEAR - userBirth.getFullYear() + AGE_OFFSET_KOREAN;
+
+  return (
+    <section
+      className={cn(
+        "bg-background-sub2 text-text-primary hover:bg-background-sub3 relative flex min-h-[5.625rem] w-[22.375rem] items-center rounded-[0.625rem] py-[1.25rem] pr-2 transition-colors",
+        className,
+      )}
+    >
+      <UserInfo
+        imgUrl={imgUrl}
+        userName={userName}
+        userAge={userAge}
+        phoneNumber={phoneNumber}
+        PTReservationOtherTime={PTReservationOtherTime}
+      />
+      <Content PTReservationOtherTime={PTReservationOtherTime}>{children}</Content>
+      {ellipsIcon && <MenuIcon />}
+    </section>
+  );
+}

--- a/apps/trainer/components/ProfileCard.tsx
+++ b/apps/trainer/components/ProfileCard.tsx
@@ -83,7 +83,7 @@ function MenuIcon() {
   return (
     <Icon
       name="Ellipsis"
-      className="text-text-sub3 absolute right-1 top-0.5"
+      className="text-text-sub3 absolute right-1 top-0.5 cursor-pointer"
       aria-label="프로필 카드 메뉴 버튼"
       size="lg"
     />

--- a/apps/trainer/utils/ProfileCardUtils.ts
+++ b/apps/trainer/utils/ProfileCardUtils.ts
@@ -1,19 +1,20 @@
 /* eslint-disable no-magic-numbers */
 export const formatToMeridiem = (time: string) => {
-  try {
-    if (!/^\d{1,2}:\d{2}$/.test(time)) {
-      throw new Error(`Invalid time format: "${time}" (Expected "HH:mm")`);
-    }
-
-    const [hour] = time.split(":").map(Number);
-
-    if (hour < 0 || hour > 23 || isNaN(hour)) {
-      throw new Error(`Invalid hour value: "${hour}" (Expected 0-23)`);
-    }
-
-    if (hour < 12) return `오전 ${hour === 0 ? hour + 12 : hour}시`;
-    else return `오후 ${hour === 12 ? hour : hour - 12}시`;
-  } catch (error) {
-    console.error(error);
+  if (!/^\d{1,2}:\d{2}$/.test(time)) {
+    throw new Error(`Invalid time format: "${time}" (Expected "HH:mm")`);
   }
+
+  const [hour, minute] = time.split(":").map(Number);
+
+  if (hour < 0 || hour > 23) {
+    throw new Error(`Invalid hour value: "${hour}" (Expected 0-23)`);
+  }
+
+  // 분 범위 체크
+  if (minute < 0 || minute > 59) {
+    throw new Error(`Invalid minute value: "${minute}" (Expected 0-59)`);
+  }
+
+  if (hour < 12) return `오전 ${hour === 0 ? hour + 12 : hour}시`;
+  else return `오후 ${hour === 12 ? hour : hour - 12}시`;
 };

--- a/apps/trainer/utils/ProfileCardUtils.ts
+++ b/apps/trainer/utils/ProfileCardUtils.ts
@@ -1,0 +1,19 @@
+/* eslint-disable no-magic-numbers */
+export const formatToMeridiem = (time: string) => {
+  try {
+    if (!/^\d{1,2}:\d{2}$/.test(time)) {
+      throw new Error(`Invalid time format: "${time}" (Expected "HH:mm")`);
+    }
+
+    const [hour] = time.split(":").map(Number);
+
+    if (hour < 0 || hour > 23 || isNaN(hour)) {
+      throw new Error(`Invalid hour value: "${hour}" (Expected 0-23)`);
+    }
+
+    if (hour < 12) return `오전 ${hour === 0 ? hour + 12 : hour}시`;
+    else return `오후 ${hour === 12 ? hour : hour - 12}시`;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/apps/trainer/utils/__tests__/ProfileCardUtils.spec.ts
+++ b/apps/trainer/utils/__tests__/ProfileCardUtils.spec.ts
@@ -1,0 +1,31 @@
+import { formatToMeridiem } from "@trainer/utils/ProfileCardUtils";
+
+describe("formatToMeridiem", () => {
+  it("00:00은 오전 12시로 포맷되어야 한다", () => {
+    expect(formatToMeridiem("00:00")).toBe("오전 12시");
+  });
+
+  it("01:00은 오전 1시로 포맷되어야 한다", () => {
+    expect(formatToMeridiem("01:00")).toBe("오전 1시");
+  });
+
+  it("12:00은 오후 12시로 포맷되어야 한다", () => {
+    expect(formatToMeridiem("12:00")).toBe("오후 12시");
+  });
+
+  it("15:30은 오후 3시로 포맷되어야 한다", () => {
+    expect(formatToMeridiem("15:30")).toBe("오후 3시");
+  });
+
+  it("23:59는 오후 11시로 포맷되어야 한다", () => {
+    expect(formatToMeridiem("23:59")).toBe("오후 11시");
+  });
+
+  it("잘못된 시간 형식에는 에러가 발생해야 한다", () => {
+    expect(() => formatToMeridiem("25:00")).toThrow('Invalid hour value: "25" (Expected 0-23)');
+    expect(() => formatToMeridiem("12:60")).toThrow('Invalid minute value: "60" (Expected 0-59)');
+    expect(() => formatToMeridiem("0600")).toThrow(
+      'Invalid time format: "0600" (Expected "HH:mm")',
+    );
+  });
+});

--- a/docs/storybook/stories/trainer/ProfileCard.stories.tsx
+++ b/docs/storybook/stories/trainer/ProfileCard.stories.tsx
@@ -102,3 +102,13 @@ export const WithBadge: ProfileCardStory = {
     </ProfileCard>
   ),
 };
+
+export const WithEllipsis: ProfileCardStory = {
+  render: (args) => (
+    <ProfileCard {...args} ellipsIcon>
+      <Badge size="sm" variant={"brand"}>
+        00/20
+      </Badge>
+    </ProfileCard>
+  ),
+};

--- a/docs/storybook/stories/trainer/ProfileCard.stories.tsx
+++ b/docs/storybook/stories/trainer/ProfileCard.stories.tsx
@@ -1,0 +1,104 @@
+import { Badge } from "@5unwan/ui/components/Badge";
+import {
+  Dropdown,
+  DropdownContent,
+  DropdownItem,
+  DropdownTrigger,
+} from "@5unwan/ui/components/Dropdown/index";
+import { Meta, StoryObj } from "@storybook/react";
+import ProfileCard from "trainer/components/ProfileCard";
+
+const meta: Meta<typeof ProfileCard> = {
+  component: ProfileCard,
+  tags: ["autodocs"],
+  argTypes: {
+    imgUrl: {
+      control: "text",
+      description: "img url을 입력하여 아바타에 이미지를 삽입합니다.",
+    },
+    userBirth: {
+      control: "date",
+      description: "date 타입의 출생일을 입력받아 컴포넌트 내부적으로 나이를 계산합니다.",
+    },
+    userName: {
+      control: "text",
+      description: "유저의 이름을 입력 받습니다.",
+    },
+    phoneNumber: {
+      control: "text",
+      description: "유저의 휴대폰 번호를 입력 받습니다.",
+    },
+    PTReservationOtherTime: {
+      control: "text",
+      description: "유저가 선택한 PT 예약 시간을 입력 받습니다.",
+    },
+  },
+  args: {
+    imgUrl: "https://picsum.photos/300",
+    userBirth: new Date("1998-07-04"),
+    userName: "홍길동",
+    phoneNumber: "010 0000 0000",
+    PTReservationOtherTime: undefined,
+  },
+};
+
+export default meta;
+
+const DropdownSchedule = () => {
+  const DUMMY_DATA = [
+    { day: "월", hours: "09:00 - 23:00" },
+    { day: "화", hours: "12:00 - 12:00" },
+    { day: "수", hours: "12:00 - 12:00" },
+    { day: "목", hours: "12:00 - 12:00" },
+    { day: "금", hours: "12:00 - 12:00" },
+    { day: "토", hours: "12:00 - 12:00" },
+    { day: "일", hours: "12:00 - 12:00" },
+  ];
+
+  return (
+    <Dropdown>
+      <DropdownTrigger>{`${DUMMY_DATA[0].day} ${DUMMY_DATA[0].hours}`}</DropdownTrigger>
+      <DropdownContent>
+        {DUMMY_DATA.map((item) => (
+          <DropdownItem key={item.day} className="flex gap-2">
+            <span className="">{item.day}</span>
+            <span>{item.hours}</span>
+          </DropdownItem>
+        ))}
+      </DropdownContent>
+    </Dropdown>
+  );
+};
+
+type ProfileCardStory = StoryObj<typeof ProfileCard>;
+
+export const Default: ProfileCardStory = {};
+
+export const WithDropdown: ProfileCardStory = {
+  render: (args) => (
+    <ProfileCard {...args}>
+      <DropdownSchedule />
+    </ProfileCard>
+  ),
+};
+
+export const WithPTReservationOtherTime: ProfileCardStory = {
+  args: {
+    PTReservationOtherTime: "10:00",
+  },
+  render: (args) => (
+    <ProfileCard {...args}>
+      <DropdownSchedule />
+    </ProfileCard>
+  ),
+};
+
+export const WithBadge: ProfileCardStory = {
+  render: (args) => (
+    <ProfileCard {...args}>
+      <Badge size="sm" variant={"brand"}>
+        00/20
+      </Badge>
+    </ProfileCard>
+  ),
+};


### PR DESCRIPTION
## 📝 작업 내용

### 컴포넌트 용도
- 해당 컴포넌트는 트레이너 도메인 내의 캘린더/알람/회원리스트 페이지 내에서 유저정보를 공통으로 나타내는 용도의 컴포넌트입니다.

### 컴포넌트 설계
- 해당 컴포넌트는 두 가지 영역으로 분리되며 유저의 정보를 나타내는 `UserInfo`와 상황에 따른 내용을 나타내는 `Content` 영역으로 나누어집니다.
- 유저의 정보 같은 경우에는 `ProfileCard` 내에서 항상 같은 정보인 프로필사진/이름/나이/휴대폰 번호를 고정적으로 나타내고 있기에 해당 컴포넌트 내부에 고정적으로 주입이 되어있습니다
- Content 영역의 경우 유저의 `PT 희망 시간` 또는 `전체 PT횟수/남은 PT횟수`를 나타내는 컴포넌트가 들어올 수 있습니다. 해당 영역을 합성 컴포넌트 패턴으로 `PT 희망 시간` 과 `전체 PT횟수/남은 PT횟수` 컴포넌트를 미리 구현해두고 상위에서 선택하여 주입하도록 구현하려 했으나, 프로필 카드 컴포넌트 같은 경우 버전업이 되면서 디자인이 추가 및 변경 될 가능성이 높다고 판단되어 확장성을 고려해 `children`으로 상위에서 주입받는 방향으로 구현하였습니다.
- `formatToMeridiem` 유틸 함수를 구현하였습니다.
  - DateController 메서드 체이닝 함수에 작성하는 방향으로 구현하려 했으나, DateController의 크기가 너무 커지고 내부 구현 로직이 점점 많아져 복잡해질 수 있다 판단하여 따로 구현해두었습니다. 추가로 해당 함수 같은 경우 시간 값을 인자로 받고 있어 DateController에서 핸들링하기에는 인자의 개수도 하나 늘어나야 함으로 복잡성이 증가할 수 있다고 판단하였습니다.

해당 컴포넌트의 각 상황 별 스토리와 유틸함수의 테스트 코드를 작성하였습니다. ProfileCard 컴포넌트의 경우 현재 작업까지는 조건부 렌더링이 전부이기 때문에 테스트 코드는 아직 작성하지 않았습니다. 

### 📷 스크린샷 (선택)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/3df11d2f-3dbc-4a52-bb40-1a0680090125" />
