### PR TITLE
[FLIZ-137/trainer] feat: 트레이너 도메인 QueryKey Factory 구현

### DIFF
--- a/apps/trainer/queries/myInformation.ts
+++ b/apps/trainer/queries/myInformation.ts
@@ -13,7 +13,7 @@ export const myInformationBaseKeys = {
 export const myInformationQueries = {
   myInformation: () =>
     queryOptions({
-      queryKey: myInformationBaseKeys.all,
+      queryKey: [myInformationBaseKeys.all, "profile"] as const,
       queryFn: getMyInformation,
     }),
   trainerCode: () =>

--- a/apps/trainer/queries/myInformation.ts
+++ b/apps/trainer/queries/myInformation.ts
@@ -18,12 +18,12 @@ export const myInformationQueries = {
     }),
   trainerCode: () =>
     queryOptions({
-      queryKey: [...myInformationBaseKeys.all, "trainerCode"],
+      queryKey: [...myInformationBaseKeys.all, "trainerCode"] as const,
       queryFn: getTrainerCode,
     }),
   ptAvailableTime: () =>
     queryOptions({
-      queryKey: [...myInformationBaseKeys.all, "ptAvailableTime"],
+      queryKey: [...myInformationBaseKeys.all, "ptAvailableTime"] as const,
       queryFn: getAvailablePtTime,
     }),
 };

--- a/apps/trainer/queries/myInformation.ts
+++ b/apps/trainer/queries/myInformation.ts
@@ -1,0 +1,29 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import {
+  getAvailablePtTime,
+  getMyInformation,
+  getTrainerCode,
+} from "@trainer/services/myInformation";
+
+export const myInformationBaseKeys = {
+  all: ["myInformation"] as const,
+};
+
+export const myInformationQueries = {
+  myInformation: () =>
+    queryOptions({
+      queryKey: myInformationBaseKeys.all,
+      queryFn: getMyInformation,
+    }),
+  trainerCode: () =>
+    queryOptions({
+      queryKey: [...myInformationBaseKeys.all, "trainerCode"],
+      queryFn: getTrainerCode,
+    }),
+  ptAvailableTime: () =>
+    queryOptions({
+      queryKey: [...myInformationBaseKeys.all, "ptAvailableTime"],
+      queryFn: getAvailablePtTime,
+    }),
+};

--- a/apps/trainer/queries/notification.ts
+++ b/apps/trainer/queries/notification.ts
@@ -5,12 +5,13 @@ import { getNotification } from "@trainer/services/notification";
 
 export const notificationBaseKeys = {
   all: ["notification"] as const,
+  lists: () => [...notificationBaseKeys.all, "lists"] as const,
 };
 
 export const notificationQueries = {
-  notifications: (type: NotificationType, name?: string) =>
+  list: (type: NotificationType, name?: string) =>
     queryOptions({
-      queryKey: [...notificationBaseKeys.all, type, name] as const,
+      queryKey: [...notificationBaseKeys.lists(), type, name] as const,
       queryFn: () => getNotification({ type, name }),
     }),
 };

--- a/apps/trainer/queries/notification.ts
+++ b/apps/trainer/queries/notification.ts
@@ -10,7 +10,7 @@ export const notificationBaseKeys = {
 export const notificationQueries = {
   notifications: (type: NotificationType, name?: string) =>
     queryOptions({
-      queryKey: [...notificationBaseKeys.all, type, name],
+      queryKey: [...notificationBaseKeys.all, type, name] as const,
       queryFn: () => getNotification({ type, name }),
     }),
 };

--- a/apps/trainer/queries/notification.ts
+++ b/apps/trainer/queries/notification.ts
@@ -1,0 +1,16 @@
+import { NotificationType } from "@5unwan/core/api/types/common";
+import { queryOptions } from "@tanstack/react-query";
+
+import { getNotification } from "@trainer/services/notification";
+
+export const notificationBaseKeys = {
+  all: ["notification"] as const,
+};
+
+export const notificationQueries = {
+  notifications: (type: NotificationType, name?: string) =>
+    queryOptions({
+      queryKey: [...notificationBaseKeys.all, type, name],
+      queryFn: () => getNotification({ type, name }),
+    }),
+};

--- a/apps/trainer/queries/reservation.ts
+++ b/apps/trainer/queries/reservation.ts
@@ -2,13 +2,15 @@ import { queryOptions } from "@tanstack/react-query";
 
 import {
   getReservationDetailStatus,
-  getReservationDetailStatusPendingStatus,
+  getReservationDetailPendingStatus,
   getReservationStatus,
 } from "@trainer/services/reservations";
 
 export const reservationBaseKeys = {
   all: ["reservation"] as const,
-  status: () => [...reservationBaseKeys.all, "status"] as const,
+  statuses: () => [...reservationBaseKeys.all, "statuses"] as const,
+  details: () => [...reservationBaseKeys.all, "details"] as const,
+  pendingDetails: () => [...reservationBaseKeys.all, "pendingDetails"] as const,
 };
 
 export const reservationQueries = {
@@ -16,18 +18,18 @@ export const reservationQueries = {
     const parsedStringDate = String(date);
 
     return queryOptions({
-      queryKey: [...reservationBaseKeys.status(), parsedStringDate],
+      queryKey: [...reservationBaseKeys.statuses(), parsedStringDate] as const,
       queryFn: () => getReservationStatus({ date: parsedStringDate }),
     });
   },
   detail: (reservationId: number) =>
     queryOptions({
-      queryKey: [...reservationBaseKeys.status(), "detail", reservationId],
+      queryKey: [...reservationBaseKeys.details(), reservationId] as const,
       queryFn: () => getReservationDetailStatus({ reservationId }),
     }),
-  pendingDetail: (reservatio: number) =>
+  pendingDetail: (reservationId: number) =>
     queryOptions({
-      queryKey: [...reservationBaseKeys.status(), "pending", reservatio],
-      queryFn: () => getReservationDetailStatusPendingStatus({ reservationId: reservatio }),
+      queryKey: [...reservationBaseKeys.pendingDetails(), reservationId] as const,
+      queryFn: () => getReservationDetailPendingStatus({ reservationId: reservationId }),
     }),
 };

--- a/apps/trainer/queries/reservation.ts
+++ b/apps/trainer/queries/reservation.ts
@@ -8,17 +8,16 @@ import {
 
 export const reservationBaseKeys = {
   all: ["reservation"] as const,
-  statuses: () => [...reservationBaseKeys.all, "statuses"] as const,
-  details: () => [...reservationBaseKeys.all, "details"] as const,
-  pendingDetails: () => [...reservationBaseKeys.all, "pendingDetails"] as const,
+  lists: () => [reservationBaseKeys.all, "lists"] as const,
+  details: () => [reservationBaseKeys.all, "details"] as const,
 };
 
 export const reservationQueries = {
-  status: (date: Date | string) => {
+  list: (date: Date | string) => {
     const parsedStringDate = String(date);
 
     return queryOptions({
-      queryKey: [...reservationBaseKeys.statuses(), parsedStringDate] as const,
+      queryKey: [...reservationBaseKeys.lists(), parsedStringDate] as const,
       queryFn: () => getReservationStatus({ date: parsedStringDate }),
     });
   },
@@ -29,7 +28,7 @@ export const reservationQueries = {
     }),
   pendingDetail: (reservationId: number) =>
     queryOptions({
-      queryKey: [...reservationBaseKeys.pendingDetails(), reservationId] as const,
+      queryKey: [...reservationBaseKeys.details(), reservationId] as const,
       queryFn: () => getReservationDetailPendingStatus({ reservationId: reservationId }),
     }),
 };

--- a/apps/trainer/queries/reservation.ts
+++ b/apps/trainer/queries/reservation.ts
@@ -1,0 +1,33 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import {
+  getReservationDetailStatus,
+  getReservationDetailStatusPendingStatus,
+  getReservationStatus,
+} from "@trainer/services/reservations";
+
+export const reservationBaseKeys = {
+  all: ["reservation"] as const,
+  status: () => [...reservationBaseKeys.all, "status"] as const,
+};
+
+export const reservationQueries = {
+  status: (date: Date | string) => {
+    const parsedStringDate = String(date);
+
+    return queryOptions({
+      queryKey: [...reservationBaseKeys.status(), parsedStringDate],
+      queryFn: () => getReservationStatus({ date: parsedStringDate }),
+    });
+  },
+  detail: (reservationId: number) =>
+    queryOptions({
+      queryKey: [...reservationBaseKeys.status(), "detail", reservationId],
+      queryFn: () => getReservationDetailStatus({ reservationId }),
+    }),
+  pendingDetail: (reservatio: number) =>
+    queryOptions({
+      queryKey: [...reservationBaseKeys.status(), "pending", reservatio],
+      queryFn: () => getReservationDetailStatusPendingStatus({ reservationId: reservatio }),
+    }),
+};

--- a/apps/trainer/queries/userManagement.ts
+++ b/apps/trainer/queries/userManagement.ts
@@ -1,7 +1,11 @@
 import { PtStatus } from "@5unwan/core/api/types/common";
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
-import { getPtUserDetail, getTargetMemberPtHistory } from "@trainer/services/userManagement";
+import {
+  getPtUserDetail,
+  getPtUserList,
+  getTargetMemberPtHistory,
+} from "@trainer/services/userManagement";
 
 const PT_HISTORY_PAGE_SIZE = 3;
 const START_PAGE = 0;
@@ -12,7 +16,7 @@ export const userManagementBaseKeys = {
   all: ["userManagement"] as const,
   lists: () => [...userManagementBaseKeys.all, "lists"] as const,
   infos: () => [...userManagementBaseKeys.all, "infos"] as const,
-  info: (memberId: number) => [...userManagementBaseKeys.memberInfos(), memberId] as const,
+  info: (memberId: number) => [...userManagementBaseKeys.infos(), memberId] as const,
 };
 
 export const userManagementQueries = {

--- a/apps/trainer/queries/userManagement.ts
+++ b/apps/trainer/queries/userManagement.ts
@@ -1,11 +1,7 @@
 import { PtStatus } from "@5unwan/core/api/types/common";
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
-import {
-  getPtUserDetail,
-  getPtUserList,
-  getTargetMemberPtHistory,
-} from "@trainer/services/userManagement";
+import { getPtUserDetail, getTargetMemberPtHistory } from "@trainer/services/userManagement";
 
 const PT_HISTORY_PAGE_SIZE = 3;
 const START_PAGE = 0;
@@ -14,15 +10,36 @@ const TO_NEXT_PAGE = 1;
 
 export const userManagementBaseKeys = {
   all: ["userManagement"] as const,
-  targetMemberPtHistories: () => [...userManagementBaseKeys.all, "targetMemberPtHistory"] as const,
-  memberLists: () => [...userManagementBaseKeys.all, "memberLists"] as const,
-  memberDetails: () => [...userManagementBaseKeys.all, "memberDetails"] as const,
+  lists: () => [...userManagementBaseKeys.all, "lists"] as const,
+  infos: () => [...userManagementBaseKeys.all, "infos"] as const,
+  info: (memberId: number) => [...userManagementBaseKeys.memberInfos(), memberId] as const,
 };
 
 export const userManagementQueries = {
-  targetMemberPtHistory: (memberId: number, status: PtStatus) =>
+  list: (q: string) =>
     infiniteQueryOptions({
-      queryKey: [...userManagementBaseKeys.targetMemberPtHistories(), memberId, status] as const,
+      queryKey: [...userManagementBaseKeys.lists(), q] as const,
+      queryFn: ({ pageParam }) => getPtUserList({ q, page: pageParam, size: PT_HISTORY_PAGE_SIZE }),
+      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+        if (lastPage.data.content.length === EMPTY_PAGE) {
+          return undefined;
+        }
+
+        return lastPageParam + TO_NEXT_PAGE;
+      },
+
+      initialPageParam: START_PAGE,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+    }),
+  detail: (memberId: number) =>
+    queryOptions({
+      queryKey: [...userManagementBaseKeys.info(memberId)] as const,
+      queryFn: () => getPtUserDetail({ memberId }),
+    }),
+  ptHistory: (memberId: number, status: PtStatus) =>
+    infiniteQueryOptions({
+      queryKey: [...userManagementBaseKeys.info(memberId), status] as const,
       queryFn: ({ pageParam }) =>
         getTargetMemberPtHistory(
           { status, page: pageParam, size: PT_HISTORY_PAGE_SIZE },
@@ -39,26 +56,5 @@ export const userManagementQueries = {
       initialPageParam: START_PAGE,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
-    }),
-  memberList: (q: string) =>
-    infiniteQueryOptions({
-      queryKey: [...userManagementBaseKeys.memberLists(), q] as const,
-      queryFn: ({ pageParam }) => getPtUserList({ q, page: pageParam, size: PT_HISTORY_PAGE_SIZE }),
-      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
-        if (lastPage.data.content.length === EMPTY_PAGE) {
-          return undefined;
-        }
-
-        return lastPageParam + TO_NEXT_PAGE;
-      },
-
-      initialPageParam: START_PAGE,
-      refetchOnWindowFocus: false,
-      refetchOnMount: false,
-    }),
-  memberDetail: (memberId: number) =>
-    queryOptions({
-      queryKey: [...userManagementBaseKeys.memberDetails(), memberId] as const,
-      queryFn: () => getPtUserDetail({ memberId }),
     }),
 };

--- a/apps/trainer/queries/userManagement.ts
+++ b/apps/trainer/queries/userManagement.ts
@@ -14,13 +14,15 @@ const TO_NEXT_PAGE = 1;
 
 export const userManagementBaseKeys = {
   all: ["userManagement"] as const,
-  members: () => [...userManagementBaseKeys.all, "members"] as const,
+  targetMemberPtHistories: () => [...userManagementBaseKeys.all, "targetMemberPtHistory"] as const,
+  memberLists: () => [...userManagementBaseKeys.all, "memberLists"] as const,
+  memberDetails: () => [...userManagementBaseKeys.all, "memberDetails"] as const,
 };
 
 export const userManagementQueries = {
   targetMemberPtHistory: (memberId: number, status: PtStatus) =>
     infiniteQueryOptions({
-      queryKey: [...userManagementBaseKeys.all, "targetMemberPtHistory", memberId, status],
+      queryKey: [...userManagementBaseKeys.targetMemberPtHistories(), memberId, status] as const,
       queryFn: ({ pageParam }) =>
         getTargetMemberPtHistory(
           { status, page: pageParam, size: PT_HISTORY_PAGE_SIZE },
@@ -38,10 +40,10 @@ export const userManagementQueries = {
       refetchOnWindowFocus: false,
       refetchOnMount: false,
     }),
-  memberList: (q: string, size: number) =>
+  memberList: (q: string) =>
     infiniteQueryOptions({
-      queryKey: [...userManagementBaseKeys.members(), q, size],
-      queryFn: ({ pageParam }) => getPtUserList({ q, page: pageParam, size }),
+      queryKey: [...userManagementBaseKeys.memberLists(), q] as const,
+      queryFn: ({ pageParam }) => getPtUserList({ q, page: pageParam, size: PT_HISTORY_PAGE_SIZE }),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (lastPage.data.content.length === EMPTY_PAGE) {
           return undefined;
@@ -56,7 +58,7 @@ export const userManagementQueries = {
     }),
   memberDetail: (memberId: number) =>
     queryOptions({
-      queryKey: [...userManagementBaseKeys.members(), memberId],
+      queryKey: [...userManagementBaseKeys.memberDetails(), memberId] as const,
       queryFn: () => getPtUserDetail({ memberId }),
     }),
 };

--- a/apps/trainer/queries/userManagement.ts
+++ b/apps/trainer/queries/userManagement.ts
@@ -1,0 +1,62 @@
+import { PtStatus } from "@5unwan/core/api/types/common";
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
+
+import {
+  getPtUserDetail,
+  getPtUserList,
+  getTargetMemberPtHistory,
+} from "@trainer/services/userManagement";
+
+const PT_HISTORY_PAGE_SIZE = 3;
+const START_PAGE = 0;
+const EMPTY_PAGE = 0;
+const TO_NEXT_PAGE = 1;
+
+export const userManagementBaseKeys = {
+  all: ["userManagement"] as const,
+  members: () => [...userManagementBaseKeys.all, "members"] as const,
+};
+
+export const userManagementQueries = {
+  targetMemberPtHistory: (memberId: number, status: PtStatus) =>
+    infiniteQueryOptions({
+      queryKey: [...userManagementBaseKeys.all, "targetMemberPtHistory", memberId, status],
+      queryFn: ({ pageParam }) =>
+        getTargetMemberPtHistory(
+          { status, page: pageParam, size: PT_HISTORY_PAGE_SIZE },
+          { memberId },
+        ),
+      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+        if (lastPage.data.content.length === EMPTY_PAGE) {
+          return undefined;
+        }
+
+        return lastPageParam + TO_NEXT_PAGE;
+      },
+
+      initialPageParam: START_PAGE,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+    }),
+  memberList: (q: string, size: number) =>
+    infiniteQueryOptions({
+      queryKey: [...userManagementBaseKeys.members(), q, size],
+      queryFn: ({ pageParam }) => getPtUserList({ q, page: pageParam, size }),
+      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+        if (lastPage.data.content.length === EMPTY_PAGE) {
+          return undefined;
+        }
+
+        return lastPageParam + TO_NEXT_PAGE;
+      },
+
+      initialPageParam: START_PAGE,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+    }),
+  memberDetail: (memberId: number) =>
+    queryOptions({
+      queryKey: [...userManagementBaseKeys.members(), memberId],
+      queryFn: () => getPtUserDetail({ memberId }),
+    }),
+};

--- a/apps/trainer/services/myInformation.ts
+++ b/apps/trainer/services/myInformation.ts
@@ -18,11 +18,10 @@ import {
   TrainerCodeApiResponse,
 } from "./types/myInformation.dto";
 
-export const getMyInformation = () => {
+export const getMyInformation = () =>
   http.get<MyInformationApiResponse>({ url: `${TRAINER_BASE_URL}/me` });
-};
 
-export const editMyInformation = ({ name, phoneNumber }: EditMyInformationRequestBody) => {
+export const editMyInformation = ({ name, phoneNumber }: EditMyInformationRequestBody) =>
   http.patch<EditMyInformationApiResponse>({
     url: `${TRAINER_BASE_URL}/me`,
     data: {
@@ -30,30 +29,25 @@ export const editMyInformation = ({ name, phoneNumber }: EditMyInformationReques
       phoneNumber,
     },
   });
-};
 
-export const getTrainerCode = () => {
+export const getTrainerCode = () =>
   http.get<TrainerCodeApiResponse>({ url: `${TRAINER_BASE_URL}/trainer-code` });
-};
 
-export const getAvailablePtTime = () => {
+export const getAvailablePtTime = () =>
   http.get<AvailablePtTimeApiResponse>({ url: `${TRAINER_BASE_URL}/available-times` });
-};
 
-export const deleteAvailablePtTime = ({ availableTimeId }: DeleteAvailablePtTimeRequestPath) => {
+export const deleteAvailablePtTime = ({ availableTimeId }: DeleteAvailablePtTimeRequestPath) =>
   http.delete<DeleteAvailableTimeApiResponse>({
     url: `${TRAINER_BASE_URL}/available-times/${availableTimeId}`,
   });
-};
 
-export const addAvailablePtTime = ({ applyAt, availableTimes }: AddAvailablePtTimeRequestBody) => {
+export const addAvailablePtTime = ({ applyAt, availableTimes }: AddAvailablePtTimeRequestBody) =>
   http.post<AddAvailablePtTimeApiResponse>({
     url: `${TRAINER_BASE_URL}/available-times`,
     data: { applyAt, availableTimes },
   });
-};
 
-export const addTimeOff = ({ dayOfWeek, dayOfTime }: AddTimeOffRequestBody) => {
+export const addTimeOff = ({ dayOfWeek, dayOfTime }: AddTimeOffRequestBody) =>
   http.post<AddTimeOffApiResponse>({
     url: `${TRAINER_BASE_URL}/day-off`,
     data: {
@@ -61,7 +55,6 @@ export const addTimeOff = ({ dayOfWeek, dayOfTime }: AddTimeOffRequestBody) => {
       dayOfTime,
     },
   });
-};
 
 export const deleteTimeOff = (
   requestPath: DeleteTimeOffRequestPath,
@@ -70,7 +63,7 @@ export const deleteTimeOff = (
   const { dayOffId } = requestPath;
   const { dayOfWeek, dayOfTime } = requestBody;
 
-  http.delete<DeleteTimeOffApiResponse>({
+  return http.delete<DeleteTimeOffApiResponse>({
     url: `${TRAINER_BASE_URL}/day-off/${dayOffId}`,
     data: {
       dayOfWeek,

--- a/apps/trainer/services/reservations.ts
+++ b/apps/trainer/services/reservations.ts
@@ -28,54 +28,40 @@ import {
   ConfirmReservationChangeRequestPath,
 } from "./types/reservations.dto";
 
-export const getReservationStatus = ({ date }: ReservationStatusRequestQuery) => {
+export const getReservationStatus = ({ date }: ReservationStatusRequestQuery) =>
   http.get<ReservationStatusApiResponse>({ url: `${RESERVATION_BASE_URL}`, params: { date } });
-};
 
-export const getReservationDetailStatus = ({
-  reservationId,
-}: ReservationDetailStatusRequestPath) => {
+export const getReservationDetailStatus = ({ reservationId }: ReservationDetailStatusRequestPath) =>
   http.get<ReservationDetailStatusApiResponse>({
     url: `${RESERVATION_BASE_URL}/${reservationId}`,
   });
-};
 
 export const getReservationDetailStatusPendingStatus = ({
   reservationId,
-}: ReservationDetailPendingStatusRequestPath) => {
+}: ReservationDetailPendingStatusRequestPath) =>
   http.get<ReservationDetailPendingStatusApiResponse>({
     url: `${RESERVATION_BASE_URL}/${reservationId}`,
   });
-};
 
-export const createReservationSetNotAvailable = ({
-  date,
-}: ReservationSetNotAvailableRequestBody) => {
+export const createReservationSetNotAvailable = ({ date }: ReservationSetNotAvailableRequestBody) =>
   http.post<ReservationSetNotAvailableApiResponse>({
     url: `${RESERVATION_BASE_URL}/availability/disable`,
     data: {
       date,
     },
   });
-};
 
-export const createDirectReservation = ({ reservations }: DirectReservationRequestBody) => {
+export const createDirectReservation = ({ reservations }: DirectReservationRequestBody) =>
   http.post<DirectReservationApiResponse>({
     url: `${RESERVATION_BASE_URL}`,
     data: { reservations },
   });
-};
 
-export const createFixReservation = ({
-  memberId,
-  name,
-  reservations,
-}: FixReservationRequestBody) => {
+export const createFixReservation = ({ memberId, name, reservations }: FixReservationRequestBody) =>
   http.post<FixReservationApiResponse>({
     url: `${RESERVATION_BASE_URL}/fixed-reservation`,
     data: { memberId, name, reservations },
   });
-};
 
 export const createCancelReservation = (
   requestPath: CancelReservationRequestPath,
@@ -84,7 +70,7 @@ export const createCancelReservation = (
   const { reservationId } = requestPath;
   const { cancel_reason } = requestBody;
 
-  http.post<CancelReservationApiResponse>({
+  return http.post<CancelReservationApiResponse>({
     url: `${RESERVATION_BASE_URL}/${reservationId}/cancel`,
     data: { cancel_reason },
   });
@@ -97,7 +83,7 @@ export const createApproveReservation = (
   const { reservationId } = requestPath;
   const { memberId, trainerId } = reqeustBody;
 
-  http.post<ApproveReservationApiResponse>({
+  return http.post<ApproveReservationApiResponse>({
     url: `${RESERVATION_BASE_URL}/${reservationId}/approve`,
     data: { memberId, trainerId },
   });
@@ -110,7 +96,7 @@ export const createCompletedPt = (
   const { sessionId } = requestPath;
   const { isJoin } = requestBody;
 
-  http.post<CompletedPtApiResponse>({
+  return http.post<CompletedPtApiResponse>({
     url: `${RESERVATION_BASE_URL}/${sessionId}/complete`,
     data: { isJoin },
   });
@@ -123,7 +109,7 @@ export const createConfirmReservationChange = (
   const { reservationId } = requestPath;
   const { memberId, trainerId } = requestBody;
 
-  http.post<ConfirmReservationChangeApiResponse>({
+  return http.post<ConfirmReservationChangeApiResponse>({
     url: `${RESERVATION_BASE_URL}/${reservationId}/changes/apporove`,
     data: { memberId, trainerId },
   });

--- a/apps/trainer/services/reservations.ts
+++ b/apps/trainer/services/reservations.ts
@@ -36,7 +36,7 @@ export const getReservationDetailStatus = ({ reservationId }: ReservationDetailS
     url: `${RESERVATION_BASE_URL}/${reservationId}`,
   });
 
-export const getReservationDetailStatusPendingStatus = ({
+export const getReservationDetailPendingStatus = ({
   reservationId,
 }: ReservationDetailPendingStatusRequestPath) =>
   http.get<ReservationDetailPendingStatusApiResponse>({

--- a/apps/trainer/services/types/userManagement.dto.ts
+++ b/apps/trainer/services/types/userManagement.dto.ts
@@ -1,6 +1,7 @@
 import {
   NoResponseData,
   PreferredWorkout,
+  PtInfo,
   PtStatus,
   ResponseBase,
   SessionInfo,
@@ -27,7 +28,7 @@ type PtUserListResponse = {
 };
 export type PtUserListApiResponse = ResponseBase<PtUserListResponse>;
 
-export type PtUserDetailRequestPath = { memberId: string };
+export type PtUserDetailRequestPath = { memberId: number };
 type PtUserDetailResponse = Omit<PtUser, "totalCount" | "remainingCount"> & {
   profilePictureUrl: string;
   sessionInfo: SessionInfo;
@@ -45,6 +46,15 @@ type SessionCountEditResponse = {
   remainingCount: number;
 };
 export type SessionCountEditApiResponse = ResponseBase<SessionCountEditResponse>;
+
+export type TargetMemberPtHistoryRequestQuery = { status: PtStatus; page: number; size: number };
+export type TargetMemberPtHistoryRequestPath = { memberId: number };
+type TargetMemberPtHistoryResponse = {
+  content: PtInfo[];
+  totalPages: string;
+  totalElements: string;
+};
+export type TargetMemberPtHistoryApiResponse = ResponseBase<TargetMemberPtHistoryResponse>;
 
 export type TargetMemberEditPtHistoryRequestPath = { memberId: string; sessionId: string };
 export type TargetMemberEditPtHistoryRequestBody = { status: PtStatus };

--- a/apps/trainer/services/userManagement.ts
+++ b/apps/trainer/services/userManagement.ts
@@ -11,12 +11,27 @@ import {
   SessionCountEditRequestPath,
   TargetMemberEditPtHistoryRequestBody,
   TargetMemberEditPtHistoryRequestPath,
+  TargetMemberPtHistoryApiResponse,
+  TargetMemberPtHistoryRequestPath,
+  TargetMemberPtHistoryRequestQuery,
   TargetUserEditPtHistoryApiResponse,
   UnlinkMemberApiResponse,
   UnlinkMemberRequestPath,
 } from "./types/userManagement.dto";
 
-export const getPtUserList = ({ q, page, size }: PtUserListRequestQuery) => {
+export const getTargetMemberPtHistory = (
+  requestQuery: TargetMemberPtHistoryRequestQuery,
+  requestPath: TargetMemberPtHistoryRequestPath,
+) => {
+  const { memberId } = requestPath;
+
+  return http.get<TargetMemberPtHistoryApiResponse>({
+    url: `${TRAINER_BASE_URL}/members/${memberId}/sessions`,
+    params: requestQuery,
+  });
+};
+
+export const getPtUserList = ({ q, page, size }: PtUserListRequestQuery) =>
   http.get<PtUserListApiResponse>({
     url: `${TRAINER_BASE_URL}/members`,
     params: {
@@ -25,17 +40,14 @@ export const getPtUserList = ({ q, page, size }: PtUserListRequestQuery) => {
       size,
     },
   });
-};
 
-export const getPtUserDetail = ({ memberId }: PtUserDetailRequestPath) => {
+export const getPtUserDetail = ({ memberId }: PtUserDetailRequestPath) =>
   http.get<PtUserDetailApiResponse>({ url: `${TRAINER_BASE_URL}/members/${memberId}` });
-};
 
-export const unLinkMember = ({ memberId }: UnlinkMemberRequestPath) => {
+export const unLinkMember = ({ memberId }: UnlinkMemberRequestPath) =>
   http.post<UnlinkMemberApiResponse>({
     url: `${TRAINER_BASE_URL}/members/${memberId}/disconnect`,
   });
-};
 
 export const sessionCountEdit = (
   requestPath: SessionCountEditRequestPath,
@@ -43,7 +55,8 @@ export const sessionCountEdit = (
 ) => {
   const { memberId, sessionInfoId } = requestPath;
   const { totalCount, remainingCount } = requestBody;
-  http.patch<SessionCountEditApiResponse>({
+
+  return http.patch<SessionCountEditApiResponse>({
     url: `${TRAINER_BASE_URL}/${memberId}/session-info/${sessionInfoId}`,
     data: {
       totalCount,
@@ -58,7 +71,8 @@ export const targetMemberEditPtHistory = (
 ) => {
   const { memberId, sessionId } = requestPath;
   const { status } = requestBody;
-  http.patch<TargetUserEditPtHistoryApiResponse>({
+
+  return http.patch<TargetUserEditPtHistoryApiResponse>({
     url: `${TRAINER_BASE_URL}/members/${memberId}/using-sessions/${sessionId}`,
     data: {
       status,


### PR DESCRIPTION
## 📝 작업 내용

### 트레이너 도메인 `QueryKey Factory`를 구현하였습니다.
- 트레이너 도메인에서 `QueryKey Factory`의 명확한 관심사 분리를 위해 `엔티티(회원관리, 예약, 알림, 내정보)`를 기반으로 분리하여 QueryKey Factory를 작성하였습니다.
- 쿼리 키는 계층 구조로 설계되어 있고 각 계층 구조의 루트 키는 `엔티티명+BaseKeys`객체에 구현되어 있으며 각각의 쿼리는 `queryOptions`로 감싸져 `엔티티명+Quries` 객체에 구현되어있습니다. 
   - 이와 같은 설계는 `Queries` 객체 내부에서 작성된 쿼리 키를 `set/getQueryData`와 같은 API에서 사용할 때 타입 세이프하게 사용할 수 있도록 강제합니다. 
   - `엔티티명+BaseKeys` 객체 내부에 정의된 타입 세이프하지 않은 쿼리키를 `set/getQueryData`와 같은 API에서 오용할 수 있는 경우의 수가 존재하지만, 이 같은 경우 PR #101 에서 정해진 컨벤션을 통해 `엔티티명+BaseKeys` 객체 내부에는 Invalidate에 사용하기 위한 각 계층 구조의 루트 쿼리 키만 작성하여 `set/getQueryData`와 같은 API에서는 사용하지 않도록 합니다.
- 트레이너 도메인의 API 함수가 void를 리턴하도록 잘못 작성되어있어 이를 수정하였습니다.
- 누락된 특정 회원의 PT 내역을 조회하는 API 함수와 DTO 타입을 새로 정의하였습니다.

## 💬 리뷰 요구사항(선택)
- 쿼리의 네이밍 피드백과 PR #101 에서 정의된 내용이 잘 반영되었는지 확인 부탁드립니다.
