### PR TITLE
[FLIZ-182/root] ci: 서비스 배포 fork repository ci/cd 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: ['dev']
+    branches: ["dev"]
 
 jobs:
   build:
@@ -23,8 +23,8 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
         with:
-          source-directory: 'output'
-          destination-github-username: yjc2021
+          source-directory: "output"
+          destination-github-username: choi-ik
           destination-repository-name: FitLink-FE
           user-email: ${{ secrets.EMAIL }}
           commit-message: ${{ github.event.commits[0].message }}


### PR DESCRIPTION
## 📝 작업 내용

vercel을 기반으로 서비스 배포할 fork repository cicd를 변경하였습니다.
기존 yjc2021 -> choi-ik으로 변경하여 제 개인 리포지토리에 싱크가 맞춰지도록 수정하였습니다.

