### PR TITLE
[FLIZ-131/trainer] feat: Auth DTO 및 API 작업

### DIFF
--- a/apps/trainer/services/auth.ts
+++ b/apps/trainer/services/auth.ts
@@ -1,0 +1,14 @@
+import http from "@5unwan/core/api/core";
+
+import { LogoutApiResponse, SignupRequestBody, SignupApiResponse } from "./types/auth.dto";
+
+export const signup = (data: SignupRequestBody) =>
+  http.post<SignupApiResponse>({
+    url: "/v1/auth/trainers/register",
+    data,
+  });
+
+export const logout = () =>
+  http.post<LogoutApiResponse>({
+    url: "/v1/auth/logout",
+  });

--- a/apps/trainer/services/types/auth.dto.ts
+++ b/apps/trainer/services/types/auth.dto.ts
@@ -1,0 +1,14 @@
+import {
+  AvailablePtTime,
+  BaseSignupInfo,
+  NoResponseData,
+  ResponseBase,
+} from "@5unwan/core/api/types/common";
+
+export type SignupRequestBody = BaseSignupInfo & {
+  availableTimes: Omit<AvailablePtTime, "availableTimeId">[];
+};
+
+export type SignupApiResponse = ResponseBase<{ accessToken: string; refreshToken: string }>;
+
+export type LogoutApiResponse = NoResponseData;

--- a/apps/user/services/types/auth.dto.ts
+++ b/apps/user/services/types/auth.dto.ts
@@ -1,17 +1,9 @@
 import {
   BaseSignupInfo,
-  DayOfWeek,
   NoResponseData,
   PreferredWorkout,
   ResponseBase,
 } from "@5unwan/core/api/types/common";
-
-export type AvailablePtTime = {
-  dayOfWeek: DayOfWeek;
-  isHoliday: boolean;
-  startTime: string;
-  endTime: string;
-};
 
 export type SignupRequestBody = BaseSignupInfo & {
   workoutSchedule: PreferredWorkout[];


### PR DESCRIPTION
# [FLIZ-131/trainer] feat: Auth DTO 및 API 작업

## 📝 작업 내용

트레이너 > Auth 도메인의 DTO 타입 정의와 REST API 요청 함수를 정의했습니다
- 프로젝트 type 컨벤션에 따라 DTO 타입 파일은 trainer/services/types 폴더에 도메인 이름으로 생성했습니다
- 프로젝트 type 컨벤션에 따라 DTO 타입 파일은 trainer/services 폴더에 도메인 이름으로 생성했습니다

user/services/types/auth.dto.ts에서 불필요한 dto 타입을 제거했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
