### PR TITLE
[FLIZ-205/docs] fix: 스토리북의 user/Calendar 스토리의 잘못된 import 경로 수정

### DIFF
--- a/docs/storybook/stories/user/Calendar.stories.tsx
+++ b/docs/storybook/stories/user/Calendar.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import Calendar from "user/components/Calendar/index";
+import Calendar from "user/app/schedule-management/_components/Calendar/index";
 
 const meta: Meta<typeof Calendar> = {
   component: Calendar,


### PR DESCRIPTION
## 📝 작업 내용

스토리북의 `user/Calendar` 스토리의 잘못된 import 경로를 수정하여 스토리북 빌드 에러를 해결합니다.