### PR TITLE
[FLIZ-207/root] chore: husky, lint-staged 워크플로우 및 스크립트 작성

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,5 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm type-check
 pnpm lint-staged

--- a/apps/trainer/app/schedule-management/pending-reservations/page.tsx
+++ b/apps/trainer/app/schedule-management/pending-reservations/page.tsx
@@ -1,25 +1,26 @@
-import { ModifiedReservationListItem } from "@trainer/services/types/reservations.dto";
+/** TODO: 예약 대기 내역 구현이 완료되지 않아 에러 방지를 위한 주석 처리 */
+// import { ModifiedReservationListItem } from "@trainer/services/types/reservations.dto";
 
-import Header from "./_components/Header";
-import PendingReservationContainer from "./_components/PendingReservationContainer";
+// import Header from "./_components/Header";
+// // import PendingReservationContainer from "./_components/PendingReservationContainer";
 
-type PendingReservationsProps = {
-  searchParams: { members: string; selectedDate: string };
-};
-function PendingReservations({ searchParams }: PendingReservationsProps) {
-  const members: ModifiedReservationListItem[] = JSON.parse(
-    decodeURIComponent(searchParams.members),
-  );
+// type PendingReservationsProps = {
+//   searchParams: { members: string; selectedDate: string };
+// };
+// function PendingReservations({ searchParams }: PendingReservationsProps) {
+//   const members: ModifiedReservationListItem[] = JSON.parse(
+//     decodeURIComponent(searchParams.members),
+//   );
 
-  return (
-    <main className="flex h-full flex-col">
-      <Header />
-      <PendingReservationContainer
-        memberInformations={members}
-        selectedDate={searchParams.selectedDate}
-      />
-    </main>
-  );
-}
+//   return (
+//     <main className="flex h-full flex-col">
+//       <Header />
+//       {/* <PendingReservationContainer
+//         memberInformations={members}
+//         selectedDate={searchParams.selectedDate}
+//       /> */}
+//     </main>
+//   );
+// }
 
-export default PendingReservations;
+// export default PendingReservations;

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
-    "header-max-length": [2, "always", 100],
+    "header-max-length": [2, "always", 150],
     "subject-case": [0],
     "subject-empty": [2, "never"],
     "subject-full-stop": [2, "never", "."],

--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
     "prepare": "husky",
     "test": "turbo run test"
   },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
+  },
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "^19.6.0",


### PR DESCRIPTION
## 📝 작업 내용

- husky/pre-commit 워크플로우, root package.json의 lint-staged 스크립트를 작성하여 커밋 전 eslint 오류를 자동으로 수정가능 한 부분은 자동으로 수정(자동 수정 안되는 부분이 있다면 커밋이 안되고 직접 수정해야함)되게 설정하고, 타입 에러가 있을시 커밋이 되지 않도록 작성하였습니다.
- 커밋 내용의 limit 길이가 너무 짧은 것 같아 100 -> 150자로 늘렸습니다.
- 예약 대기 페이지에서 아직 만들어지지 않은 컴포넌트를 import하여 생기는 빌드 오류를 수정하였습니다.
