### PR TITLE
[FLIZ-132/trainer] feat: 알림 DTO 및 API 작업

### DIFF
--- a/apps/trainer/services/notification.ts
+++ b/apps/trainer/services/notification.ts
@@ -1,0 +1,20 @@
+import http from "@5unwan/core/api/core";
+
+import {
+  GetNotificationApiResponse,
+  GetNotificationRequestQuery,
+  ReadNotificationApiResponse,
+  ReadNotificationRequestBody,
+} from "./types/notification.dto";
+
+export const getNotification = (params: GetNotificationRequestQuery) =>
+  http.get<GetNotificationApiResponse>({
+    url: `/v1/notifications`,
+    params,
+  });
+
+export const readNotification = (data: ReadNotificationRequestBody) =>
+  http.patch<ReadNotificationApiResponse>({
+    url: `/v1/notifications`,
+    data,
+  });

--- a/apps/trainer/services/types/notification.dto.ts
+++ b/apps/trainer/services/types/notification.dto.ts
@@ -1,0 +1,15 @@
+import { NotificationInfo, NotificationType, ResponseBase } from "@5unwan/core/api/types/common";
+
+export type GetNotificationRequestQuery = {
+  type: NotificationType;
+  name?: string;
+};
+export type GetNotificationApiResponse = ResponseBase<{
+  notificationList: NotificationInfo[];
+}>;
+export type ReadNotificationRequestBody = {
+  id: number;
+};
+export type ReadNotificationApiResponse = ResponseBase<{
+  notificationId: number;
+}>;

--- a/apps/user/services/notification.ts
+++ b/apps/user/services/notification.ts
@@ -16,6 +16,6 @@ export const getNotification = () =>
 
 export const readNotification = (data: ReadNotificationRequestBody) =>
   http.patch<ReadNotificationApiResponse>({
-    url: `v1/notifications`,
+    url: `/v1/notifications`,
     data,
   });


### PR DESCRIPTION
# [FLIZ-132/trainer] feat: 알림 DTO 및 API 작업

## 📝 작업 내용

트레이너 > 알림 도메인의 DTO 타입 정의와 REST API 요청 함수를 정의했습니다
- 프로젝트 type 컨벤션에 따라 DTO 타입 파일은 trainer/services/types 폴더에 도메인 이름으로 생성했습니다
- 프로젝트 type 컨벤션에 따라 DTO 타입 파일은 trainer/services 폴더에 도메인 이름으로 생성했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

