### PR TITLE
[FLIZ-211/user] feat: 유저 서비스 라우트 상수 정의

### DIFF
--- a/apps/user/app/my-page/_components/LogoutButton.tsx
+++ b/apps/user/app/my-page/_components/LogoutButton.tsx
@@ -13,7 +13,7 @@ import {
 import { useRouter } from "next/navigation";
 import React from "react";
 
-import { ROUTE } from "../_constants/route";
+import RouteInstance from "@user/constants/routes";
 
 export default function LogoutButton() {
   const router = useRouter();
@@ -21,7 +21,7 @@ export default function LogoutButton() {
   const handleClickLogout = () => {
     // TODO
     // 로그아웃 요청
-    router.push(ROUTE.LOGIN);
+    router.push(RouteInstance.login());
   };
 
   return (

--- a/apps/user/app/my-page/_components/PTInformation/ConnectedTrainerItem.tsx
+++ b/apps/user/app/my-page/_components/PTInformation/ConnectedTrainerItem.tsx
@@ -4,7 +4,7 @@ import { ChevronRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import React from "react";
 
-import { ROUTE } from "../../_constants/route";
+import RouteInstance from "@user/constants/routes";
 
 interface TrainerInformationProps {
   trainerName: string;
@@ -26,9 +26,11 @@ export default function ConnectedTrainerItem({ trainerName }: TrainerInformation
             trainerName ? "text-text-sub2" : "text-text-primary",
           )}
           onClick={() => {
-            trainerName
-              ? handleClickRouting(ROUTE.MY_TRAINER_INFORMATION)
-              : handleClickRouting(ROUTE.CONNECT_TRAINER);
+            handleClickRouting(
+              trainerName
+                ? RouteInstance["my-trainer-information"]()
+                : RouteInstance["connect-trainer"](),
+            );
           }}
         >
           {trainerName ? trainerName : "연동하기"}

--- a/apps/user/app/my-page/_components/ProfileHeader.tsx
+++ b/apps/user/app/my-page/_components/ProfileHeader.tsx
@@ -4,8 +4,9 @@ import React from "react";
 
 import { MyInformationApiResponse } from "@user/services/types/myInformation.dto";
 
+import RouteInstance from "@user/constants/routes";
+
 import LogoutButton from "./LogoutButton";
-import { ROUTE } from "../_constants/route";
 
 interface HeaderProps {
   userInformation: MyInformationApiResponse["data"];
@@ -23,7 +24,7 @@ export default function ProfileHeader({ userInformation }: HeaderProps) {
       <Profile>
         <Profile.Section
           onClick={() => {
-            handleClickRouting(ROUTE.MY_INFORMATION);
+            handleClickRouting(RouteInstance["my-information"]());
           }}
         >
           <Profile.Avatar name="홍길동" imageSrc={userInformation.profilePictureUrl} />

--- a/apps/user/app/my-page/_constants/route.ts
+++ b/apps/user/app/my-page/_constants/route.ts
@@ -1,8 +1,0 @@
-export const ROUTE = {
-  ROOT: "/my-page",
-  MY_INFORMATION: "/my-page/my-information",
-  MY_TRAINER_INFORMATION: "/my-page/my-trainer-information",
-  CONNECT_TRAINER: "/my-page/connect-trainer",
-  VERIFY_PHONE: "/my-page/my-information/verify-phone",
-  LOGIN: "/login",
-};

--- a/apps/user/app/my-page/my-information/_components/MemorizedChangePhoneLink.tsx
+++ b/apps/user/app/my-page/my-information/_components/MemorizedChangePhoneLink.tsx
@@ -3,7 +3,7 @@ import { ChevronRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import React from "react";
 
-import { ROUTE } from "../../_constants/route";
+import RouteInstance from "@user/constants/routes";
 
 interface MemorizedProfileLinkProps {
   value: string;
@@ -13,7 +13,7 @@ export const MemorizedChangePhoneLink = React.memo(({ value }: MemorizedProfileL
   const router = useRouter();
 
   const handleClickRoutingVerifyPhone = () => {
-    router.push(ROUTE.VERIFY_PHONE);
+    router.push(RouteInstance["verify-phone"]());
   };
 
   return (

--- a/apps/user/app/schedule-management/_components/BottomSheet/ReservationStatusSheet.tsx
+++ b/apps/user/app/schedule-management/_components/BottomSheet/ReservationStatusSheet.tsx
@@ -24,9 +24,10 @@ import { cn } from "@ui/lib/utils";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+import RouteInstance from "@user/constants/routes";
+
 import RequestSuccessSheet from "./RequestSuccessSheet";
 import ReservationCancelSheet from "./ReservationCancelSheet";
-import { ROUTES } from "../../_constants/route";
 
 type ReservationStatusSheetProps = {
   open: boolean;
@@ -62,7 +63,9 @@ function ReservationStatusSheet({
   };
 
   const handleClickChangeButton = () => {
-    router.push(`${ROUTES.ROOT}/${ROUTES.EDIT_RESERVATION}?${searchParams.toString()}`);
+    router.push(
+      RouteInstance.reservation("edit", { reservationDate: searchParams.get("reservationDate") }),
+    );
   };
 
   const handleClickRemindButton = () => {

--- a/apps/user/app/schedule-management/_components/ReservationAdder.tsx
+++ b/apps/user/app/schedule-management/_components/ReservationAdder.tsx
@@ -15,7 +15,8 @@ import Icon from "@ui/components/Icon";
 import { useRouter } from "next/navigation";
 import { ComponentPropsWithoutRef } from "react";
 
-import { ROUTES } from "../_constants/route";
+import RouteInstance from "@user/constants/routes";
+
 import { TrainerConnectStatus } from "../_types/addReservation";
 import { resolveTrainerConnectionFlow } from "../_utils/resolveTrainerConnectionFlow";
 
@@ -30,8 +31,9 @@ function ReservationAdder({ trainerConnectStatus, ptCount }: ReservationAdderPro
   /** TODO: 트레이너 연결 상태 추출 */
   // const { data: myInformation } = useSuspenseQuery(myInformationQueries.summary());
 
-  const onGoNewReservation = () => router.push(`${ROUTES.ROOT}/${ROUTES.NEW_RESERVATION}`);
-  const onRequestConnect = () => router.push(ROUTES.TRAINER_CODE);
+  const onGoNewReservation = () => router.push(RouteInstance.reservation("new"));
+
+  const onRequestConnect = () => router.push(RouteInstance["connect-trainer"]());
 
   const { popupData, onClickButton } = resolveTrainerConnectionFlow(
     trainerConnectStatus,

--- a/apps/user/app/schedule-management/_constants/route.ts
+++ b/apps/user/app/schedule-management/_constants/route.ts
@@ -1,6 +1,0 @@
-export const ROUTES = {
-  ROOT: "/schedule-management",
-  EDIT_RESERVATION: "/reservation/edit",
-  NEW_RESERVATION: "/reservation/new",
-  TRAINER_CODE: "/trainerCode",
-};

--- a/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/PtTimeSelector/ReservationRequestor.tsx
+++ b/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/PtTimeSelector/ReservationRequestor.tsx
@@ -4,7 +4,8 @@ import { useRouter } from "next/navigation";
 import RequestSuccessSheet, {
   RequestSucccessSheetTrigger,
 } from "@user/app/schedule-management/_components/BottomSheet/RequestSuccessSheet";
-import { ROUTES } from "@user/app/schedule-management/_constants/route";
+
+import RouteInstance from "@user/constants/routes";
 
 import { RequestReservationMode } from "@user/app/schedule-management/reservation/[mode]/types/requestReservation";
 
@@ -43,7 +44,7 @@ function ReservationRequestor({ mode, open, onChangeOpen, isActive }: Reservatio
 
   // TODO: selectedDate와 selectedTimes를 통해 예약 변경 요청 진행
   const handleClickRequestButton = () => {
-    router.push(ROUTES.ROOT);
+    router.push(RouteInstance.root());
   };
 
   return (

--- a/apps/user/components/Providers/FooterProvider.tsx
+++ b/apps/user/components/Providers/FooterProvider.tsx
@@ -4,12 +4,14 @@ import { cn } from "@ui/lib/utils";
 import { usePathname } from "next/navigation";
 import React from "react";
 
+import RouteInstance from "@user/constants/routes";
+
 import BottomNavigation from "../BottomNavigation";
 
 // TODO[2025.03.18]: user 모든 경로 분류하기
 const PATHS = {
-  WITH_FOOTER: new Set(["/", "/schedule-management"]),
-  WITHOUT_FOOTER: new Set(["/register", "/login"]),
+  WITH_FOOTER: new Set(["/", RouteInstance["schedule-management"]()]),
+  WITHOUT_FOOTER: new Set([RouteInstance.register(), RouteInstance.login()]),
 };
 
 const doesPathNeedFooter = (pathName: string) => PATHS.WITH_FOOTER.has(pathName);

--- a/apps/user/constants/routes.ts
+++ b/apps/user/constants/routes.ts
@@ -1,0 +1,93 @@
+/* eslint-disable no-magic-numbers */
+const ROUTE_DIVIDER = "/";
+const SEARCH_PARAMS_DIVIDER = "&";
+
+const filterEmptyDynamicRoute = (url: string | undefined, index: number) => {
+  if (index === 0) return true;
+
+  return url !== undefined;
+};
+
+const generateQueryString = (searchParams: Partial<{ [key: string]: string | null }>) => {
+  return (
+    Object.entries(searchParams)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      .filter(([_, value]) => value !== undefined || value !== null)
+      .map(([key, value]) => `${key}=${value!}`)
+      .join(SEARCH_PARAMS_DIVIDER)
+  );
+};
+
+class ROUTES {
+  private _root = () => [""];
+  private _login = () => [...this._root(), "login"];
+  private _register = () => [...this._root(), "register"];
+  private "_my-page" = () => [...this._root(), "my-page"];
+  private "_connect-trainer" = () => [...this["_my-page"](), "connect-trainer"];
+  private "_edit-workout-schedules" = () => [...this["_my-page"](), "edit-workout-schedules"];
+  private "_my-information" = () => [...this["_my-page"](), "my-information"];
+  private "_verify-phone" = () => [...this["_my-information"](), "verify-phone"];
+  private "_my-trainer-information" = () => [...this["_my-page"](), "my-trainer-information"];
+
+  private _notification = () => [...this._root(), "notification"];
+  private "_schedule-management" = () => [...this._root(), "schedule-management"];
+  private "_reservation" = (routeParams?: string) => [
+    ...this["_schedule-management"](),
+    "reservation",
+    routeParams,
+  ];
+
+  get root() {
+    return () => this._root().join(ROUTE_DIVIDER) + "/";
+  }
+  get login() {
+    return () => this._login().join(ROUTE_DIVIDER);
+  }
+  get register() {
+    return () => this._register().join(ROUTE_DIVIDER);
+  }
+  get "my-page"() {
+    return () => this["_my-page"]().join(ROUTE_DIVIDER);
+  }
+  get "connect-trainer"() {
+    return () => this["_connect-trainer"]().join(ROUTE_DIVIDER);
+  }
+  get "edit-workout-schedules"() {
+    return () => this["_edit-workout-schedules"]().join(ROUTE_DIVIDER);
+  }
+  get "my-information"() {
+    return () => this["_my-information"]().join(ROUTE_DIVIDER);
+  }
+  get "verify-phone"() {
+    return () => this["_verify-phone"]().join(ROUTE_DIVIDER);
+  }
+  get "my-trainer-information"() {
+    return () => this["_my-trainer-information"]().join(ROUTE_DIVIDER);
+  }
+  get notification() {
+    return () => this["_notification"]().join(ROUTE_DIVIDER);
+  }
+  get "schedule-management"() {
+    return () => this["_schedule-management"]().join(ROUTE_DIVIDER);
+  }
+  get reservation() {
+    return (
+      routeParams?: string,
+      searchParams?: {
+        reservationDate: string | null;
+      },
+    ) => {
+      const filteredRoute = this["_reservation"](routeParams).filter(filterEmptyDynamicRoute);
+      const beforeSearchParams = filteredRoute.slice(0, filteredRoute.length);
+      const queryString = searchParams && generateQueryString(searchParams);
+
+      return queryString
+        ? `${beforeSearchParams.join(ROUTE_DIVIDER)}?${queryString}`
+        : beforeSearchParams.join(ROUTE_DIVIDER);
+    };
+  }
+}
+
+const RouteInstance = new ROUTES();
+
+export default RouteInstance;


### PR DESCRIPTION
# [FLIZ-211/user] feat: 유저 서비스 라우트 상수 정의

## 📝 작업 내용

user 서비스에서 사용되는 route 상수를 관리하는 인스턴스를 구현 및 적용했습니다
- tanstack-query에서 사용되는 query key factory 방식에서 착안하여 user 서비스의 route 상수를 계층적으로 관리합니다. 이를 위해 각 경로의 구성 요소 (`/`를 기준으로 분리되는 문자열들)는 private 프로퍼티에 배열로 저장합니다
- 배열로 관리되는 경로를 실제로 사용할 때 다시 `/`로 join된 문자열을 받아야 하기 때문에 경로별로 getter를 정의하여 url 문자열을 만들어주는 로직을 주입했습니다
- 프로젝트 전역에서 ROUTES 인스턴스가 여러 개 생성되는 것을 방지하기 위해 싱글턴 패턴을 사용했습니다

기존 user의 각 경로에서 사용되던 _constants/route.ts 파일은 모두 제거했으며, 새로 정의한 RouteInstance로 교체했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
