### PR TITLE
[FLIZ-202/root] fix: origin 레포의 모든 파일 및 폴더를 개인 레포에 복사하도록 build.sh 수정

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 cd ../
-mkdir output
+
+mkdir -p output
+
+cp -R ./FitLink-FE/.[!.]* ./output 2>/dev/null
 cp -R ./FitLink-FE/* ./output
 cp -R ./output ./FitLink-FE/


### PR DESCRIPTION
## 📝 작업 내용

origin 레포지토리의 모든 파일 및 폴더(dot 파일 및 숨김 파일)를 vercel을 사용하여 배포하기 위해 개인 레포로 복사하도록 build.sh 수정
