### PR TITLE
[FLIZ-97/user] feat: 알림 페이지 구현

### DIFF
--- a/apps/user/app/notification/_components/Fallback.tsx
+++ b/apps/user/app/notification/_components/Fallback.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from "@ui/components/Skeleton";
+import { Text } from "@ui/components/Text";
+import React from "react";
+
+function Fallback() {
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-[0.8125rem] w-[3.125rem]" />
+        <Text.Body3>최신순</Text.Body3>
+      </div>
+      <ul className="flex flex-col items-center gap-4">
+        {Array.from({ length: 6 }).map((_v, idx) => (
+          <NotificationItemSkeleton key={`noti-skeleton-${idx}`} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default Fallback;
+
+function NotificationItemSkeleton() {
+  return (
+    <li className="bg-background-sub1 flex h-[6.25rem] w-full items-center gap-4 rounded-[10px] px-[15px]">
+      <Skeleton className="h-[3.125rem] w-[3.125rem] rounded-full" />
+      <div className="flex flex-col items-start gap-2">
+        <Skeleton className="h-[0.9375rem] w-[12.5rem] rounded-full" />
+        <Skeleton className="h-[0.9375rem] w-[9.375rem]" />
+      </div>
+    </li>
+  );
+}

--- a/apps/user/app/notification/_components/NotificationContainer.tsx
+++ b/apps/user/app/notification/_components/NotificationContainer.tsx
@@ -19,7 +19,7 @@ const notificationList = [
     },
     content: "회원님이 PT 예약을 요청하였습니다.",
     sendDate: "2025-02-12T18:00",
-    isProcessed: false,
+    isProcessed: true,
   },
   {
     notificationId: 1, //알림 ID

--- a/apps/user/app/notification/_components/NotificationContainer.tsx
+++ b/apps/user/app/notification/_components/NotificationContainer.tsx
@@ -1,4 +1,5 @@
 import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { Text } from "@ui/components/Text";
 import React from "react";
 
 import NotificationList from "./NotificationList";
@@ -54,7 +55,7 @@ const notificationList = [
   },
 ];
 
-function NotificationContent() {
+function NotificationContainer() {
   // const { data } = useSuspenseQuery(notificationQueries.list());
 
   // const {
@@ -64,12 +65,12 @@ function NotificationContent() {
   return (
     <div>
       <div className="flex items-center justify-between">
-        <span>{`${notificationList.length}개의 알림`}</span>
-        <div>최신순</div>
+        <Text.Body3>{`${notificationList.length}개의 알림`}</Text.Body3>
+        <Text.Body3>최신순</Text.Body3>
       </div>
       <NotificationList notificationList={notificationList} />
     </div>
   );
 }
 
-export default NotificationContent;
+export default NotificationContainer;

--- a/apps/user/app/notification/_components/NotificationContent.tsx
+++ b/apps/user/app/notification/_components/NotificationContent.tsx
@@ -1,0 +1,75 @@
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import React from "react";
+
+import NotificationList from "./NotificationList";
+
+const notificationList = [
+  {
+    notificationId: 1, //알림 ID
+    refId: 1, // 연동 ID
+    refType: "예약" as NotificationInfo["refType"], //알람 종류 ["예약","세션","트레이너 연동"]
+    notificationType: "예약 요청" as NotificationInfo["notificationType"], // 알림종류
+    memberInfo: {
+      memberId: 1,
+      name: "홍길동",
+      birthDate: "1996-07-13",
+      phoneNumber: "01057145507",
+      profilePictureUrl: "https://",
+    },
+    content: "회원님이 PT 예약을 요청하였습니다.",
+    sendDate: "2025-02-12T18:00",
+    isProcessed: false,
+  },
+  {
+    notificationId: 1, //알림 ID
+    refId: 1, // 연동 ID
+    refType: "예약" as NotificationInfo["refType"], //알람 종류 ["예약","세션","트레이너 연동"]
+    notificationType: "예약 요청" as NotificationInfo["notificationType"], // 알림종류
+    memberInfo: {
+      memberId: 1,
+      name: "홍길동",
+      birthDate: "1996-07-13",
+      phoneNumber: "01057145507",
+      profilePictureUrl: "https://",
+    },
+    content: "회원님이 PT 예약을 요청하였습니다.",
+    sendDate: "2025-02-12T18:00",
+    isProcessed: false,
+  },
+  {
+    notificationId: 1, //알림 ID
+    refId: 1, // 연동 ID
+    refType: "예약" as NotificationInfo["refType"], //알람 종류 ["예약","세션","트레이너 연동"]
+    notificationType: "예약 요청" as NotificationInfo["notificationType"], // 알림종류
+    memberInfo: {
+      memberId: 1,
+      name: "홍길동",
+      birthDate: "1996-07-13",
+      phoneNumber: "01057145507",
+      profilePictureUrl: "https://",
+    },
+    content: "회원님이 PT 예약을 요청하였습니다.",
+    sendDate: "2025-02-12T18:00",
+    isProcessed: false,
+  },
+];
+
+function NotificationContent() {
+  // const { data } = useSuspenseQuery(notificationQueries.list());
+
+  // const {
+  //   data: { notificationList },
+  // } = data;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <span>{`${notificationList.length}개의 알림`}</span>
+        <div>최신순</div>
+      </div>
+      <NotificationList notificationList={notificationList} />
+    </div>
+  );
+}
+
+export default NotificationContent;

--- a/apps/user/app/notification/_components/NotificationList.tsx
+++ b/apps/user/app/notification/_components/NotificationList.tsx
@@ -9,6 +9,7 @@ type NotificationListProps = {
 };
 
 function NotificationList({ notificationList }: NotificationListProps) {
+  // TODO[2025.03.30]: NotificationItem onClick 핸들러 구현 (알림 읽음 처리 API)
   return (
     <ul className="flex flex-col items-center gap-4">
       {notificationList?.map(({ content, sendDate, isProcessed }, index) => (

--- a/apps/user/app/notification/_components/NotificationList.tsx
+++ b/apps/user/app/notification/_components/NotificationList.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import NotificationItem from "@ui/components/NotificationItem/NotificationItem";
+import React from "react";
+
+type NotificationListProps = {
+  notificationList: NotificationInfo[];
+};
+
+function NotificationList({ notificationList }: NotificationListProps) {
+  return (
+    <ul className="flex flex-col items-center gap-4">
+      {notificationList?.map(({ content, sendDate, isProcessed }, index) => (
+        <NotificationItem
+          message={content}
+          createdAt={sendDate}
+          isCompleted={isProcessed}
+          variant="reserve"
+          key={`${sendDate}-${index}`}
+          className="w-full"
+        />
+      ))}
+    </ul>
+  );
+}
+
+export default NotificationList;

--- a/apps/user/app/notification/layout.tsx
+++ b/apps/user/app/notification/layout.tsx
@@ -1,0 +1,18 @@
+import Header from "@ui/components/Header";
+import React from "react";
+
+type NotificationLayoutProps = Readonly<{
+  children: React.ReactNode;
+}>;
+function NotificationLayout({ children }: NotificationLayoutProps) {
+  return (
+    <>
+      <Header>
+        <Header.Title content="알림" />
+      </Header>
+      {children}
+    </>
+  );
+}
+
+export default NotificationLayout;

--- a/apps/user/app/notification/page.tsx
+++ b/apps/user/app/notification/page.tsx
@@ -1,0 +1,15 @@
+import React, { Suspense } from "react";
+
+import NotificationContent from "./_components/NotificationContent";
+
+function NotificationPage() {
+  return (
+    <main className="h-full w-full">
+      <Suspense fallback={<span>loading...</span>}>
+        <NotificationContent />
+      </Suspense>
+    </main>
+  );
+}
+
+export default NotificationPage;

--- a/apps/user/app/notification/page.tsx
+++ b/apps/user/app/notification/page.tsx
@@ -1,12 +1,13 @@
-import React, { Suspense } from "react";
+import { Suspense } from "react";
 
-import NotificationContent from "./_components/NotificationContent";
+import Fallback from "./_components/Fallback";
+import NotificationContainer from "./_components/NotificationContainer";
 
 function NotificationPage() {
   return (
     <main className="h-full w-full">
-      <Suspense fallback={<span>loading...</span>}>
-        <NotificationContent />
+      <Suspense fallback={<Fallback />}>
+        <NotificationContainer />
       </Suspense>
     </main>
   );

--- a/docs/storybook/stories/Skeleton.stories.tsx
+++ b/docs/storybook/stories/Skeleton.stories.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "@5unwan/ui/components/Skeleton";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Skeleton> = {
+  component: Skeleton,
+  tags: ["autodocs"],
+  decorators: (Story) => (
+    <div className="bg-background-primary w-screen h-screen flex items-center justify-center">
+      <Story />
+    </div>
+  )
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="flex flex-col space-y-3">
+      <Skeleton className="h-[125px] w-[250px] rounded-xl" />
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-[250px]" />
+        <Skeleton className="h-4 w-[200px]" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/src/api/types/common.ts
+++ b/packages/core/src/api/types/common.ts
@@ -44,7 +44,7 @@ export type BaseMemberInfo = {
 };
 
 export type DetailedMemberInfo = BaseMemberInfo & {
-  birthdate: string;
+  birthDate: string;
   phoneNumber: string;
   profilePictureUrl: string;
 };
@@ -80,7 +80,7 @@ export type NotificationInfo = {
   refType: "예약" | "세션" | "트레이너 연동";
   notificationType: NotificationType;
   memberInfo: DetailedMemberInfo;
-  createdAt: string;
+  sendDate: string;
   content: string;
   isProcessed: boolean;
 };

--- a/packages/ui/src/components/NotificationItem/NotificationItem.tsx
+++ b/packages/ui/src/components/NotificationItem/NotificationItem.tsx
@@ -11,13 +11,13 @@ type Props = Omit<HTMLAttributes<HTMLLIElement>, "onClick"> & NotificationProps;
 type NotificationProps = {
   isCompleted: boolean;
   memberName?: string;
-  avatarSrc: string;
+  avatarSrc?: string;
   message: string;
   eventDate?: Date | string;
   eventDetail?: Date | string;
   createdAt: Date | string;
   variant: Variant;
-  onClick: MouseEventHandler<HTMLLIElement>;
+  onClick?: MouseEventHandler<HTMLLIElement>;
 };
 
 const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
@@ -31,11 +31,13 @@ const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
     eventDetail,
     variant,
     onClick,
+    className,
     ...commonProps
   } = props;
 
   const handleClick: MouseEventHandler<HTMLLIElement> = (e) => {
-    if (isCompleted) return;
+    if (isCompleted || !onClick) return;
+
     onClick(e);
   };
 
@@ -52,6 +54,7 @@ const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
         {
           "cursor-default": isCompleted,
         },
+        className,
       )}
       onClick={handleClick}
       {...commonProps}

--- a/packages/ui/src/components/NotificationItem/NotificationThumbnail.tsx
+++ b/packages/ui/src/components/NotificationItem/NotificationThumbnail.tsx
@@ -3,7 +3,7 @@ import { Variant } from "./variants";
 import { Avatar, AvatarFallback, AvatarImage } from "../../components/Avatar";
 
 type Props = {
-  avatarSrc: string;
+  avatarSrc?: string;
   variant: Variant;
   isCompleted: boolean;
 };

--- a/packages/ui/src/components/Skeleton.tsx
+++ b/packages/ui/src/components/Skeleton.tsx
@@ -1,0 +1,9 @@
+import { cn } from "@ui/lib/utils";
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn("bg-background-sub5/10 animate-pulse rounded-md", className)} {...props} />
+  );
+}
+
+export { Skeleton };


### PR DESCRIPTION
# [FLIZ-97/user] feat: 알림 페이지 구현

## 📝 작업 내용

회원 서비스 알림(notification) 페이지를 구현했습니다

1. Skeleton 공통 컴포넌트 구현
shadcn의 [Skeleton 컴포넌트](https://ui.shadcn.com/docs/components/skeleton)를 ui 패키지에 설치했습니다
Skeleton 공통 컴포넌트를 활용하여 notification 페이지 스켈레톤을 구현했습니다

2.  수정된 API에 맞게 notification domain DTO를 수정했습니다

3. NotificationItem 및 자식 컴포넌트의 props를 수정했습니다
optional 설정이 필요한 props에 대해 optional props로 수정했습니다

4. NotificationItem을 활용하여 페이지 UI를 설계했습니다

5. API 연결 및 Suspense 설정
API 로직을 연결했습니다. 또한 React Suspense로 비동기 작업이 있는 컴포넌트를 wrapping하여 비동기 상태에 따른 UI를 선언적으로 지정했습니다
- 예외처리의 경우 별도의 PR로 공통 ErrorBoundary를 구현할 예정입니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
