### PR TITLE
[FLIZ-187/user] fix: 유저 도메인의 tailwind.config content의 불필요한 파일 스캔 수정

### DIFF
--- a/apps/user/tailwind.config.ts
+++ b/apps/user/tailwind.config.ts
@@ -6,7 +6,7 @@ const config: Config = {
   content: [
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
-    "node_modules/@5unwan/ui/**/*.tsx",
+    "./node_modules/@5unwan/ui/dist/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   presets: [sharedConfig],
 };


### PR DESCRIPTION
## 📝 작업 내용

#109 PR은 트레이너 도메인의 tailwind.config content를 수정하였는데 PR 제목과 브랜치 생성을 user로 잘못 생성하였습니다.
유저 도메인의 tailwind.config content의 불필요한 파일 스캔을 수정하여 성능 저하를 방지하였습니다.
