### PR TITLE
[FLIZ-212/trainer] chore: 트레이너 도메인 RouteInstance 정의

### DIFF
--- a/apps/trainer/app/schedule-management/_components/MemberProfileCard/index.tsx
+++ b/apps/trainer/app/schedule-management/_components/MemberProfileCard/index.tsx
@@ -20,7 +20,7 @@ function MemberProfileCard({
 }: MemberProfileCardProps) {
   return (
     <ProfileCard
-      key={`${memberId}-${name}`}
+      key={`${memberId}-${userName}`}
       imgUrl={imgUrl}
       userBirth={userBirth}
       userName={userName}

--- a/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/ReservationPendingSheet.tsx
+++ b/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/ReservationPendingSheet.tsx
@@ -2,11 +2,11 @@
 
 import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle } from "@ui/components/Sheet";
 import DateController from "@ui/lib/DateController";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 import { ModifiedReservationListItem } from "@trainer/services/types/reservations.dto";
 
-import { ROUTES } from "@trainer/constants/route";
+import RouteInstance from "@trainer/constants/route";
 
 import TimeOptionList from "../TimeOptionList";
 
@@ -24,13 +24,15 @@ function ReservationPendingSheet({
   memberInformations,
 }: ReservationPendingSheetProps) {
   const router = useRouter();
-  const pathName = usePathname();
 
   const selectedFormatDate = DateController(selectedDate).toDateTimeWithDayFormat();
 
   const handleClickRoutePendingReservationPage = () => {
     router.push(
-      `${pathName}${ROUTES.PENDING_RESERVATIONS}?members=${encodeURIComponent(JSON.stringify(memberInformations))}&selectedDate=${selectedFormatDate}`,
+      RouteInstance["pending-reservations"]("", {
+        members: encodeURIComponent(JSON.stringify(memberInformations)),
+        selectedDate: selectedFormatDate,
+      }),
     );
   };
 

--- a/apps/trainer/app/schedule-management/_components/TimeOptionList.tsx
+++ b/apps/trainer/app/schedule-management/_components/TimeOptionList.tsx
@@ -13,7 +13,7 @@ import {
 } from "@ui/components/Sheet";
 import { useRouter } from "next/navigation";
 
-import { ROUTES } from "@trainer/constants/route";
+import RouteInstance from "@trainer/constants/route";
 
 import TimeOption from "./TimeOption";
 
@@ -23,25 +23,27 @@ type TimeOptionListProps = {
   onChangeOpen: (isOpen: boolean) => void;
 };
 
+type Route = keyof typeof RouteInstance;
+
 export default function TimeOptionList({
   // selectedDate,
   selectedFormatDate,
   onChangeOpen,
 }: TimeOptionListProps) {
-  const { ROOT } = ROUTES;
-
   const router = useRouter();
 
-  const handleClickTimeOption = (route: Exclude<keyof typeof ROUTES, "ROOT">) => {
+  const handleClickTimeOption = (
+    route: Extract<Route, "reservation" | "fixed-reservation" | "dayoff-management">,
+  ) => {
     switch (route) {
-      case "RESERVATION":
-        router.push(`${ROOT}${ROUTES[route]}?selectedDate=${selectedFormatDate}`);
+      case "reservation":
+        router.push(RouteInstance.reservation("", { selectedDate: selectedFormatDate }));
         break;
-      case "FIXED_RESERVATION":
-        router.push(`${ROOT}${ROUTES[route]}`);
+      case "fixed-reservation":
+        router.push(RouteInstance["fixed-reservation"]());
         break;
-      case "DATOFF_MANAGEMENT":
-        router.push(`${ROOT}${ROUTES[route]}`);
+      case "dayoff-management":
+        router.push(RouteInstance["dayoff-management"]());
     }
   };
 
@@ -56,14 +58,14 @@ export default function TimeOptionList({
   // TODO: 추후 각 TimeOption 클릭 시 이동할 페이지의 경로 Name이 정해지면 클릭 이벤트 추가
   return (
     <div className="mb-[1.625rem] ml-[1.063rem] mt-[1.25rem] flex items-center gap-1.5 overflow-x-auto [&::-webkit-scrollbar]:hidden">
-      <TimeOption onClick={() => handleClickTimeOption("RESERVATION")}>
+      <TimeOption onClick={() => handleClickTimeOption("reservation")}>
         <TimeOption.Icon iconName={"Dumbbell"} />
         <TimeOption.Content>
           <div>PT 예약</div>
         </TimeOption.Content>
       </TimeOption>
 
-      <TimeOption onClick={() => handleClickTimeOption("FIXED_RESERVATION")}>
+      <TimeOption onClick={() => handleClickTimeOption("fixed-reservation")}>
         <TimeOption.Icon iconName={"CalendarClock"} />
         <TimeOption.Content>
           <div>PT</div>
@@ -103,7 +105,7 @@ export default function TimeOptionList({
         </SheetContent>
       </Sheet>
 
-      <TimeOption onClick={() => handleClickTimeOption("DATOFF_MANAGEMENT")}>
+      <TimeOption onClick={() => handleClickTimeOption("dayoff-management")}>
         <TimeOption.Icon iconName={"CalendarMinus"} />
         <TimeOption.Content>
           <div>휴무일</div>

--- a/apps/trainer/app/schedule-management/dayoff-management/_components/DayoffCalendarContainer/DayoffAdderButton.tsx
+++ b/apps/trainer/app/schedule-management/dayoff-management/_components/DayoffCalendarContainer/DayoffAdderButton.tsx
@@ -13,7 +13,7 @@ import {
 import DateController from "@ui/lib/DateController";
 import { useRouter } from "next/navigation";
 
-import { ROUTES } from "@trainer/constants/route";
+import RouteInstance from "@trainer/constants/route";
 
 type DayoffAdderButtonProps = {
   selectedDate?: Date;
@@ -28,7 +28,7 @@ function DayoffAdderButton({ selectedDate }: DayoffAdderButtonProps) {
   const handleClickDayoffAdder = () => {
     // TODO: 휴무일 추가 API에 주입할 포맷 날짜 데이터
     // const validateDate = format(selectedDate, "yyyy-MM-dd");
-    router.push(ROUTES.ROOT);
+    router.push(RouteInstance["schedule-management"]());
   };
 
   return (

--- a/apps/trainer/app/schedule-management/fixed-reservation/_components/SelectTimeRouteButton.tsx
+++ b/apps/trainer/app/schedule-management/fixed-reservation/_components/SelectTimeRouteButton.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { Button } from "@ui/components/Button";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 import { PtUser } from "@trainer/services/types/userManagement.dto";
 
-import { ROUTES } from "@trainer/constants/route";
+import RouteInstance from "@trainer/constants/route";
 
 type SelectTimeRouteButtonProps = {
   selectedMemberInformation: PtUser | null;
@@ -13,11 +13,12 @@ type SelectTimeRouteButtonProps = {
 
 function SelectTimeRouteButton({ selectedMemberInformation }: SelectTimeRouteButtonProps) {
   const router = useRouter();
-  const pathName = usePathname();
 
   const handleClickRoute = () => {
     router.push(
-      `${pathName}${ROUTES.SELECT_PT_TIMES}?memberInformation=${encodeURIComponent(JSON.stringify(selectedMemberInformation as PtUser))}`,
+      RouteInstance["select-pt-times"]("", {
+        memberInformation: encodeURIComponent(JSON.stringify(selectedMemberInformation as PtUser)),
+      }),
     );
   };
 

--- a/apps/trainer/app/schedule-management/pending-reservations/page.tsx
+++ b/apps/trainer/app/schedule-management/pending-reservations/page.tsx
@@ -1,26 +1,27 @@
 /** TODO: 예약 대기 내역 구현이 완료되지 않아 에러 방지를 위한 주석 처리 */
-// import { ModifiedReservationListItem } from "@trainer/services/types/reservations.dto";
+import { ModifiedReservationListItem } from "@trainer/services/types/reservations.dto";
 
-// import Header from "./_components/Header";
-// // import PendingReservationContainer from "./_components/PendingReservationContainer";
+import Header from "./_components/Header";
+// import PendingReservationContainer from "./_components/PendingReservationContainer";
 
-// type PendingReservationsProps = {
-//   searchParams: { members: string; selectedDate: string };
-// };
-// function PendingReservations({ searchParams }: PendingReservationsProps) {
-//   const members: ModifiedReservationListItem[] = JSON.parse(
-//     decodeURIComponent(searchParams.members),
-//   );
+type PendingReservationsProps = {
+  searchParams: { members: string; selectedDate: string };
+};
+function PendingReservations({ searchParams }: PendingReservationsProps) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const members: ModifiedReservationListItem[] = JSON.parse(
+    decodeURIComponent(searchParams.members),
+  );
 
-//   return (
-//     <main className="flex h-full flex-col">
-//       <Header />
-//       {/* <PendingReservationContainer
-//         memberInformations={members}
-//         selectedDate={searchParams.selectedDate}
-//       /> */}
-//     </main>
-//   );
-// }
+  return (
+    <main className="flex h-full flex-col">
+      <Header />
+      {/* <PendingReservationContainer
+        memberInformations={members}
+        selectedDate={searchParams.selectedDate}
+      /> */}
+    </main>
+  );
+}
 
-// export default PendingReservations;
+export default PendingReservations;

--- a/apps/trainer/app/sns-verification/_components/ResultStep.tsx
+++ b/apps/trainer/app/sns-verification/_components/ResultStep.tsx
@@ -7,6 +7,8 @@ import React from "react";
 
 import { SignupRequestBody } from "@trainer/services/types/auth.dto";
 
+import RouteInstance from "@trainer/constants/route";
+
 import { useSignupForm } from "../_hooks/useSignupForm";
 
 type ResultStepProps = {
@@ -20,7 +22,7 @@ function ResultStep({ form }: ResultStepProps) {
 
   const handleClick = (status: "success" | "error") => {
     if (status === "success") {
-      router.replace("/");
+      router.replace(RouteInstance.root());
     } else if (status === "error") {
       onSubmit(form);
     }

--- a/apps/trainer/constants/route.ts
+++ b/apps/trainer/constants/route.ts
@@ -1,8 +1,148 @@
-export const ROUTES = {
-  ROOT: "/schedule-management",
-  RESERVATION: "/reservation",
-  FIXED_RESERVATION: "/fixed-reservation",
-  SELECT_PT_TIMES: "/select-pt-times",
-  DATOFF_MANAGEMENT: "/dayoff-management",
-  PENDING_RESERVATIONS: "/pending-reservations",
+/* eslint-disable no-magic-numbers */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// export const ROUTES = {
+//   ROOT: "/schedule-management",
+//   RESERVATION: "/reservation",
+//   FIXED_RESERVATION: "/fixed-reservation",
+//   SELECT_PT_TIMES: "/select-pt-times",
+//   DATOFF_MANAGEMENT: "/dayoff-management",
+//   PENDING_RESERVATIONS: "/pending-reservations",
+// };
+
+/**
+ * 라우트 컨벤션
+ * private 변수들은 접두사로 "_"를 붙인다.
+ * 라우트의 Key는 소문자로 현재 app 디렉토리 내 페이지 네이밍과 동일하게 짓는다.
+ */
+
+const ROUTE_DIVIDER = "/";
+const SEARCH_PARAMS_DIVIDER = "&";
+
+const filterEmptyDynamicRoute = (url: string | undefined, index: number) => {
+  if (index === 0) return true;
+
+  return url !== undefined;
 };
+
+const generateQueryString = (searchParams: Partial<{ [key: string]: string | null }>) => {
+  return (
+    Object.entries(searchParams)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      .filter(([_, value]) => value !== undefined || value !== null)
+      .map(([key, value]) => `${key}=${value!}`)
+      .join(SEARCH_PARAMS_DIVIDER)
+  );
+};
+
+class ROUTES {
+  private _root = () => [""];
+
+  private _login = () => [...this._root(), "login"];
+
+  private "_sns-verification" = () => [...this._root(), "sns-verification"];
+
+  private "_schedule-management" = () => [...this._root(), "schedule-management"];
+  private "_dayoff-management" = () => [...this["_schedule-management"](), "dayoff-management"];
+  private "_fixed-reservation" = () => [...this["_schedule-management"](), "fixed-reservation"];
+  private "_select-pt-times" = (routeParams?: string) => [
+    ...this["_fixed-reservation"](),
+    "select-pt-times",
+    routeParams,
+  ];
+  private "_pending-reservations" = (routeParams?: string) => [
+    ...this["_schedule-management"](),
+    "pending-reservations",
+    routeParams,
+  ];
+  private "_reservation" = (routeParams?: string) => [
+    ...this["_schedule-management"](),
+    "reservation",
+    routeParams,
+  ];
+
+  get root() {
+    return () => {
+      return this._root().join(ROUTE_DIVIDER) + "/";
+    };
+  }
+  get login() {
+    return () => {
+      return this._login().join(ROUTE_DIVIDER);
+    };
+  }
+  get "sns-verification"() {
+    return () => {
+      return this["_sns-verification"]().join(ROUTE_DIVIDER);
+    };
+  }
+  get "schedule-management"() {
+    return () => {
+      return this["_schedule-management"]().join(ROUTE_DIVIDER);
+    };
+  }
+  get "dayoff-management"() {
+    return () => {
+      return this["_dayoff-management"]().join(ROUTE_DIVIDER);
+    };
+  }
+  get "fixed-reservation"() {
+    return () => {
+      return this["_fixed-reservation"]().join(ROUTE_DIVIDER);
+    };
+  }
+  get "select-pt-times"() {
+    return (
+      routeParams?: string,
+      searchParams?: {
+        memberInformation: string | null;
+      },
+    ) => {
+      const filteredRoute = this["_select-pt-times"](routeParams).filter(filterEmptyDynamicRoute);
+      const beforeSearchParams = filteredRoute.slice(0, filteredRoute.length);
+      const queryString = searchParams && generateQueryString(searchParams);
+
+      return queryString
+        ? `${beforeSearchParams.join(ROUTE_DIVIDER)}?${queryString}`
+        : beforeSearchParams.join(ROUTE_DIVIDER);
+    };
+  }
+  get "pending-reservations"() {
+    return (
+      routeParams?: string,
+      searchParams?: {
+        members: string | null;
+        selectedDate: string | null;
+      },
+    ) => {
+      const filteredRoute =
+        this["_pending-reservations"](routeParams).filter(filterEmptyDynamicRoute);
+      const beforeSearchParams = filteredRoute.slice(0, filteredRoute.length);
+      const queryString = searchParams && generateQueryString(searchParams);
+
+      return queryString
+        ? `${beforeSearchParams.join(ROUTE_DIVIDER)}?${queryString}`
+        : beforeSearchParams.join(ROUTE_DIVIDER);
+    };
+  }
+  get reservation() {
+    return (
+      routeParams?: string,
+      searchParams?: {
+        selectedDate: string | null;
+      },
+    ) => {
+      const filteredRoute = this["_reservation"](routeParams).filter(filterEmptyDynamicRoute);
+      const beforeSearchParams = filteredRoute.slice(0, filteredRoute.length);
+      const queryString = searchParams && generateQueryString(searchParams);
+
+      return queryString
+        ? `${beforeSearchParams.join(ROUTE_DIVIDER)}?${queryString}`
+        : beforeSearchParams.join(ROUTE_DIVIDER);
+    };
+  }
+}
+
+const RouteInstance = new ROUTES();
+
+export default RouteInstance;


### PR DESCRIPTION
## 📝 작업 내용

### 트레이너 도메인 경로 RouteInstance 정의
트레이너 도메인의 경로를 `_constants` 폴더 내부에 정의하였습니다.
라우팅을 계층적으로 관리할 수 있도록 설계하였으며, routeParams/searchParams를 하드코딩하지 않고 주입할 수 있습니다.

다만, 매번 경로가 새로 생성될때마다 개발자가 직접 RouteInstance에 경로를 직접 추가해주어야 합니다. 해당 사항에 대해서는 좀 더 개선책이 있는지 찾아볼 예정입니다.

route.ts에 삭제하지 않은 주석은 혹시 제가 이번 Task에서 Route 관련 메소드를 사용하고 있는 곳에 RouteInstance를 적용하지 않은 곳이 있을 수 있을 것 같아 남겨둔 것으로, 해당 PR이 머지되기 직전 제거할 예정입니다.

## 💬 리뷰 요구사항(선택)

RouteInstance가 계층적으로 잘 관리되고 있는지 체크해주시면 감사하겠습니다.