### PR TITLE
[FLIZ-214/docs] fix: 스토리북 빌드 에러 해결

### DIFF
--- a/docs/storybook/.eslintrc.js
+++ b/docs/storybook/.eslintrc.js
@@ -1,7 +1,11 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
-  extends: ['@5unwan/eslint-config/react-internal.js', 'plugin:storybook/recommended'],
+  extends: ["@5unwan/eslint-config/react-internal", "plugin:storybook/recommended"],
   env: {
     browser: true,
+  },
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ["./tsconfig.json"],
   },
 };

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -2,7 +2,6 @@
   "name": "@5unwan/storybook",
   "private": true,
   "version": "0.0.0",
-  "type": "module",
   "scripts": {
     "dev": "storybook dev -p 6006",
     "build": "storybook build",

--- a/docs/storybook/stories/trainer/Calendar.stories.tsx
+++ b/docs/storybook/stories/trainer/Calendar.stories.tsx
@@ -1,6 +1,6 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import Calendar from "trainer/app/schedule-management/_components/Calendar/index";
 
-import Calendar from "trainer/components/Calendar/index";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Calendar> = {
   component: Calendar,

--- a/docs/storybook/stories/trainer/ScheduleBottomSheet.stories.tsx
+++ b/docs/storybook/stories/trainer/ScheduleBottomSheet.stories.tsx
@@ -1,5 +1,6 @@
+import ScheduleBottomSheet from "trainer/app/schedule-management/_components/ScheduleBottomSheet";
+
 import type { Meta, StoryObj } from "@storybook/react";
-import ScheduleBottomSheet from "trainer/components/ScheduleBottomSheet";
 
 const meta: Meta<typeof ScheduleBottomSheet> = {
   component: ScheduleBottomSheet,

--- a/docs/storybook/stories/trainer/TimeOption.stories.tsx
+++ b/docs/storybook/stories/trainer/TimeOption.stories.tsx
@@ -1,7 +1,6 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import { CalendarClock, CalendarMinus2, CalendarX2, Dumbbell } from "lucide-react";
+import TimeOption from "trainer/app/schedule-management/_components/TimeOption";
 
-import TimeOption from "trainer/components/TimeOption";
+import type { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof TimeOption> = {
   component: TimeOption,


### PR DESCRIPTION
## 📝 작업 내용

### 스토리북 빌드 에러 해결
- 트레이너 도메인에서 컴포넌트의 위치 변경에 따라 스토리북에서 잘못된 경로로 import 하던 것을 올바른 경로로 수정하였습니다.
- eslint가 스토리북 내에 위치한 tsconfig.json을 참조할 수 있도록 parserOptions를 설정하였습니다.
- eslintrc의 확장자가 `.js`로 되어있어 esm 방식으로 동작하지 못하던 에러를 docs/package.json의 type 프로퍼티를 제거하여 해결하였습니다.