### PR TITLE
[FLIZ-204/root] chore: vercel이 터보레포의 환경 변수를 이해할 수 있도록 turbo.json의 globalEnv에 환경 변수 네이밍 추가

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["NODE_ENV"],
+  "globalEnv": ["NODE_ENV", "NEXT_PUBLIC_*"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## 📝 작업 내용

vercel이 터보레포의 환경 변수를 이해할 수 있도록 turbo.json의 globalEnv에 환경 변수 네이밍 추가
