### PR TITLE
[FLIZ-176/ui] fix: Spinner 컴포넌트의 타입에러로 인한 빌드 에러 수정

### DIFF
--- a/packages/ui/src/components/Spinner.tsx
+++ b/packages/ui/src/components/Spinner.tsx
@@ -62,7 +62,9 @@ export default function Spinner({ size, className }: SpinnerProps) {
       {Array.from({ length: 8 }).map((_, index) => (
         <span
           key={SPINNER_KEYS[index]}
-          ref={(el) => (spinnerRefs.current[index] = el)}
+          ref={(el) => {
+            spinnerRefs.current[index] = el;
+          }}
           className={cn(spinnerVariants({ size }), className)}
           style={{
             transform: `rotate(${index * -ROTATION_DEGREE}deg) ${size === "small" ? "translateY(-0.5rem)" : "translateY(-0.625rem)"}`,


### PR DESCRIPTION
## 📝 작업 내용

Spinner 컴포넌트의 ref 콜백 함수가 반환하는 값의 타입이 void가 되도록 인라인 코드를 수정하였습니다.

