### PR TITLE
[FLIZ-193/root] chore:  root의 build.sh에서 기존에 output 폴더를 제거하던 로직 제거

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 cd ../
 # Ensure a clean slate
-rm -rf output
 mkdir output
 
 # Copy necessary content to the output directory


### PR DESCRIPTION
## 📝 작업 내용

root의 build.sh에서 기존에 output 폴더를 제거하던 로직 제거하여 개인 레포지토리로 PR merge를 반영할 때 기존에 존재하던 폴더를 삭제하던 이슈 해결
