### PR TITLE
[FLIZ-197/root] fix: deploy.yml cicd 로직에서 build.sh를 실행할 셸 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
         run: apk add ruby && gem install mustache
 
       - name: Prepare output
-        run: sh ./build.sh
+        run: bash ./build.sh
 
       - name: Pushes to another repository
         id: push_directory


### PR DESCRIPTION
## 📝 작업 내용

deploy.yml cicd 로직에서 build.sh를 실행할 셸 수정하여 build.sh가 bash에서 실행되도록 수정하였습니다.
