### PR TITLE
[FLIZ-195/user] fix: 유저도메인 마이페이지 타입 에러로 인한 빌드 에러 수정

### DIFF
--- a/apps/user/app/my-page/page.tsx
+++ b/apps/user/app/my-page/page.tsx
@@ -19,6 +19,7 @@ import ScheduleInformationItem from "./_components/PTInformation/ScheduleInforma
 
 export default function MyPage() {
   const mockData: MyInformationApiResponse["data"] = {
+    connectingStatus: "CONNECTED", // 또는 올바른 기본값을 넣으세요.
     memberId: 1,
     name: "홍길동",
     trainerId: 1,


### PR DESCRIPTION
## 📝 작업 내용

유저 도메인 마이페이지의 목 데이터 타입 에러로 인한 빌드 에러를 수정하였습니다.
