### PR TITLE
[FLIZ-126/user] feat. 유저 마이페이지 UI 구현

### DIFF
--- a/apps/user/app/my-page/connect-trainer/page.tsx
+++ b/apps/user/app/my-page/connect-trainer/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Button } from "@ui/components/Button";
+import Header from "@ui/components/Header";
+import { InputOTP, InputOTPGroup, InputOTPMessage, InputOTPSlot } from "@ui/components/InputOTP";
+import { useRouter } from "next/navigation";
+import React, { useState } from "react";
+
+type otp_status = "default" | "focused" | "filled" | "error";
+
+export default function Home() {
+  const router = useRouter();
+  const OTP_LENGTH = 5;
+
+  const [value, setValue] = useState("");
+  const [status, setStatus] = useState<otp_status>("default");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const handleClickBack = () => {
+    router.push("/my-page");
+  };
+
+  const handleChangeValue = (newValue: string) => {
+    setValue(newValue);
+
+    if (newValue.length === OTP_LENGTH) {
+      setStatus("filled");
+    } else {
+      setErrorMessage("");
+      setStatus("default");
+    }
+  };
+
+  const handleSubmit = () => {
+    // TODO
+    // 트레이너 코드 제출 시, 없는 경우 variant를 error로 설정
+    setStatus("error");
+    setErrorMessage("입력한 코드를 확인해 주세요.");
+  };
+
+  return (
+    <main className="flex h-screen w-full flex-col items-center pb-[5.063rem]">
+      <Header>
+        <Header.Left>
+          <Header.Back onClick={handleClickBack} />
+        </Header.Left>
+        <Header.Title content="트레이너 연동" />
+      </Header>
+
+      <p className="text-body-1 text-text-sub2"> 트레이너에게 받은 코드를 입력해주세요</p>
+
+      <section className="mt-[3.75rem] flex h-full w-full flex-col">
+        <InputOTP maxLength={OTP_LENGTH} onChange={handleChangeValue}>
+          <InputOTPGroup className="flex justify-center">
+            {Array.from({ length: OTP_LENGTH }, (_, index) => (
+              <InputOTPSlot key={`otp-slot-${index}`} index={index} variant={status} />
+            ))}
+          </InputOTPGroup>
+          <InputOTPMessage className="flex justify-center" variant={status}>
+            {errorMessage}
+          </InputOTPMessage>
+        </InputOTP>
+      </section>
+      <section className="relative flex h-full w-full items-end">
+        <Button
+          type="submit"
+          className="relative bottom-2 h-[3.5rem] w-full"
+          onClick={handleSubmit}
+          disabled={value.length !== OTP_LENGTH}
+        >
+          연동 요청
+        </Button>
+      </section>
+    </main>
+  );
+}

--- a/apps/user/app/my-page/edit-workout-schedules/page.tsx
+++ b/apps/user/app/my-page/edit-workout-schedules/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { Button } from "@ui/components/Button";
+import DayOfWeekPicker from "@ui/components/DayOfWeekPicker";
+import Header from "@ui/components/Header";
+import Icon from "@ui/components/Icon";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@ui/components/Sheet";
+import TimeCellToggleGroup from "@ui/components/TimeCellToggleGroup";
+import { TimeCell } from "@ui/utils/timeCellUtils";
+import { useRouter } from "next/navigation";
+import React, { useState } from "react";
+
+export default function Home() {
+  const router = useRouter();
+  const handleClickBack = () => {
+    router.push("/my-page");
+  };
+
+  const MOCK_TIME_CELL_INFO: TimeCell[] = [
+    {
+      dayOfWeek: "MON",
+      time: "09:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "TUE",
+      time: "10:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "WED",
+      time: "11:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "THU",
+      time: "12:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "FRI",
+      time: "13:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "SAT",
+      time: "14:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "SUN",
+      time: "15:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "MON",
+      time: "16:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "MON",
+      time: "17:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "MON",
+      time: "18:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "MON",
+      time: "19:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "MON",
+      time: "20:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "MON",
+      time: "21:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "MON",
+      time: "22:00",
+      disabled: false,
+    },
+    {
+      dayOfWeek: "MON",
+      time: "23:00",
+      disabled: false,
+    },
+  ];
+
+  const [timeCell, setTimeCell] = useState<string[]>([]);
+
+  return (
+    <main className="flex h-screen w-full flex-col pb-[5.063rem]">
+      <Header>
+        <Header.Left>
+          <Header.Back onClick={handleClickBack} />
+        </Header.Left>
+        <Header.Title content="PT 희망 시간" />
+      </Header>
+
+      <section className="mt-[0.625rem] text-center">
+        <p className="text-body-1 text-text-sub2">PT 시간 : 50분</p>
+        <p className="text-body-1 text-text-sub2">PT 선택 시간은 시작 시간입니다.</p>
+      </section>
+
+      <section className="mt-[1.875rem] w-full">
+        <DayOfWeekPicker className="w-full" onCurrentDayChange={() => {}}></DayOfWeekPicker>
+        <div className="mt-[1.875rem]">
+          <TimeCellToggleGroup
+            timeCellInfo={MOCK_TIME_CELL_INFO}
+            selected={timeCell}
+            onSelectedChange={setTimeCell}
+          />
+        </div>
+      </section>
+
+      <section className="relative h-full w-full">
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant={"brand"} className="absolute bottom-0 h-[3.375rem] w-full">
+              수정
+            </Button>
+          </SheetTrigger>
+          <SheetContent side={"bottom"}>
+            <SheetHeader>
+              <SheetTitle className="flex justify-center">
+                <Icon name="Check" className="h-[3.125rem] w-[3.125rem]" background="brand" />
+              </SheetTitle>
+            </SheetHeader>
+            <SheetDescription asChild>
+              <div className="text-title-1 text-center">
+                <p>회원의 PT 희망 시간이</p>
+                <p>수정되었습니다</p>
+              </div>
+            </SheetDescription>
+            <SheetFooter className="flex flex-col gap-[0.625rem]">
+              <SheetClose asChild>
+                <Button variant={"brand"} className="h-[3.375rem] w-full">
+                  확인
+                </Button>
+              </SheetClose>
+            </SheetFooter>
+          </SheetContent>
+        </Sheet>
+      </section>
+    </main>
+  );
+}

--- a/apps/user/app/my-page/my-infomation/page.tsx
+++ b/apps/user/app/my-page/my-infomation/page.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@ui/components/Avatar";
+import { Button } from "@ui/components/Button";
+import Header from "@ui/components/Header";
+import { ProfileItem } from "@ui/components/ProfileItem";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+  SheetTrigger,
+} from "@ui/components/Sheet";
+import { ChevronRight } from "lucide-react";
+import { useRouter } from "next/navigation";
+import React, { useState } from "react";
+
+import { MyInformationDetailApiResponse } from "@user/services/types/myInformation.dto";
+
+import SheetItem from "@user/components/SheetItem";
+
+export default function MyInfomation() {
+  const router = useRouter();
+
+  const handleClickBack = () => {
+    router.push("/my-page");
+  };
+
+  const [mockData, setMockData] = useState<MyInformationDetailApiResponse["data"]>({
+    memberId: 1,
+    name: "홍길동",
+    birthDate: "2024-05-12",
+    phoneNumber: "010-2938-2312",
+    profilePictureUrl: "https://github.com/shadcn.png",
+  });
+
+  const handleClickRoutingVerifyPhone = () => {
+    const currentPath = window.location.pathname;
+    router.push(`${currentPath}/verify-phone`);
+  };
+
+  const handleClickDeleteSelectImageFromAlbum = () => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "image/*";
+    input.onchange = () => {
+      const file = input.files?.[0];
+
+      if (!file) return;
+
+      const uri = URL.createObjectURL(file as Blob);
+      setMockData({
+        ...mockData,
+        profilePictureUrl: uri,
+      });
+    };
+    input.click();
+  };
+
+  const handleClickDeleteProfileImage = () => {
+    setMockData({
+      ...mockData,
+      profilePictureUrl: "",
+    });
+  };
+
+  return (
+    <main className="flex h-screen w-full flex-col pb-[5.063rem]">
+      <Header>
+        <Header.Left>
+          <Header.Back onClick={handleClickBack} />
+        </Header.Left>
+        <Header.Title content="내 정보" />
+      </Header>
+      <section className="mt-[1.563rem] flex flex-col items-center justify-center">
+        <Avatar className="h-[6.313rem] w-[6.313rem]">
+          <AvatarFallback />
+          <AvatarImage src={mockData.profilePictureUrl} />
+        </Avatar>
+
+        <div className={"mt-[1.25rem]"}>
+          <Sheet>
+            <SheetTrigger asChild={true}>
+              <Button variant={"brand"} size={"sm"} corners={"pill"}>
+                {mockData.profilePictureUrl ? "프로필 사진 수정" : "프로필 사진 등록"}
+              </Button>
+            </SheetTrigger>
+            <SheetContent side={"bottom"}>
+              <SheetTitle></SheetTitle>
+              <SheetDescription className="flex flex-col gap-[0.625rem]">
+                <SheetClose asChild>
+                  <SheetItem
+                    icon="Image"
+                    label="앨범에서 선택"
+                    onClick={handleClickDeleteSelectImageFromAlbum}
+                  />
+                </SheetClose>
+                <SheetClose asChild>
+                  <SheetItem
+                    icon="Trash2"
+                    label="프로필 사진 삭제"
+                    variant="danger"
+                    onClick={handleClickDeleteProfileImage}
+                  />
+                </SheetClose>
+              </SheetDescription>
+            </SheetContent>
+          </Sheet>
+        </div>
+
+        <div className={"mt-[1.25rem] w-full"}>
+          <ProfileItem variant={"name"}>
+            <div className="flex h-full items-center gap-[0.625rem]">
+              <label>{mockData.name}</label>
+            </div>
+          </ProfileItem>
+          <ProfileItem variant={"birthday"}>
+            <div className="flex h-full items-center gap-[0.625rem]">
+              <label>{mockData.birthDate}</label>
+            </div>
+          </ProfileItem>
+          <ProfileItem variant={"phone"} onClick={handleClickRoutingVerifyPhone}>
+            <div className="flex h-full items-center gap-[0.625rem]">
+              <span className="h-full">{mockData.phoneNumber}</span>
+              <div className="flex items-center">
+                <span>변경</span> <ChevronRight size={25} />
+              </div>
+            </div>
+          </ProfileItem>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/user/app/my-page/my-infomation/verify-phone/page.tsx
+++ b/apps/user/app/my-page/my-infomation/verify-phone/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Button } from "@ui/components/Button";
+import Header from "@ui/components/Header";
+import { useRouter } from "next/navigation";
+import React from "react";
+
+export default function VerifyPhone() {
+  const router = useRouter();
+
+  const handleClickBack = () => {
+    router.push("/my-page/my-infomation");
+  };
+
+  return (
+    <main className="flex h-screen w-full flex-col items-center pb-[5.063rem]">
+      <Header>
+        <Header.Left>
+          <Header.Back onClick={handleClickBack} />
+        </Header.Left>
+        <Header.Title content="휴대폰 인증" />
+      </Header>
+      <section className="relative h-full w-full">
+        {/* //TODO - 
+        // href 'sms:<email>:body?<token>' 형식으로 변경 */}
+        <a>
+          <Button className="absolute bottom-0 h-[3.375rem] w-full">휴대폰 변경</Button>
+        </a>
+      </section>
+    </main>
+  );
+}

--- a/apps/user/app/my-page/my-trainer-infomation/page.tsx
+++ b/apps/user/app/my-page/my-trainer-infomation/page.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@ui/components/Avatar";
+import { Button } from "@ui/components/Button";
+import Header from "@ui/components/Header";
+import Icon from "@ui/components/Icon";
+import { Popup, PopupTrigger } from "@ui/components/Popup";
+import { ProfileItem } from "@ui/components/ProfileItem";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@ui/components/Sheet";
+import { ChevronRight } from "lucide-react";
+import { useRouter } from "next/navigation";
+import React, { useState } from "react";
+
+import { MyInformationDetailApiResponse } from "@user/services/types/myInformation.dto";
+
+export default function MyInfomation() {
+  const [isOpenBottomSheet, setIsOpenBottomSheet] = useState(false);
+
+  const [mockData] = useState<MyInformationDetailApiResponse["data"]>({
+    memberId: 2,
+    name: "김민수",
+    birthDate: "1990-05-12",
+    phoneNumber: "010-2938-2312",
+    profilePictureUrl: "https://github.com/shadcn.png",
+  });
+  const router = useRouter();
+
+  const handleClickBack = () => {
+    router.push("/my-page");
+  };
+
+  const handleClickPopupNegative = () => {
+    // TODO
+    // 트레이너 연동 해제 취소
+  };
+
+  const handleClickPopupPositive = () => {
+    // TODO
+    // 트레이너 연동 해제
+    handleClickBack();
+    setIsOpenBottomSheet(true);
+  };
+
+  const negative = {
+    label: "취소",
+    callback: handleClickPopupNegative,
+  };
+
+  const positive = {
+    label: "확인",
+    callback: handleClickPopupPositive,
+  };
+
+  return (
+    <main className="flex h-screen w-full flex-col overflow-hidden pb-[5.063rem]">
+      <Header>
+        <Header.Left>
+          <Header.Back onClick={handleClickBack} />
+        </Header.Left>
+        <Header.Title content="내 정보" />
+      </Header>
+
+      <section className="mt-[1.563rem] flex flex-col items-center justify-center">
+        <Avatar className="h-[6.313rem] w-[6.313rem]">
+          <AvatarFallback />
+          <AvatarImage src={mockData.profilePictureUrl} />
+        </Avatar>
+
+        <div className={"mt-[1.25rem] w-full"}>
+          <ProfileItem variant={"name"}>
+            <div className="flex h-full items-center gap-[0.625rem]">
+              <label>{mockData.name}</label>
+            </div>
+          </ProfileItem>
+          <ProfileItem variant={"birthday"}>
+            <div className="flex h-full items-center gap-[0.625rem]">
+              <label>{mockData.birthDate}</label>
+            </div>
+          </ProfileItem>
+          <Popup title="트레이너와 연동 해제하시겠습니까?" negative={negative} positive={positive}>
+            <PopupTrigger className="w-full">
+              <ProfileItem variant={"unlink"}>
+                <div className="flex h-full items-center gap-[0.625rem]">
+                  <div className="flex items-center">
+                    <ChevronRight />
+                  </div>
+                </div>
+              </ProfileItem>
+            </PopupTrigger>
+          </Popup>
+        </div>
+      </section>
+      <Sheet open={isOpenBottomSheet} onOpenChange={setIsOpenBottomSheet}>
+        <SheetTrigger></SheetTrigger>
+        <SheetContent side={"bottom"}>
+          <SheetHeader>
+            <SheetTitle className="flex justify-center">
+              <Icon name="Check" className="h-[3.125rem] w-[3.125rem]" background="brand" />
+            </SheetTitle>
+          </SheetHeader>
+          <SheetDescription asChild>
+            <div className="flex flex-col gap-[0.875rem] text-center">
+              <p className="text-title-1">트레이너와 연동 해제되었습니다</p>
+              <p className="text-body-1">트레이너에게 연동 해제 알람이 전송돼요</p>
+            </div>
+          </SheetDescription>
+          <SheetFooter>
+            <SheetClose asChild>
+              <Button variant={"brand"} className="h-[3.375rem] w-full">
+                확인
+              </Button>
+            </SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </main>
+  );
+}

--- a/apps/user/app/my-page/page.tsx
+++ b/apps/user/app/my-page/page.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { PtInfo } from "@5unwan/core/api/types/common";
+import { Badge } from "@ui/components/Badge";
+import { Button } from "@ui/components/Button";
+import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from "@ui/components/Dropdown";
+import { Popup, PopupTrigger } from "@ui/components/Popup";
+import ProfileHeader from "@ui/components/ProfileHeader";
+import { ProfileItem, ProfileItemContent } from "@ui/components/ProfileItem";
+import PTHistoryItem from "@ui/components/PTHistoryItem";
+import { ChevronRight } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import {
+  MyInformationApiResponse,
+  MyPtHistoryApiResponse,
+} from "@user/services/types/myInformation.dto";
+
+import { getFormattedPTCount } from "@user/utils/count";
+
+type PTHistoryFilterTypes = "ALL" | "COMPLETED" | "NO_SHOW" | "NONE";
+
+export default function Home() {
+  const router = useRouter();
+
+  const FILTER_OPTIONS: Record<PTHistoryFilterTypes, string> = {
+    ALL: "전체",
+    COMPLETED: "PT 완료",
+    NO_SHOW: "불참석",
+    NONE: "미처리",
+  };
+
+  const [ptHistoryFilter, setPtHistoryFilter] = useState<PTHistoryFilterTypes>("ALL");
+
+  const [mockData] = useState<MyInformationApiResponse["data"]>({
+    memberId: 1,
+    name: "홍길동",
+    trainerId: 1,
+    trainerName: "",
+    profilePictureUrl:
+      "https://img1.daumcdn.net/thumb/R1280x0.fjpg/?fname=http://t1.daumcdn.net/brunch/service/user/cnoC/image/L5UV5eFyTS1Ar4MTDDOd_Ynrzt4",
+    sessionInfo: {
+      sessionInfoId: 1,
+      totalCount: 20,
+      remainingCount: 2,
+    },
+    workoutSchedules: [
+      {
+        workoutScheduleId: "1",
+        dayOfWeek: "MONDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: "2",
+        dayOfWeek: "TUESDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: "3",
+        dayOfWeek: "WEDNESDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: "4",
+        dayOfWeek: "THURSDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: "5",
+        dayOfWeek: "FRIDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: "6",
+        dayOfWeek: "SATURDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: "7",
+        dayOfWeek: "SUNDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+    ],
+  });
+
+  const [mock_pt_history] = useState<MyPtHistoryApiResponse["data"]>({
+    content: [
+      {
+        sessionId: 1,
+        reservationDate: "2021-08-01T12:00:00",
+        status: "COMPLETED",
+      },
+      {
+        sessionId: 2,
+        reservationDate: "2021-08-01T12:00:00",
+        status: "NO_SHOW",
+      },
+      {
+        sessionId: 3,
+        reservationDate: "2021-08-01T12:00:00",
+        status: "NONE",
+      },
+    ],
+    totalPages: "1",
+    totalElements: "1",
+  });
+
+  const handleClickChangeHistoryFilter = (filter: PTHistoryFilterTypes) => {
+    setPtHistoryFilter(filter);
+  };
+
+  const handleClickRouting = (path: string) => {
+    const currentPath = window.location.pathname;
+
+    if (currentPath === path) return;
+    router.push(`${currentPath}/${path}`);
+  };
+
+  const negative = {
+    label: "취소",
+    callback: () => {},
+  };
+
+  const positive = {
+    label: "로그아웃",
+    callback: () => {
+      router.push("/");
+    },
+  };
+
+  return (
+    <main className="flex h-screen w-full flex-col overflow-hidden pb-[5.063rem]">
+      <section className="flex items-center justify-between">
+        <ProfileHeader>
+          <ProfileHeader.Section
+            onClick={() => {
+              handleClickRouting("/my-infomation");
+            }}
+          >
+            <ProfileHeader.Avatar name="홍길동" imageSrc={mockData.profilePictureUrl} />
+            <ProfileHeader.Name name="홍길동" />
+          </ProfileHeader.Section>
+        </ProfileHeader>
+        <Popup title="로그아웃을 하시겠습니까?" negative={negative} positive={positive}>
+          <PopupTrigger className="w-fit">
+            <Badge variant="sub2" className="px-4">
+              로그아웃
+            </Badge>
+          </PopupTrigger>
+        </Popup>
+      </section>
+
+      <section className="mt-[1.563rem] flex h-auto flex-col">
+        <ProfileItem variant="dumbbell">
+          <ProfileItemContent>
+            <Badge>
+              {getFormattedPTCount(
+                mockData.sessionInfo.remainingCount,
+                mockData.sessionInfo.totalCount,
+              )}
+            </Badge>
+          </ProfileItemContent>
+        </ProfileItem>
+        <ProfileItem variant="trainer">
+          <ProfileItemContent
+            className="cursor-pointer"
+            onClick={() => {
+              if (mockData.trainerName !== "") {
+                handleClickRouting("/my-trainer-infomation");
+              } else {
+                handleClickRouting("/connect-trainer");
+              }
+            }}
+          >
+            <div
+              className={`flex items-center gap-0 ${mockData.trainerName ? "" : "text-text-primary"}`}
+            >
+              {mockData.trainerName ? mockData.trainerName : "연동하기"}
+              <ChevronRight />
+            </div>
+          </ProfileItemContent>
+        </ProfileItem>
+      </section>
+
+      <section className="mt-[0.625rem] flex h-auto flex-col">
+        <Dropdown className="w-full">
+          <DropdownTrigger>
+            <div className="text-headline">PT희망 시간</div>
+          </DropdownTrigger>
+          <DropdownContent>
+            <DropdownItem>
+              <div className="">희망시간</div>
+            </DropdownItem>
+          </DropdownContent>
+        </Dropdown>
+      </section>
+
+      <section className="flex h-auto flex-col">
+        <Dropdown className="w-full">
+          <DropdownTrigger>
+            <div className="text-headline">PT고정 시간</div>
+          </DropdownTrigger>
+          <DropdownContent>
+            <DropdownItem>
+              <div className="">고정시간</div>
+            </DropdownItem>
+          </DropdownContent>
+        </Dropdown>
+      </section>
+
+      <section>
+        <p className="text-headline mt-[1.625rem]">PT 내역</p>
+
+        <div className="mt-[0.625rem] flex items-center gap-2">
+          {Object.entries(FILTER_OPTIONS).map(([key, value]) => (
+            <Button
+              key={`PT-history-filter-${key}`}
+              size="sm"
+              variant={ptHistoryFilter === key ? "negative" : "secondary"}
+              onClick={() => handleClickChangeHistoryFilter(key as PTHistoryFilterTypes)}
+            >
+              {value}
+            </Button>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-[1.25rem] flex flex-col gap-[0.625rem] overflow-y-auto pb-2">
+        {mock_pt_history.content.map((item: PtInfo) => {
+          if (item.status !== ptHistoryFilter && ptHistoryFilter !== "ALL") return;
+
+          return (
+            <PTHistoryItem
+              key={`PT-history-item-${item.sessionId}`}
+              reservationDate={item.reservationDate}
+              status={item.status as "COMPLETED" | "NO_SHOW" | "NONE"}
+            />
+          );
+        })}
+      </section>
+    </main>
+  );
+}

--- a/apps/user/components/SheetItem.tsx
+++ b/apps/user/components/SheetItem.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@ui/lib/utils";
+import { icons } from "lucide-react";
+
+interface SheetItemProps extends React.HTMLAttributes<HTMLButtonElement> {
+  icon: string;
+  label: string;
+  variant?: "danger" | "default";
+}
+
+export default function SheetItem({ icon, label, variant = "default", onClick }: SheetItemProps) {
+  const Icon = icons[icon as keyof typeof icons];
+  const variants = {
+    danger: "text-notification",
+    default: "text-text-primary",
+  };
+
+  return (
+    <button
+      className={cn(
+        "bg-background-sub1 hover:bg-background-sub3 flex h-[2.813rem] w-full items-center gap-[0.625rem] rounded-md px-[0.625rem]",
+        variants[variant],
+      )}
+      onClick={onClick}
+    >
+      <Icon size={24} className="h-[1.5rem] w-[1.5rme]" />
+      <label>{label}</label>
+    </button>
+  );
+}

--- a/apps/user/constants/count.ts
+++ b/apps/user/constants/count.ts
@@ -1,0 +1,1 @@
+export const DIGIT_LENGTH = 2;

--- a/apps/user/utils/count.ts
+++ b/apps/user/utils/count.ts
@@ -1,0 +1,8 @@
+import { DIGIT_LENGTH } from "@user/constants/count";
+
+export const getFormattedPTCount = (remainingCount: number, totalCount: number): string => {
+  const formattedRemaining = remainingCount.toString().padStart(DIGIT_LENGTH, "0");
+  const formattedTotal = totalCount.toString().padStart(DIGIT_LENGTH, "0");
+
+  return `${formattedRemaining}/${formattedTotal}`;
+};

--- a/packages/ui/src/components/InputOTP.tsx
+++ b/packages/ui/src/components/InputOTP.tsx
@@ -30,7 +30,7 @@ const InputOTP = React.forwardRef<
 >(({ className, containerClassName, ...props }, ref) => (
   <OTPInput
     ref={ref}
-    containerClassName={cn(" items-center gap-2 has-[:disabled]:opacity-50", containerClassName)}
+    containerClassName={cn("gap-2 has-[:disabled]:opacity-50", containerClassName)}
     className={cn("disabled:cursor-not-allowed", className)}
     {...props}
   />

--- a/packages/ui/src/components/Popup.tsx
+++ b/packages/ui/src/components/Popup.tsx
@@ -67,13 +67,17 @@ function Popup({
         <DialogFooter>
           <DialogClose asChild>
             {negative && (
-              <Button variant="secondary" onClick={negative.callback}>
+              <Button className="w-full" variant="secondary" onClick={negative.callback}>
                 {negative.label}
               </Button>
             )}
           </DialogClose>
           <DialogClose asChild>
-            {positive && <Button onClick={positive.callback}>{positive.label}</Button>}
+            {positive && (
+              <Button className="w-full" onClick={positive.callback}>
+                {positive.label}
+              </Button>
+            )}
           </DialogClose>
         </DialogFooter>
       </DialogContent>

--- a/packages/ui/src/components/Popup.tsx
+++ b/packages/ui/src/components/Popup.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 
+import { cn } from "@ui/lib/utils";
+
+import useControllableState from "@ui/hooks/useControllableState";
+
 import { Button } from "./Button";
 import {
   Dialog,
@@ -18,6 +22,9 @@ type PopupButton = {
 };
 
 type PopupProps = {
+  prop?: boolean;
+  onChange?: () => void;
+  defaultProp?: boolean;
   title: string;
   description?: string;
   negative?: PopupButton;
@@ -25,10 +32,25 @@ type PopupProps = {
   children: React.ReactNode;
 };
 
-function Popup({ title, description, negative, positive, children }: PopupProps) {
+function Popup({
+  prop,
+  onChange,
+  defaultProp,
+  title,
+  description,
+  negative,
+  positive,
+  children,
+}: PopupProps) {
+  const [open = false, setOpen] = useControllableState({
+    prop: prop,
+    onChange: onChange,
+    defaultProp: defaultProp,
+  });
+
   return (
-    <Dialog>
-      <DialogTrigger asChild>{children}</DialogTrigger>
+    <Dialog open={open} onOpenChange={setOpen}>
+      {children}
       <DialogContent>
         <DialogHeader>
           <DialogTitle>
@@ -36,18 +58,20 @@ function Popup({ title, description, negative, positive, children }: PopupProps)
               <p key={`popup_title_${line}`}>{line}</p>
             ))}
           </DialogTitle>
-          {description && (
-            <DialogDescription>
-              {description
-                ?.split("\\n")
-                .map((line) => <p key={`popup_description_${line}`}>{line}</p>)}
-            </DialogDescription>
-          )}
         </DialogHeader>
+
+        {description && (
+          <DialogDescription>
+            {description
+              ?.split("\\n")
+              .map((line) => <p key={`popup_description_${line}`}>{line}</p>)}
+          </DialogDescription>
+        )}
+
         <DialogFooter>
           <DialogClose asChild>
             {negative && (
-              <Button variant="dark" onClick={negative.callback}>
+              <Button variant="secondary" onClick={negative.callback}>
                 {negative.label}
               </Button>
             )}
@@ -61,4 +85,17 @@ function Popup({ title, description, negative, positive, children }: PopupProps)
   );
 }
 
-export { Popup, type PopupProps };
+interface PopupTriggerProps {
+  asChild?: boolean;
+  className?: string;
+  children: React.ReactNode;
+}
+function PopupTrigger({ asChild = false, children, className }: PopupTriggerProps) {
+  return (
+    <DialogTrigger asChild={asChild} className={cn("w-full", className)}>
+      {children}
+    </DialogTrigger>
+  );
+}
+
+export { Popup, type PopupProps, PopupTrigger };

--- a/packages/ui/src/components/Popup.tsx
+++ b/packages/ui/src/components/Popup.tsx
@@ -60,13 +60,9 @@ function Popup({
           </DialogTitle>
         </DialogHeader>
 
-        {description && (
-          <DialogDescription>
-            {description
-              ?.split("\\n")
-              .map((line) => <p key={`popup_description_${line}`}>{line}</p>)}
-          </DialogDescription>
-        )}
+        <DialogDescription>
+          {description?.split("\\n").map((line) => <p key={`popup_description_${line}`}>{line}</p>)}
+        </DialogDescription>
 
         <DialogFooter>
           <DialogClose asChild>


### PR DESCRIPTION
## 📝 작업 내용

작성한 컴포넌트를 사용하여 User의 마이페이지 영역의 페이지 UI를 구현하였습니다.
✅ 각 페이지의 최상위 태그는 `pb-5.063rem` 값을 추가하여 아래 네비게이션 영역을 확보하였습니다.
✅ 유저의 PT 횟수를 두 자리수로 표현하기 위한 `유틸함수`가 추가되었습니다.
✅ `Popup(Dialog 랩핑)` 컴포넌트의 사용 확장을 위해 트리거 컴포넌트를 따로 사용할 수 있도록 기존 컴포넌트 외부에 따로 선언하게 변경되었습니다.
✅ 라우팅이 구현되었습니다.
✅ 바텀 시트에 사용될 버튼을 공통 컴포넌트로 하여 구현하였습니다. (📁user/📁components/📄SheetItem.tsx)
🐞`Popup` 컴포넌트에 표시되는 버튼의 style 값을 기본 `w-full` 값으로 수정하여 영역을 차지할 수 있도록 하였습니다.
🐞 팝업 컴포넌트에 Button에 variant값이 `dark`로 정의되어 있던 에러 부분을 `secondary`로 수정하여 오류를 바로 잡았습니다.
🐞 `Popup` 컴포넌트에 Description 부분을 description 값에 따른 조건 렌더링을 하였는데 에러가 발생하여 Description을 무조건 반환하도록 수정하였습니다

## 💬 리뷰 요구사항(선택)
⚠️ InputOTP가 5개로 고정되어 있는 상태에서 매직넘버를 Array.from()을 통하여 렌더링할 때,  key값을 따로 객체 혹은 배열에서 뽑아 쓸까하다가 길이가 고정되거나 순서가 변경되지 않는 경우는 index를 key로 사용해도 된다고 보아 해당 내용으로 진행하였습니다.

