### PR TITLE
[FLIZ-215/trainer] feat: 트레이너 도메인의 예약 대기자를 확인하고 예약을 승인할 수 있는 페이지 구현

### DIFF
--- a/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/ReservationPendingSheet.tsx
+++ b/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/ReservationPendingSheet.tsx
@@ -43,7 +43,7 @@ function ReservationPendingSheet({
           <SheetTitle className="flex justify-center">{selectedFormatDate}</SheetTitle>
         </SheetHeader>
         <div
-          className="text-body-1 bg-background-sub1 flex h-[5.625rem] w-full items-center justify-center rounded-[0.625rem]"
+          className="text-body-1 bg-background-sub1 flex h-[5.625rem] w-full cursor-pointer items-center justify-center rounded-[0.625rem]"
           onClick={handleClickRoutePendingReservationPage}
         >
           해당 시간에 PT 예약을 요청한 회원은

--- a/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/ApproveButton.tsx
+++ b/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/ApproveButton.tsx
@@ -1,0 +1,57 @@
+import { Button } from "@ui/components/Button";
+import Icon from "@ui/components/Icon";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@ui/components/Sheet";
+import { FormEvent } from "react";
+
+import { ReservationDetailPendingStatus } from "@trainer/services/types/reservations.dto";
+
+type ApproveButtonProps = {
+  selectedMemberInformation: ReservationDetailPendingStatus | null;
+  selectedDate: string;
+};
+
+function ApproveButton({ selectedMemberInformation, selectedDate }: ApproveButtonProps) {
+  /** TODO: 선택된 회원 정보로 예약 승인 API 요청 */
+  const handleSubmitApproveReservation = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <form onSubmit={handleSubmitApproveReservation}>
+          <Button disabled={selectedMemberInformation === null} className="w-full" size={"xl"}>
+            승인
+          </Button>
+        </form>
+      </SheetTrigger>
+      <SheetContent side={"bottom"} className="md:max-w-mobile left-1/2 w-full -translate-x-1/2">
+        <SheetHeader className="flex items-center">
+          <div className="bg-brand-primary-500 mb-7 flex h-[3.125rem] w-[3.125rem] items-center justify-center rounded-full">
+            <Icon name="Check" size="lg" />
+          </div>
+          <SheetTitle>{selectedDate}</SheetTitle>
+          <SheetDescription>
+            {selectedMemberInformation?.name} 회원의 PT 수업 예약이 완료되었습니다.
+          </SheetDescription>
+        </SheetHeader>
+        <SheetFooter>
+          <SheetClose asChild>
+            <Button className="h-[3.375rem] w-full">확인</Button>
+          </SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export default ApproveButton;

--- a/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/MemberCardList.tsx
+++ b/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/MemberCardList.tsx
@@ -2,6 +2,8 @@
 import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from "@ui/components/Dropdown";
 import Icon from "@ui/components/Icon";
 import { cn } from "@ui/lib/utils";
+import { format, parse } from "date-fns";
+import { ko } from "date-fns/locale";
 
 import MemberProfileCard from "@trainer/app/schedule-management/_components/MemberProfileCard";
 
@@ -16,6 +18,7 @@ import { DAYS } from "@trainer/constants/Day";
 import { formatContinuousTimes } from "../../_utils/formatContinuousTimes";
 
 type MemberCardListProps = {
+  selectedDate?: string;
   hasOtherReservations: boolean;
   selectedMemberInformation: ReservationDetailPendingStatus | null;
   onChangeSelectMemberInformation: (
@@ -27,17 +30,28 @@ function MemberCardList({
   hasOtherReservations,
   selectedMemberInformation,
   onChangeSelectMemberInformation,
+  selectedDate,
 }: MemberCardListProps) {
   /**
    * TODO: memberId를 통해 회원 상세 정보를 리스트로 가져와 PT 가능 시간을 프로필카드 Dropdown에 나타내기
    * TODO: reservationDate를 통해 상세 대기 목록을 모두 가져오기
    */
 
-  const formatedTime = (date: string[]) => {
+  const formatedTime = (dates: string[]) => {
     if (!hasOtherReservations) return undefined;
-    if (date.length === 1) return undefined;
+    if (dates.length === 1) return undefined;
 
-    return date[1].split("T")[1];
+    if (selectedDate) {
+      const parsedDate = parse(selectedDate, "M. d (E) HH:mm", new Date(), {
+        locale: ko,
+      });
+
+      const timeOnly = format(parsedDate, "HH:mm");
+
+      return dates.filter((date) => date.split("T")[1] !== timeOnly)[0].split("T")[1];
+    }
+
+    return undefined;
   };
 
   const handleClickMemberCard = (memberId: number) => () => {
@@ -60,8 +74,6 @@ function MemberCardList({
         );
 
         if (hasOtherReservations && reservationDates.length === 1) return;
-
-        hasOtherReservations && reservationDates.length > 1 && console.log(reservationDates[1]);
 
         return (
           <MemberProfileCard
@@ -127,7 +139,7 @@ const MOCK_PENDING_MEMBERS: ReservationDetailPendingStatusApiResponse["data"] = 
       phoneNumber: "01057645507",
       profilePictureUrl: "https://",
       reservationId: 11,
-      reservationDates: ["2025-02-12T18:00", "2025-02-12T20:00"],
+      reservationDates: ["2025-04-28T15:00", "2025-04-28T20:00"],
       dayOfWeek: "MONDAY",
     },
     {
@@ -137,7 +149,7 @@ const MOCK_PENDING_MEMBERS: ReservationDetailPendingStatusApiResponse["data"] = 
       phoneNumber: "01057645507",
       profilePictureUrl: "https://",
       reservationId: 11,
-      reservationDates: ["2025-02-12T18:00", "2025-02-12T20:00"],
+      reservationDates: ["2025-04-28T15:00", "2025-04-28T19:00"],
       dayOfWeek: "MONDAY",
     },
   ],

--- a/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/MemberCardList.tsx
+++ b/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/MemberCardList.tsx
@@ -1,0 +1,297 @@
+/* eslint-disable no-magic-numbers */
+import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from "@ui/components/Dropdown";
+import Icon from "@ui/components/Icon";
+import { cn } from "@ui/lib/utils";
+
+import MemberProfileCard from "@trainer/app/schedule-management/_components/MemberProfileCard";
+
+import {
+  ReservationDetailPendingStatus,
+  ReservationDetailPendingStatusApiResponse,
+} from "@trainer/services/types/reservations.dto";
+import { PtUserDetailApiResponse } from "@trainer/services/types/userManagement.dto";
+
+import { DAYS } from "@trainer/constants/Day";
+
+import { formatContinuousTimes } from "../../_utils/formatContinuousTimes";
+
+type MemberCardListProps = {
+  hasOtherReservations: boolean;
+  selectedMemberInformation: ReservationDetailPendingStatus | null;
+  onChangeSelectMemberInformation: (
+    memberInformation: ReservationDetailPendingStatus | null,
+  ) => void;
+};
+
+function MemberCardList({
+  hasOtherReservations,
+  selectedMemberInformation,
+  onChangeSelectMemberInformation,
+}: MemberCardListProps) {
+  /**
+   * TODO: memberId를 통해 회원 상세 정보를 리스트로 가져와 PT 가능 시간을 프로필카드 Dropdown에 나타내기
+   * TODO: reservationDate를 통해 상세 대기 목록을 모두 가져오기
+   */
+
+  const formatedTime = (date: string[]) => {
+    if (!hasOtherReservations) return undefined;
+    if (date.length === 1) return undefined;
+
+    return date[1].split("T")[1];
+  };
+
+  const handleClickMemberCard = (memberId: number) => () => {
+    if (hasOtherReservations) return;
+
+    const parsedMemberInformation = MOCK_PENDING_MEMBERS.waitingMembers.find(
+      (memberInformation) => memberInformation.memberId === memberId,
+    );
+
+    onChangeSelectMemberInformation(parsedMemberInformation || null);
+  };
+
+  return (
+    <section className="flex flex-col gap-[0.625rem] pt-[0.625rem]">
+      {MOCK_PENDING_MEMBERS.waitingMembers.map((memberInfo) => {
+        const { memberId, name, birthDate, profilePictureUrl, phoneNumber, reservationDates } =
+          memberInfo;
+        const userInformation = MOCK_MEMBER_DETAIL_INFORMATIONS.find(
+          (memberInformation) => memberInformation.memberId === memberId,
+        );
+
+        if (hasOtherReservations && reservationDates.length === 1) return;
+
+        hasOtherReservations && reservationDates.length > 1 && console.log(reservationDates[1]);
+
+        return (
+          <MemberProfileCard
+            key={`${memberId}-${name}`}
+            memberId={memberId}
+            imgUrl={profilePictureUrl}
+            userBirth={new Date(birthDate)}
+            userName={name}
+            phoneNumber={phoneNumber}
+            PTReservationOtherTime={formatedTime(reservationDates)}
+            className={cn(
+              !hasOtherReservations &&
+                selectedMemberInformation?.memberId === memberId &&
+                "border-brand-primary-500 border",
+            )}
+            onClick={handleClickMemberCard(memberId)}
+          >
+            <Dropdown>
+              <DropdownTrigger asChild>
+                <div className="flex cursor-pointer items-center gap-2">
+                  <p>PT 희망 시간</p>
+                  <Icon name="ChevronDown" size="md" />
+                </div>
+              </DropdownTrigger>
+              <DropdownContent>
+                {userInformation?.workoutSchedules.map(
+                  ({ workoutScheduleId, dayOfWeek, preferenceTimes }) => (
+                    <DropdownItem key={workoutScheduleId} className="flex items-start gap-2">
+                      <span>{DAYS[dayOfWeek]}</span>
+                      <span className="w-full whitespace-pre-line">
+                        {formatContinuousTimes(preferenceTimes)}
+                      </span>
+                    </DropdownItem>
+                  ),
+                )}
+              </DropdownContent>
+            </Dropdown>
+          </MemberProfileCard>
+        );
+      })}
+    </section>
+  );
+}
+
+export default MemberCardList;
+
+const MOCK_PENDING_MEMBERS: ReservationDetailPendingStatusApiResponse["data"] = {
+  waitingMembers: [
+    {
+      memberId: 5,
+      name: "홍길동",
+      birthDate: "1996-07-13",
+      phoneNumber: "01057145507",
+      profilePictureUrl: "https://",
+      reservationId: 11,
+      reservationDates: ["2025-02-12T18:00"],
+      dayOfWeek: "MONDAY",
+    },
+    {
+      memberId: 7,
+      name: "김민수",
+      birthDate: "1998-10-13",
+      phoneNumber: "01057645507",
+      profilePictureUrl: "https://",
+      reservationId: 11,
+      reservationDates: ["2025-02-12T18:00", "2025-02-12T20:00"],
+      dayOfWeek: "MONDAY",
+    },
+    {
+      memberId: 15,
+      name: "하제홍",
+      birthDate: "1998-10-13",
+      phoneNumber: "01057645507",
+      profilePictureUrl: "https://",
+      reservationId: 11,
+      reservationDates: ["2025-02-12T18:00", "2025-02-12T20:00"],
+      dayOfWeek: "MONDAY",
+    },
+  ],
+};
+
+const MOCK_MEMBER_DETAIL_INFORMATIONS: PtUserDetailApiResponse["data"][] = [
+  {
+    memberId: 5,
+    name: "홍길동",
+    birthDate: "2002-01-12",
+    phoneNumber: "01028321232",
+    connectingStatus: "CONNECTED", // CONNECTED(연동 완료) -> 무조건 CONNECTED 상태만 조회
+    profilePictureUrl: "asdasd@asdasd.com",
+    sessionInfo: {
+      sessionInfoId: 1,
+      totalCount: 1,
+      remainingCount: 2,
+    },
+    workoutSchedules: [
+      {
+        workoutScheduleId: 1,
+        dayOfWeek: "MONDAY",
+        preferenceTimes: ["10:00", "11:00", "12:00", "14:00", "15:00", "20:00", "21:00", "24:00"],
+      },
+      {
+        workoutScheduleId: 2,
+        dayOfWeek: "TUESDAY",
+        preferenceTimes: ["10:00", "11:00", "12:00", "14:00", "15:00", "20:00", "21:00", "24:00"],
+      },
+      {
+        workoutScheduleId: 3,
+        dayOfWeek: "WEDNESDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 4,
+        dayOfWeek: "THURSDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 5,
+        dayOfWeek: "FRIDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 6,
+        dayOfWeek: "SATURDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 7,
+        dayOfWeek: "SUNDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+    ],
+  },
+  {
+    memberId: 7,
+    name: "김민수",
+    birthDate: "2002-01-12",
+    phoneNumber: "01028321232",
+    connectingStatus: "CONNECTED", // CONNECTED(연동 완료) -> 무조건 CONNECTED 상태만 조회
+    profilePictureUrl: "asdasd@asdasd.com",
+    sessionInfo: {
+      sessionInfoId: 1,
+      totalCount: 1,
+      remainingCount: 2,
+    },
+    workoutSchedules: [
+      {
+        workoutScheduleId: 1,
+        dayOfWeek: "MONDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 2,
+        dayOfWeek: "TUESDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 3,
+        dayOfWeek: "WEDNESDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 4,
+        dayOfWeek: "THURSDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 5,
+        dayOfWeek: "FRIDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 6,
+        dayOfWeek: "SATURDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 7,
+        dayOfWeek: "SUNDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+    ],
+  },
+  {
+    memberId: 15,
+    name: "하제홍",
+    birthDate: "2002-01-12",
+    phoneNumber: "01028321232",
+    connectingStatus: "CONNECTED", // CONNECTED(연동 완료) -> 무조건 CONNECTED 상태만 조회
+    profilePictureUrl: "asdasd@asdasd.com",
+    sessionInfo: {
+      sessionInfoId: 1,
+      totalCount: 1,
+      remainingCount: 2,
+    },
+    workoutSchedules: [
+      {
+        workoutScheduleId: 1,
+        dayOfWeek: "MONDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 2,
+        dayOfWeek: "TUESDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 3,
+        dayOfWeek: "WEDNESDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 4,
+        dayOfWeek: "THURSDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 5,
+        dayOfWeek: "FRIDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 6,
+        dayOfWeek: "SATURDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+      {
+        workoutScheduleId: 7,
+        dayOfWeek: "SUNDAY",
+        preferenceTimes: ["10:00", "12:00"],
+      },
+    ],
+  },
+];

--- a/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/index.tsx
+++ b/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/index.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { useState } from "react";
+
+import {
+  ModifiedReservationListItem,
+  ReservationDetailPendingStatus,
+} from "@trainer/services/types/reservations.dto";
+
+import ApproveButton from "./ApproveButton";
+import MemberCardList from "./MemberCardList";
+
+type PendingReservationContainerProps = {
+  memberInformations: ModifiedReservationListItem[];
+  selectedDate: string;
+};
+
+function PendingReservationContainer({
+  memberInformations,
+  selectedDate,
+}: PendingReservationContainerProps) {
+  const [selectedMemberInformation, setSelectedMemberInformation] =
+    useState<ReservationDetailPendingStatus | null>(null);
+
+  return (
+    <section className="flex h-full w-full flex-col overflow-hidden pt-[1.688rem]">
+      <section className="bg-background-sub1 flex h-[5.625rem] w-full flex-col items-center justify-center gap-[0.625rem] rounded-[0.625rem] px-[1.938rem] py-[1.125rem]">
+        <p className="text-headline">{selectedDate}</p>
+        <p className="text-body-1">
+          해당 시간에 PT 예약을 요청한 회원
+          <span className="bg-brand-secondary-500 text-body-1 text-text-sub5 mx-1 rounded-[0.625rem] px-[0.625rem] py-1">
+            {memberInformations.length}명
+          </span>{" "}
+          입니다
+        </p>
+      </section>
+      <section className="mb-[0.625rem] mt-[1.563rem] flex h-full flex-col overflow-y-auto [&::-webkit-scrollbar]:hidden">
+        <p className="text-body-3  w-full text-left">해당 시간에만 가능한 회원</p>
+        <MemberCardList
+          hasOtherReservations={false}
+          selectedMemberInformation={selectedMemberInformation}
+          onChangeSelectMemberInformation={setSelectedMemberInformation}
+        />
+        <p className="text-body-3 mt-[1.563rem] w-full text-left">다른 시간에도 가능한 회원</p>
+        <MemberCardList
+          hasOtherReservations={true}
+          selectedMemberInformation={selectedMemberInformation}
+          onChangeSelectMemberInformation={setSelectedMemberInformation}
+        />
+      </section>
+      <ApproveButton
+        selectedMemberInformation={selectedMemberInformation}
+        selectedDate={selectedDate}
+      />
+    </section>
+  );
+}
+
+export default PendingReservationContainer;

--- a/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/index.tsx
+++ b/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/index.tsx
@@ -42,6 +42,7 @@ function PendingReservationContainer({
         />
         <p className="text-body-3 mt-[1.563rem] w-full text-left">다른 시간에도 가능한 회원</p>
         <MemberCardList
+          selectedDate={selectedDate}
           hasOtherReservations={true}
           selectedMemberInformation={selectedMemberInformation}
           onChangeSelectMemberInformation={setSelectedMemberInformation}

--- a/apps/trainer/app/schedule-management/pending-reservations/_utils/formatContinuousTimes.ts
+++ b/apps/trainer/app/schedule-management/pending-reservations/_utils/formatContinuousTimes.ts
@@ -1,0 +1,43 @@
+/* eslint-disable no-magic-numbers */
+
+type Range = [start: number, end: number];
+
+export const formatContinuousTimes = (times: string[]): string => {
+  const toMinutes = (t: string): number => {
+    const [h, m] = t.split(":").map(Number);
+
+    return h * 60 + m;
+  };
+
+  const toTimeString = (mins: number): string => {
+    const hh = String(Math.floor(mins / 60)).padStart(2, "0");
+    const mm = String(mins % 60).padStart(2, "0");
+
+    return `${hh}:${mm}`;
+  };
+
+  if (times.length === 0) return "";
+
+  const sorted = times.map(toMinutes).sort((a, b) => a - b);
+
+  const ranges = sorted.reduce<Range[]>((acc, curr) => {
+    if (acc.length === 0) {
+      return [[curr, curr]];
+    }
+
+    const lastRange = acc[acc.length - 1];
+    const [start, end] = lastRange;
+
+    if (curr - end === 60) {
+      return [...acc.slice(0, -1), [start, curr]];
+    } else {
+      return [...acc, [curr, curr]];
+    }
+  }, []);
+
+  return ranges
+    .map(([start, end]) =>
+      start === end ? toTimeString(start) : `${toTimeString(start)} ~ ${toTimeString(end)}`,
+    )
+    .join("\n");
+};

--- a/apps/trainer/app/schedule-management/pending-reservations/page.tsx
+++ b/apps/trainer/app/schedule-management/pending-reservations/page.tsx
@@ -2,13 +2,13 @@
 import { ModifiedReservationListItem } from "@trainer/services/types/reservations.dto";
 
 import Header from "./_components/Header";
-// import PendingReservationContainer from "./_components/PendingReservationContainer";
+import PendingReservationContainer from "./_components/PendingReservationContainer";
 
 type PendingReservationsProps = {
   searchParams: { members: string; selectedDate: string };
 };
+
 function PendingReservations({ searchParams }: PendingReservationsProps) {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const members: ModifiedReservationListItem[] = JSON.parse(
     decodeURIComponent(searchParams.members),
   );
@@ -16,10 +16,10 @@ function PendingReservations({ searchParams }: PendingReservationsProps) {
   return (
     <main className="flex h-full flex-col">
       <Header />
-      {/* <PendingReservationContainer
+      <PendingReservationContainer
         memberInformations={members}
         selectedDate={searchParams.selectedDate}
-      /> */}
+      />
     </main>
   );
 }

--- a/apps/trainer/constants/Day.ts
+++ b/apps/trainer/constants/Day.ts
@@ -1,0 +1,9 @@
+export const DAYS = {
+  MONDAY: "월",
+  TUESDAY: "화",
+  WEDNESDAY: "수",
+  THURSDAY: "목",
+  FRIDAY: "금",
+  SATURDAY: "토",
+  SUNDAY: "일",
+};

--- a/apps/trainer/services/types/reservations.dto.ts
+++ b/apps/trainer/services/types/reservations.dto.ts
@@ -51,12 +51,12 @@ type ReservationDetailStatusResponse = BaseReservationDetail<
 export type ReservationDetailStatusApiResponse = ResponseBase<ReservationDetailStatusResponse>;
 
 export type ReservationDetailPendingStatusRequestPath = ReservationPathParams;
+export type ReservationDetailPendingStatus = DetailedMemberInfo &
+  Pick<BaseReservationListItem, "reservationId" | "dayOfWeek"> & {
+    reservationDates: string[];
+  };
 type ReservationDetailPendingStatusResponse = {
-  waitingMembers: DetailedMemberInfo &
-    Pick<BaseReservationListItem, "reservationId" | "dayOfWeek"> &
-    {
-      reservationDates: string[];
-    }[];
+  waitingMembers: Array<ReservationDetailPendingStatus>;
 };
 export type ReservationDetailPendingStatusApiResponse =
   ResponseBase<ReservationDetailPendingStatusResponse>;

--- a/apps/trainer/services/types/userManagement.dto.ts
+++ b/apps/trainer/services/types/userManagement.dto.ts
@@ -30,6 +30,7 @@ export type PtUserListApiResponse = ResponseBase<PtUserListResponse>;
 
 export type PtUserDetailRequestPath = { memberId: number };
 type PtUserDetailResponse = Omit<PtUser, "totalCount" | "remainingCount"> & {
+  connectingStatus: "CONNECTED";
   profilePictureUrl: string;
   sessionInfo: SessionInfo;
   workoutSchedules: PreferredWorkout[];

--- a/packages/core/src/api/types/common.ts
+++ b/packages/core/src/api/types/common.ts
@@ -25,6 +25,7 @@ export type SessionInfo = {
   remainingCount: number;
 };
 export type PreferredWorkout = {
+  workoutScheduleId: number;
   dayOfWeek: DayOfWeek;
   preferenceTimes: string[];
 };

--- a/packages/ui/src/components/FunnelSteps/WorkoutScheduleStep.tsx
+++ b/packages/ui/src/components/FunnelSteps/WorkoutScheduleStep.tsx
@@ -6,7 +6,7 @@ import WorkoutForm from "@ui/components/WorkoutForm";
 const TIME_CELL_SPAN = 50;
 
 type WorkoutScheduleStepProps = {
-  onNext: (workoutSchedule: PreferredWorkout[]) => void;
+  onNext: (workoutSchedule: Omit<PreferredWorkout, "workoutScheduleId">[]) => void;
 };
 function WorkoutScheduleStep({ onNext }: WorkoutScheduleStepProps) {
   return (

--- a/packages/ui/src/components/WorkoutForm.tsx
+++ b/packages/ui/src/components/WorkoutForm.tsx
@@ -26,7 +26,7 @@ const generateTimeCells: (dayOfWeek: Days) => TimeCell[] = (dayOfWeek) => {
 };
 
 type WorkoutFormProps = {
-  onSubmit: (workoutSchedule: PreferredWorkout[]) => void;
+  onSubmit: (workoutSchedule: Omit<PreferredWorkout, "workoutScheduleId">[]) => void;
 };
 function WorkoutForm({ onSubmit }: WorkoutFormProps) {
   const [currentDay, setCurrentDay] = React.useState<Days>(Days.Monday);


### PR DESCRIPTION
## 📝 작업 내용

### 트레이너 도메인 예약 대기자 확인 페이지 구현
기존 트레이너 도메인 예약 관리 페이지를 구현하면서 누락된 예약 대기자 확인 페이지를 구현하였습니다.
- 아직 API는 붙히지 않은 상태로 UI만 구현된 상태입니다. API가 필요한 부분은 TODO 주석을 남겨두었습니다.
- `PreferredWorkout` 타입에 누락된 프로퍼티를 추가하면서 용재님이 구현해주신 `WorkoutForm`, `WorkoutScheduleStep` 컴포넌트의 Props 타입에 Omit을 추가하여 추가된 `workoutScheduleId` 프로퍼티를 제거하도록 수정하였습니다.
- 기능 테스트를 위해 Mock 데이터를 컴포넌트내에 작성해두었습니다. 추후 API를 붙이면 제거할 예정입니다.

