### PR TITLE
[FLIZ-108/core] feat: packages/core 모듈 생성 및 해당 모듈에 axios instance, 공통 DTO 타입 정의

### DIFF
--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["@5unwan/eslint-config/base"],
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,8 +5,7 @@
   "description": "",
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
-    "lint": "eslint src/"
+    "build": "tsc"
   },
   "dependencies": {
     "axios": "^1.7.9"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@5unwan/core",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "axios": "^1.7.9"
+  },
+  "devDependencies": {
+    "@5unwan/eslint-config": "workspace:*",
+    "@5unwan/typescript-config": "workspace:*",
+    "@types/node": "^22.13.5",
+    "eslint": "^8.57.1",
+    "typescript": "5.5.4"
+  },
+  "exports": {
+    "./api/*": "./src/api/*.ts",
+    "./utils/*": "./src/utils/*.ts"
+  }
+}

--- a/packages/core/src/api/core.ts
+++ b/packages/core/src/api/core.ts
@@ -1,0 +1,66 @@
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, Method } from "axios";
+
+type CoreApiConfig = {
+  baseUrl: string;
+  tokenProvider?: () => string | null;
+};
+
+const HTTP_METHODS = {
+  GET: "get",
+  POST: "post",
+  PATCH: "patch",
+  PUT: "put",
+  DELETE: "delete",
+} as const;
+
+let axiosInstance: AxiosInstance | null = null;
+
+export const initCoreApi = ({ baseUrl, tokenProvider }: CoreApiConfig) => {
+  axiosInstance = axios.create({
+    baseURL: baseUrl,
+    timeout: 10000,
+    headers: { "Content-Type": "application/json" },
+  });
+
+  axiosInstance.interceptors.request.use((config) => {
+    const token = tokenProvider ? tokenProvider() : null;
+
+    if (token && config.headers) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+
+    return config;
+  });
+
+  axiosInstance.interceptors.response.use(
+    (response) => response,
+    (error: AxiosError) => Promise.reject(error),
+  );
+};
+
+const checkInstance = () => {
+  if (!axiosInstance) {
+    throw new Error("Axios instance not initialized. Call initCoreApi first.");
+  }
+};
+
+const createApiMethod =
+  (methodType: Method) =>
+  <T>(config: AxiosRequestConfig): Promise<T> => {
+    checkInstance();
+
+    return axiosInstance!({
+      ...config,
+      method: methodType,
+    });
+  };
+
+const http = {
+  get: createApiMethod(HTTP_METHODS.GET),
+  post: createApiMethod(HTTP_METHODS.POST),
+  patch: createApiMethod(HTTP_METHODS.PATCH),
+  put: createApiMethod(HTTP_METHODS.PUT),
+  delete: createApiMethod(HTTP_METHODS.DELETE),
+};
+
+export default http;

--- a/packages/core/src/api/types/common.ts
+++ b/packages/core/src/api/types/common.ts
@@ -1,0 +1,32 @@
+export type ResponseBase<T> = {
+  status: number;
+  success: boolean;
+  msg: string;
+  data: T;
+};
+export type NoResponseData = ResponseBase<null>;
+export type DayOfWeek =
+  | "MONDAY"
+  | "TUESDAY"
+  | "WEDNESDAY"
+  | "THURSDAY"
+  | "FRIDAY"
+  | "SATURDAY"
+  | "SUNDAY";
+export type PtStatus = "COMPLETED" | "NO_SHOW" | "NONE" | "PENDING";
+export type SessionInfo = {
+  sessionInfoId: number;
+  totalCount: number;
+  remainingCount: number;
+};
+export type PreferredWorkout = {
+  dayOfWeek: string;
+  preferenceTimes: Array<string>;
+};
+export type AvailablePtTime = {
+  availableTimeId: number;
+  dayOfWeek: DayOfWeek;
+  isHoliday: boolean;
+  startTime: string;
+  endTime: string;
+};

--- a/packages/core/src/utils/localStorage.ts
+++ b/packages/core/src/utils/localStorage.ts
@@ -1,0 +1,29 @@
+export const getLocalStorage = (key: string) => {
+  try {
+    const value = localStorage.getItem(key);
+
+    if (!value) {
+      return null;
+    }
+
+    return JSON.parse(value);
+  } catch (error) {
+    console.error(`Error parsing localStorage item with key "${key}":`, error);
+  }
+};
+
+export const setLocalStorage = <T>(key: string, value: T) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error(`Error serializing value for localStorage item with key "${key}":`, error);
+  }
+};
+
+export const removeLocalStorage = (key: string) => {
+  try {
+    localStorage.removeItem(key);
+  } catch (error) {
+    console.error(`Failed to remove item from localStorage with key "${key}". Error: ${error}`);
+  }
+};

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@5unwan/typescript-config/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@core/*": ["src/*"]
+    },
+    "lib": ["ES2015", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["."],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.6.1
-        version: 19.6.1(@types/node@20.17.10)(typescript@5.6.3)
+        version: 19.6.1(@types/node@22.13.5)(typescript@5.6.3)
       '@commitlint/config-conventional':
         specifier: ^19.6.0
         version: 19.6.0
@@ -268,7 +268,7 @@ importers:
         version: 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)
       '@storybook/react-vite':
         specifier: ^8.4.7
-        version: 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.29.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(vite@6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+        version: 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.29.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(vite@6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       '@storybook/test':
         specifier: ^8.4.7
         version: 8.4.7(storybook@8.4.7(prettier@3.4.2))
@@ -280,7 +280,7 @@ importers:
         version: 18.3.5(@types/react@18.3.17)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       autoprefixer:
         specifier: ^10.4.18
         version: 10.4.20(postcss@8.4.49)
@@ -301,13 +301,13 @@ importers:
         version: 8.4.7(prettier@3.4.2)
       tailwindcss:
         specifier: ^3.4.1
-        version: 3.4.16(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.6.3))
+        version: 3.4.16(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.6.3))
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
       vite:
         specifier: ^6.0.3
-        version: 6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
 
   packages/config-eslint:
     devDependencies:
@@ -331,7 +331,7 @@ importers:
         version: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))
       eslint-plugin-jest:
         specifier: ^28.9.0
-        version: 28.9.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(jest@29.7.0(@types/node@20.17.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 28.9.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0))(typescript@5.5.4)
       eslint-plugin-jest-dom:
         specifier: ^5.5.0
         version: 5.5.0(@testing-library/dom@10.4.0)(eslint@9.17.0(jiti@2.4.1))
@@ -364,16 +364,38 @@ importers:
     dependencies:
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.6.3)))
+        version: 1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.6.3)))
     devDependencies:
       '@5unwan/typescript-config':
         specifier: workspace:*
         version: link:../config-typescript
       tailwindcss:
         specifier: ^3.4.1
-        version: 3.4.16(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.6.3))
+        version: 3.4.16(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.6.3))
 
   packages/config-typescript: {}
+
+  packages/core:
+    dependencies:
+      axios:
+        specifier: ^1.7.9
+        version: 1.7.9
+    devDependencies:
+      '@5unwan/eslint-config':
+        specifier: workspace:*
+        version: link:../config-eslint
+      '@5unwan/typescript-config':
+        specifier: workspace:*
+        version: link:../config-typescript
+      '@types/node':
+        specifier: ^22.13.5
+        version: 22.13.5
+      eslint:
+        specifier: ^8.57.1
+        version: 8.57.1
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
 
   packages/ui:
     dependencies:
@@ -2143,6 +2165,9 @@ packages:
 
   '@types/node@20.17.10':
     resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
+
+  '@types/node@22.13.5':
+    resolution: {integrity: sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -5611,6 +5636,9 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
@@ -6207,11 +6235,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@19.6.1(@types/node@20.17.10)(typescript@5.6.3)':
+  '@commitlint/cli@19.6.1(@types/node@22.13.5)(typescript@5.6.3)':
     dependencies:
       '@commitlint/format': 19.5.0
       '@commitlint/lint': 19.6.0
-      '@commitlint/load': 19.6.1(@types/node@20.17.10)(typescript@5.6.3)
+      '@commitlint/load': 19.6.1(@types/node@22.13.5)(typescript@5.6.3)
       '@commitlint/read': 19.5.0
       '@commitlint/types': 19.5.0
       tinyexec: 0.3.1
@@ -6258,7 +6286,7 @@ snapshots:
       '@commitlint/rules': 19.6.0
       '@commitlint/types': 19.5.0
 
-  '@commitlint/load@19.6.1(@types/node@20.17.10)(typescript@5.6.3)':
+  '@commitlint/load@19.6.1(@types/node@22.13.5)(typescript@5.6.3)':
     dependencies:
       '@commitlint/config-validator': 19.5.0
       '@commitlint/execute-rule': 19.5.0
@@ -6266,7 +6294,7 @@ snapshots:
       '@commitlint/types': 19.5.0
       chalk: 5.3.0
       cosmiconfig: 9.0.0(typescript@5.6.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@20.17.10)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.13.5)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -6796,11 +6824,11 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.4.2(typescript@5.6.3)(vite@6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.4.2(typescript@5.6.3)(vite@6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.6.3)
-      vite: 6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
     optionalDependencies:
       typescript: 5.6.3
 
@@ -7449,13 +7477,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.4.7(storybook@8.4.7(prettier@3.4.2))(vite@6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))':
+  '@storybook/builder-vite@8.4.7(storybook@8.4.7(prettier@3.4.2))(vite@6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
       '@storybook/csf-plugin': 8.4.7(storybook@8.4.7(prettier@3.4.2))
       browser-assert: 1.2.1
       storybook: 8.4.7(prettier@3.4.2)
       ts-dedent: 2.2.0
-      vite: 6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
 
   '@storybook/components@8.4.7(storybook@8.4.7(prettier@3.4.2))':
     dependencies:
@@ -7517,11 +7545,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.4.7(prettier@3.4.2)
 
-  '@storybook/react-vite@8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.29.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(vite@6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))':
+  '@storybook/react-vite@8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.29.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(vite@6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.4.2(typescript@5.6.3)(vite@6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.4.2(typescript@5.6.3)(vite@6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       '@rollup/pluginutils': 5.1.4(rollup@4.29.1)
-      '@storybook/builder-vite': 8.4.7(storybook@8.4.7(prettier@3.4.2))(vite@6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+      '@storybook/builder-vite': 8.4.7(storybook@8.4.7(prettier@3.4.2))(vite@6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       '@storybook/react': 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -7531,7 +7559,7 @@ snapshots:
       resolve: 1.22.9
       storybook: 8.4.7(prettier@3.4.2)
       tsconfig-paths: 4.2.0
-      vite: 6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@storybook/test'
       - rollup
@@ -7725,6 +7753,10 @@ snapshots:
   '@types/node@20.17.10':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/node@22.13.5':
+    dependencies:
+      undici-types: 6.20.0
 
   '@types/parse-json@4.0.2': {}
 
@@ -7971,14 +8003,14 @@ snapshots:
 
   '@ungap/structured-clone@1.2.1': {}
 
-  '@vitejs/plugin-react@4.3.4(vite@6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))':
+  '@vitejs/plugin-react@4.3.4(vite@6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8530,9 +8562,9 @@ snapshots:
 
   core-util-is@1.0.2: {}
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@20.17.10)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@22.13.5)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.13.5
       cosmiconfig: 9.0.0(typescript@5.6.3)
       jiti: 2.4.1
       typescript: 5.6.3
@@ -8568,6 +8600,22 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  create-jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
 
   create-require@1.1.1: {}
 
@@ -9104,13 +9152,13 @@ snapshots:
     optionalDependencies:
       '@testing-library/dom': 10.4.0
 
-  eslint-plugin-jest@28.9.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(jest@29.7.0(@types/node@20.17.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4)))(typescript@5.5.4):
+  eslint-plugin-jest@28.9.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0))(typescript@5.5.4):
     dependencies:
       '@typescript-eslint/utils': 8.18.1(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4)
       eslint: 9.17.0(jiti@2.4.1)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4)
-      jest: 29.7.0(@types/node@20.17.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      jest: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10086,6 +10134,26 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   jest-config@29.7.0(@types/node@20.17.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.26.7
@@ -10116,6 +10184,37 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+
+  jest-config@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@babel/core': 7.26.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.13.5
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    optional: true
 
   jest-diff@29.7.0:
     dependencies:
@@ -10358,6 +10457,19 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
 
   jiti@1.21.6: {}
 
@@ -10937,13 +11049,13 @@ snapshots:
       postcss: 8.4.49
       ts-node: 10.9.2(@types/node@20.17.10)(typescript@5.5.4)
 
-  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.6.3)):
+  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.6.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.6.1
     optionalDependencies:
       postcss: 8.4.49
-      ts-node: 10.9.2(@types/node@20.17.10)(typescript@5.6.3)
+      ts-node: 10.9.2(@types/node@22.13.5)(typescript@5.6.3)
 
   postcss-nested@6.2.0(postcss@8.4.49):
     dependencies:
@@ -11552,9 +11664,9 @@ snapshots:
 
   tailwind-merge@2.6.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.6.3))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.6.3))):
     dependencies:
-      tailwindcss: 3.4.16(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.6.3))
+      tailwindcss: 3.4.16(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.6.3))
 
   tailwindcss@3.4.16(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4)):
     dependencies:
@@ -11583,7 +11695,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.16(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.6.3)):
+  tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.6.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -11602,7 +11714,7 @@ snapshots:
       postcss: 8.4.49
       postcss-import: 15.1.0(postcss@8.4.49)
       postcss-js: 4.0.1(postcss@8.4.49)
-      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.6.3))
+      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.6.3))
       postcss-nested: 6.2.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.9
@@ -11730,14 +11842,14 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@20.17.10)(typescript@5.6.3):
+  ts-node@10.9.2(@types/node@22.13.5)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.17.10
+      '@types/node': 22.13.5
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -11859,6 +11971,8 @@ snapshots:
 
   undici-types@6.19.8: {}
 
+  undici-types@6.20.0: {}
+
   unicorn-magic@0.1.0: {}
 
   universalify@0.2.0: {}
@@ -11939,13 +12053,13 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite@6.0.5(@types/node@20.17.10)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1):
+  vite@6.0.5(@types/node@22.13.5)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.49
       rollup: 4.29.1
     optionalDependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.13.5
       fsevents: 2.3.3
       jiti: 2.4.1
       terser: 5.37.0


### PR DESCRIPTION
## 📝 작업 내용

### packages/core 모듈 용도
- `packages/core` 모듈은 `FitLink` 프로젝트 전체에서 공통으로 사용되는 로직을 모아 놓은 모듈입니다. 
- 현재까지 해당 모듈의 예상되는 사용 용도는 아래와 같습니다.
   - api 공통 로직
   - 공통 util 함수
   - 공통 비즈니스 로직
   - 공통 interface
#### core.ts
- 해당 파일은 axios instance를 사용하여 api 관련 로직을 중앙 관리하기 위해 추상화 한 함수로, 서버 컴포넌트와 클라이언트 컴포넌트에 모두 대응할 수 있도록 설계되었습니다.
- 각각의 상황에 NextJS 프로젝트를 사용하는 서비스에서 `Provider` 컴포넌트를 만들고 그 내부에 `initCoreApi` 함수를 호출하여 baseUrl과 token을 주입하도록 구현하였습니다.
- `initCoreApi`로 함수를 export한 이유는, `packages/core`에서 환경 변수를 세팅하여 baseUrl에 주입하고 서비스 패키지에서 core.ts를 사용할 때 환경 변수를 참조하지 못하는 이슈가 있었습니다. 이 이슈를 해결하는 방법을 아직 찾지 못하였으며, 공통 로직인 만큼 core에서 baseUrl을 고정으로 사용하기보다 core를 사용하는 서비스 패키지에서 직접 주입하도록 하는 것이 오히려 더 유연한 공통 로직이 될 수 있을 것 같아 현재와 같이 구현하였습니다.
- `initCoreApi`의 `tokenProvider`는 서버/클라이언트 컴포넌트에서 각각에 상황에 맞게 토큰을 불러와 주입할 수 있도록 설계되었습니다. core.ts에서 클라리언트 컴포넌트에서만 참조할 수 있는 localStorage를 사용하여 토큰을 불러오거나, 서버 컴포넌트에서만 참조할 수 있는 서버 쿠키를 사용해 토큰을 불러오는 로직을 고정으로 두면 유연하지 못한 모듈이 될 것이라 생각하여 현재와 같이 구현하게 되었습니다.
#### api/types
- 해당 폴더는 프로젝트 전체에서 사용할 DTO 타입을 정의하기 위한 폴더로 common.ts는 공통으로 사용되는 DTO 타입을 모아놓은 파일이라고 볼 수 있습니다.
#### utils
- 해당 폴더는 프로젝트 전체에서 사용할 유틸 함수를 정의하기 위한 폴더로 localStorage에 접근하여 get/set/remove 하는 함수를 정의하였습니다.
- 현재 전체 프로젝트에서 사용하고 있는 ui 폴더 내에 정의된 DateController 같은 유틸 함수가 해당 폴더에 위치하면 좋을 것 같다고 생각합니다.

## 💬 리뷰 요구사항(선택)
- 이전 회의에서 모듈의 네이밍과 모듈의 위치 같은 경우 협의되지 않은 내용이라 현재 PR에서 다같이 의논하면 좋을 것 같습니다.
- 새롭게 모듈을 생성하면서 놓친 부분이 많이 있을 것 같습니다. 놓친 부분에 대해 피드백 주시면 감사하겠습니다. ex) linting, tsconfig, package.json, turbo.json 등
- 폴더 및 파일, 함수의 더 좋은 네이밍 피드백 대환영입니다.
- 해당 모듈에서 빠진 부분과 추상화 관련 피드백 대환영입니다.

