### PR TITLE
[FILZ-133/user] feat: 유저 도메인 Member 내 정보 관련 DTO 타입 정의 및 API 함수 구현

### DIFF
--- a/apps/user/services/myInformation.ts
+++ b/apps/user/services/myInformation.ts
@@ -1,0 +1,72 @@
+import http from "./core";
+import {
+  ConnectTrainerApiResponse,
+  ConnectTrainerRequestBody,
+  DisconnectTrainerApiResponse,
+  EditMyInformationApiResponse,
+  EditMyInformationRequestBody,
+  EditPreferredTimeApiResponse,
+  EditPreferredTimeRequestBody,
+  MyInformationApiResponse,
+  MyInformationDetailApiResponse,
+  MyPtHistoryApiResponse,
+  MyPtHistoryRequestPath,
+  MyPtHistoryRequestQuery,
+} from "./types/myInformation.dto";
+
+const USER_MANAGEMENT_BASE_URL = "members";
+
+/** 트레이너 연결 요청 */
+export const connectTrainer = ({ trainerCode }: ConnectTrainerRequestBody) => {
+  http.post<ConnectTrainerApiResponse>({
+    url: `${USER_MANAGEMENT_BASE_URL}/connect`,
+    data: {
+      trainerCode,
+    },
+  });
+};
+
+/** 트레이너 연결 해제 요청 */
+export const disconnectTrainer = () => {
+  http.post<DisconnectTrainerApiResponse>({ url: `${USER_MANAGEMENT_BASE_URL}/disconnect` });
+};
+
+/** 내 정보 조회 */
+export const myInformation = () => {
+  http.get<MyInformationApiResponse>({ url: `${USER_MANAGEMENT_BASE_URL}/me` });
+};
+
+/** 내 정보 수정 */
+export const editMyInformation = ({ name, phoneNumber }: EditMyInformationRequestBody) => {
+  http.patch<EditMyInformationApiResponse>({
+    url: `${USER_MANAGEMENT_BASE_URL}/me`,
+    data: { name, phoneNumber },
+  });
+};
+
+/** 내 정보 상세 조회 */
+export const myInformationDetail = () => {
+  http.get<MyInformationDetailApiResponse>({ url: `${USER_MANAGEMENT_BASE_URL}/me/detail` });
+};
+
+/** PT 희망시간 수정 */
+export const editPreferredTime = (requestBody: EditPreferredTimeRequestBody) => {
+  http.put<EditPreferredTimeApiResponse>({
+    url: `${USER_MANAGEMENT_BASE_URL}/me/workout-schedult`,
+    data: requestBody,
+  });
+};
+
+/** 내 PT 내역 조회 */
+export const myPtHistory = (
+  requestQuery: MyPtHistoryRequestQuery,
+  requestPath: MyPtHistoryRequestPath,
+) => {
+  const { memberId } = requestPath;
+  const { status, size, page } = requestQuery;
+
+  http.get<MyPtHistoryApiResponse>({
+    url: `${USER_MANAGEMENT_BASE_URL}/${memberId}/sessions`,
+    params: { status, size, page },
+  });
+};

--- a/apps/user/services/myInformation.ts
+++ b/apps/user/services/myInformation.ts
@@ -14,12 +14,12 @@ import {
   MyPtHistoryRequestQuery,
 } from "./types/myInformation.dto";
 
-const USER_MANAGEMENT_BASE_URL = "members";
+const USER_BASE_URL = "members";
 
 /** 트레이너 연결 요청 */
 export const connectTrainer = ({ trainerCode }: ConnectTrainerRequestBody) => {
   http.post<ConnectTrainerApiResponse>({
-    url: `${USER_MANAGEMENT_BASE_URL}/connect`,
+    url: `${USER_BASE_URL}/connect`,
     data: {
       trainerCode,
     },
@@ -28,31 +28,31 @@ export const connectTrainer = ({ trainerCode }: ConnectTrainerRequestBody) => {
 
 /** 트레이너 연결 해제 요청 */
 export const disconnectTrainer = () => {
-  http.post<DisconnectTrainerApiResponse>({ url: `${USER_MANAGEMENT_BASE_URL}/disconnect` });
+  http.post<DisconnectTrainerApiResponse>({ url: `${USER_BASE_URL}/disconnect` });
 };
 
 /** 내 정보 조회 */
 export const myInformation = () => {
-  http.get<MyInformationApiResponse>({ url: `${USER_MANAGEMENT_BASE_URL}/me` });
+  http.get<MyInformationApiResponse>({ url: `${USER_BASE_URL}/me` });
 };
 
 /** 내 정보 수정 */
 export const editMyInformation = ({ name, phoneNumber }: EditMyInformationRequestBody) => {
   http.patch<EditMyInformationApiResponse>({
-    url: `${USER_MANAGEMENT_BASE_URL}/me`,
+    url: `${USER_BASE_URL}/me`,
     data: { name, phoneNumber },
   });
 };
 
 /** 내 정보 상세 조회 */
 export const myInformationDetail = () => {
-  http.get<MyInformationDetailApiResponse>({ url: `${USER_MANAGEMENT_BASE_URL}/me/detail` });
+  http.get<MyInformationDetailApiResponse>({ url: `${USER_BASE_URL}/me/detail` });
 };
 
 /** PT 희망시간 수정 */
 export const editPreferredTime = (requestBody: EditPreferredTimeRequestBody) => {
   http.put<EditPreferredTimeApiResponse>({
-    url: `${USER_MANAGEMENT_BASE_URL}/me/workout-schedult`,
+    url: `${USER_BASE_URL}/me/workout-schedult`,
     data: requestBody,
   });
 };
@@ -66,7 +66,7 @@ export const myPtHistory = (
   const { status, size, page } = requestQuery;
 
   http.get<MyPtHistoryApiResponse>({
-    url: `${USER_MANAGEMENT_BASE_URL}/${memberId}/sessions`,
+    url: `${USER_BASE_URL}/${memberId}/sessions`,
     params: { status, size, page },
   });
 };

--- a/apps/user/services/types/myInformation.dto.ts
+++ b/apps/user/services/types/myInformation.dto.ts
@@ -1,0 +1,70 @@
+import {
+  NoResponseData,
+  PreferredWorkout,
+  PtInfo,
+  PtStatus,
+  ResponseBase,
+  SessionInfo,
+} from "@5unwan/core/api/types/common";
+
+/** Trainer 연결 요청 */
+export type ConnectTrainerRequestBody = {
+  trainerCode: string;
+};
+type ConnectTrainerResponse = NoResponseData;
+export type ConnectTrainerApiResponse = ResponseBase<ConnectTrainerResponse>;
+
+/** Trainer 연결 해제 요청 */
+type DisconnectTrainerResponse = NoResponseData;
+export type DisconnectTrainerApiResponse = ResponseBase<DisconnectTrainerResponse>;
+
+/** 내 정보 조회 */
+type MyInformationResponse = {
+  memberId: number;
+  name: string;
+  trainerId: number;
+  trainerName: string;
+  profilePictureUrl: string;
+  sessionInfo: SessionInfo;
+  workoutSchedules: (PreferredWorkout & { workoutScheduleId: string })[];
+};
+export type MyInformationApiResponse = ResponseBase<MyInformationResponse>;
+
+/** 내 정보 수정 */
+export type EditMyInformationRequestBody = {
+  name?: string;
+  phoneNumber: string;
+};
+type EditMyInformationResponse = NoResponseData;
+export type EditMyInformationApiResponse = ResponseBase<EditMyInformationResponse>;
+
+/** 내 정보 상세 조회 */
+type MyInformationDetailResponse = {
+  memberId: number;
+  profilePictureUrl: string;
+  name: string;
+  birthDate: string;
+  phoneNumber: string;
+};
+export type MyInformationDetailApiResponse = ResponseBase<MyInformationDetailResponse>;
+
+/** PT 희망시간 수정 */
+export type EditPreferredTimeRequestBody = (PreferredWorkout & { workoutScheduleId: string })[];
+type EditPreferredTimeResponse = (PreferredWorkout & { workoutScheduleId: string })[];
+export type EditPreferredTimeApiResponse = ResponseBase<EditPreferredTimeResponse>;
+
+/** 내 PT 내역 조회 */
+export type MyPtHistoryRequestQuery = {
+  status: PtStatus;
+  page: number;
+  size: number;
+};
+export type MyPtHistoryRequestPath = {
+  memberId: number;
+};
+type MyPtHistoryResponse = {
+  content: PtInfo[];
+  totalPage: string;
+  totalElements: string;
+};
+export type MyPtHistoryApiResponse = ResponseBase<MyPtHistoryResponse>;

--- a/packages/core/src/api/types/common.ts
+++ b/packages/core/src/api/types/common.ts
@@ -14,14 +14,19 @@ export type DayOfWeek =
   | "SATURDAY"
   | "SUNDAY";
 export type PtStatus = "COMPLETED" | "NO_SHOW" | "NONE" | "PENDING";
+export type PtInfo = {
+  sessionId: number;
+  reservationDate: string;
+  status: PtStatus;
+};
 export type SessionInfo = {
   sessionInfoId: number;
   totalCount: number;
   remainingCount: number;
 };
 export type PreferredWorkout = {
-  dayOfWeek: string;
-  preferenceTimes: Array<string>;
+  dayOfWeek: DayOfWeek;
+  preferenceTimes: string[];
 };
 export type AvailablePtTime = {
   availableTimeId: number;


### PR DESCRIPTION
## 📝 작업 내용

유저 도메인의 내 정보 관련 카테고리 DTO 타입 정의와 API 요청 함수를 정의했습니다.

- 프로젝트 type 컨벤션에 따라 DTO 타입 파일은 user/services/types 폴더에 카테고리 이름으로 생성했습니다
- 프로젝트 type 컨벤션에 따라 API 함수를 모아 놓은 파일은 user/services 폴더에 카테고리 이름으로 생성했습니다
