### PR TITLE
[FLIZ-216/user] feat: 휴대폰 인증 로직 구현

### DIFF
--- a/apps/trainer/app/my-page/my-information/edit-verificated-phone/_components/PhoneVerificationContainer.tsx
+++ b/apps/trainer/app/my-page/my-information/edit-verificated-phone/_components/PhoneVerificationContainer.tsx
@@ -1,4 +1,3 @@
-import PhoneVerification from "@ui/components/PhoneVerification";
 import { PhoneVerificationButton } from "@ui/components/PhoneVerification/PhoneVerificationButton";
 import PhoneVerificationGuide from "@ui/components/PhoneVerification/PhoneVerificationGuide";
 import PhoneVerificationImage from "@ui/components/PhoneVerification/PhoneVerificationImage";
@@ -6,11 +5,11 @@ import PhoneVerificationNotice from "@ui/components/PhoneVerification/PhoneVerif
 
 export default function PhoneVerificationContainer() {
   return (
-    <PhoneVerification>
+    <>
       <PhoneVerificationGuide />
       <PhoneVerificationImage />
       <PhoneVerificationNotice />
       <PhoneVerificationButton />
-    </PhoneVerification>
+    </>
   );
 }

--- a/apps/user/app/my-page/page.tsx
+++ b/apps/user/app/my-page/page.tsx
@@ -33,37 +33,37 @@ export default function MyPage() {
     },
     workoutSchedules: [
       {
-        workoutScheduleId: "1",
+        workoutScheduleId: 1,
         dayOfWeek: "MONDAY",
         preferenceTimes: ["10:00", "12:00"],
       },
       {
-        workoutScheduleId: "2",
+        workoutScheduleId: 2,
         dayOfWeek: "TUESDAY",
         preferenceTimes: ["10:00", "12:00"],
       },
       {
-        workoutScheduleId: "3",
+        workoutScheduleId: 3,
         dayOfWeek: "WEDNESDAY",
         preferenceTimes: ["10:00", "12:00"],
       },
       {
-        workoutScheduleId: "4",
+        workoutScheduleId: 4,
         dayOfWeek: "THURSDAY",
         preferenceTimes: ["10:00", "12:00"],
       },
       {
-        workoutScheduleId: "5",
+        workoutScheduleId: 5,
         dayOfWeek: "FRIDAY",
         preferenceTimes: ["10:00", "12:00"],
       },
       {
-        workoutScheduleId: "6",
+        workoutScheduleId: 6,
         dayOfWeek: "SATURDAY",
         preferenceTimes: ["10:00", "12:00"],
       },
       {
-        workoutScheduleId: "7",
+        workoutScheduleId: 7,
         dayOfWeek: "SUNDAY",
         preferenceTimes: ["10:00", "12:00"],
       },

--- a/apps/user/app/notification/_components/NotificationContainer.tsx
+++ b/apps/user/app/notification/_components/NotificationContainer.tsx
@@ -1,4 +1,4 @@
-import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { NotificationType } from "@5unwan/core/api/types/common";
 import { Text } from "@ui/components/Text";
 import React from "react";
 
@@ -6,51 +6,24 @@ import NotificationList from "./NotificationList";
 
 const notificationList = [
   {
-    notificationId: 1, //알림 ID
-    refId: 1, // 연동 ID
-    refType: "예약" as NotificationInfo["refType"], //알람 종류 ["예약","세션","트레이너 연동"]
-    notificationType: "예약 요청" as NotificationInfo["notificationType"], // 알림종류
-    memberInfo: {
-      memberId: 1,
-      name: "홍길동",
-      birthDate: "1996-07-13",
-      phoneNumber: "01057145507",
-      profilePictureUrl: "https://",
-    },
-    content: "회원님이 PT 예약을 요청하였습니다.",
-    sendDate: "2025-02-12T18:00",
-    isProcessed: true,
-  },
-  {
-    notificationId: 1, //알림 ID
-    refId: 1, // 연동 ID
-    refType: "예약" as NotificationInfo["refType"], //알람 종류 ["예약","세션","트레이너 연동"]
-    notificationType: "예약 요청" as NotificationInfo["notificationType"], // 알림종류
-    memberInfo: {
-      memberId: 1,
-      name: "홍길동",
-      birthDate: "1996-07-13",
-      phoneNumber: "01057145507",
-      profilePictureUrl: "https://",
-    },
-    content: "회원님이 PT 예약을 요청하였습니다.",
-    sendDate: "2025-02-12T18:00",
+    notificationId: 1,
+    type: "예약 요청" as NotificationType,
+    content: "예약 내용 0",
+    sendDate: "2025-04-09T17:25:15.879023",
     isProcessed: false,
   },
   {
-    notificationId: 1, //알림 ID
-    refId: 1, // 연동 ID
-    refType: "예약" as NotificationInfo["refType"], //알람 종류 ["예약","세션","트레이너 연동"]
-    notificationType: "예약 요청" as NotificationInfo["notificationType"], // 알림종류
-    memberInfo: {
-      memberId: 1,
-      name: "홍길동",
-      birthDate: "1996-07-13",
-      phoneNumber: "01057145507",
-      profilePictureUrl: "https://",
-    },
-    content: "회원님이 PT 예약을 요청하였습니다.",
-    sendDate: "2025-02-12T18:00",
+    notificationId: 4,
+    type: "예약 요청" as NotificationType,
+    content: "예약 내용 3" as NotificationType,
+    sendDate: "2025-04-06T17:25:15.882954",
+    isProcessed: false,
+  },
+  {
+    notificationId: 6,
+    type: "세션" as NotificationType,
+    content: "세션 내용 5",
+    sendDate: "2025-04-04T17:25:15.884254",
     isProcessed: false,
   },
 ];

--- a/apps/user/app/notification/_components/NotificationList.tsx
+++ b/apps/user/app/notification/_components/NotificationList.tsx
@@ -12,12 +12,12 @@ function NotificationList({ notificationList }: NotificationListProps) {
   // TODO[2025.03.30]: NotificationItem onClick 핸들러 구현 (알림 읽음 처리 API)
   return (
     <ul className="flex flex-col items-center gap-4">
-      {notificationList?.map(({ content, sendDate, isProcessed }, index) => (
+      {notificationList?.map(({ content, sendDate, isProcessed, type }, index) => (
         <NotificationItem
           message={content}
           createdAt={sendDate}
           isCompleted={isProcessed}
-          variant="reserve"
+          variant={type}
           key={`${sendDate}-${index}`}
           className="w-full"
         />

--- a/apps/user/app/register/_components/RegisterFunnel.tsx
+++ b/apps/user/app/register/_components/RegisterFunnel.tsx
@@ -9,9 +9,6 @@ import { useSaveTokenFromSearchParams } from "../_hooks/useSaveTokenFromSearchPa
 const BasicInfoStep = dynamic(() => import("@ui/components/FunnelSteps/BasicInfoStep"), {
   ssr: false,
 });
-const PhoneNumberStep = dynamic(() => import("@ui/components/FunnelSteps/PhoneNumberStep"), {
-  ssr: false,
-});
 const WorkoutScheduleStep = dynamic(
   () => import("@ui/components/FunnelSteps/WorkoutScheduleStep"),
   {
@@ -27,7 +24,6 @@ function RegisterFunnel() {
 
   const funnel = useFunnel<{
     basicInfo: BasicInfoStep;
-    phoneNumber: PhoneNumberStep;
     workoutSchedule: WorkoutScheduleStep;
     result: ResultStep;
   }>({
@@ -43,14 +39,8 @@ function RegisterFunnel() {
       return (
         <BasicInfoStep
           onNext={(name, birthDate, gender, profileUrl) =>
-            funnel.history.push("phoneNumber", { name, birthDate, gender, profileUrl })
+            funnel.history.push("workoutSchedule", { name, birthDate, gender, profileUrl })
           }
-        />
-      );
-    case "phoneNumber":
-      return (
-        <PhoneNumberStep
-          onNext={(phoneNumber) => funnel.history.push("workoutSchedule", { phoneNumber })}
         />
       );
     case "workoutSchedule":
@@ -75,30 +65,19 @@ type BasicInfoStep = {
   birthDate?: string;
   gender?: Gender;
   profileUrl?: string;
-  phoneNumber?: string;
-  workoutSchedule?: PreferredWorkout[];
-};
-type PhoneNumberStep = {
-  name: string;
-  birthDate: string;
-  gender: Gender;
-  profileUrl: string;
-  phoneNumber?: string;
-  workoutSchedule?: PreferredWorkout[];
+  workoutSchedule?: Omit<PreferredWorkout, "workoutScheduleId">[];
 };
 type WorkoutScheduleStep = {
   name: string;
   birthDate: string;
   gender: Gender;
   profileUrl: string;
-  phoneNumber: string;
-  workoutSchedule?: PreferredWorkout[];
+  workoutSchedule?: Omit<PreferredWorkout, "workoutScheduleId">[];
 };
 type ResultStep = {
   name: string;
   birthDate: string;
   gender: Gender;
   profileUrl: string;
-  phoneNumber: string;
-  workoutSchedule: PreferredWorkout[];
+  workoutSchedule: Omit<PreferredWorkout, "workoutScheduleId">[];
 };

--- a/apps/user/app/sns-verification/page.tsx
+++ b/apps/user/app/sns-verification/page.tsx
@@ -26,7 +26,6 @@ function SnsVerificationPage() {
     refetchInterval: (query) => {
       if (query.state.data?.data) {
         const { status } = query.state.data.data;
-        console.log(status);
         if (status === "REQUIRED_REGISTER") return false;
       }
 

--- a/apps/user/app/sns-verification/page.tsx
+++ b/apps/user/app/sns-verification/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import PhoneVerification from "@ui/components/PhoneVerification";
+import { useRouter } from "next/navigation";
+import React, { useState } from "react";
+
+import { authQueries } from "@user/queries/auth";
+
+const REFETCH_INTERVAL = 5000;
+
+function SnsVerificationPage() {
+  const navigation = useRouter();
+
+  const [hasClicked, setHasClicked] = useState(false);
+
+  const handleClick = () => {
+    setHasClicked(true);
+  };
+
+  const { data: tokenData, isPending: isTokenDataPending } = useQuery(authQueries.snsToken());
+
+  const { data: statusData } = useQuery({
+    ...authQueries.status(),
+    enabled: hasClicked,
+    refetchInterval: (query) => {
+      if (query.state.data?.data) {
+        const { status } = query.state.data.data;
+        console.log(status);
+        if (status === "REQUIRED_REGISTER") return false;
+      }
+
+      return REFETCH_INTERVAL;
+    },
+  });
+
+  if (statusData && statusData.data) {
+    const { status } = statusData.data;
+
+    if (status === "REQUIRED_REGISTER") navigation.push("/register");
+  }
+
+  return (
+    <PhoneVerification
+      onClick={handleClick}
+      verificationToken={!isTokenDataPending ? tokenData?.data.verificationToken : undefined}
+    />
+  );
+}
+
+export default SnsVerificationPage;

--- a/apps/user/constants/routes.ts
+++ b/apps/user/constants/routes.ts
@@ -20,6 +20,7 @@ const generateQueryString = (searchParams: Partial<{ [key: string]: string | nul
 
 class ROUTES {
   private _root = () => [""];
+  private "_sns-verification" = () => [...this._root(), "sns-verification"];
   private _login = () => [...this._root(), "login"];
   private _register = () => [...this._root(), "register"];
   private "_my-page" = () => [...this._root(), "my-page"];
@@ -39,6 +40,9 @@ class ROUTES {
 
   get root() {
     return () => this._root().join(ROUTE_DIVIDER) + "/";
+  }
+  get "sns-verification"() {
+    return () => this["_sns-verification"]().join(ROUTE_DIVIDER);
   }
   get login() {
     return () => this._login().join(ROUTE_DIVIDER);

--- a/apps/user/middleware.ts
+++ b/apps/user/middleware.ts
@@ -9,7 +9,7 @@ export function middleware(request: NextRequest) {
   const url = request.nextUrl.clone();
 
   /** TODO: login 경로는 임시 경로로 추후 sns-verification 페이지 작업자가 해당 페이지로 이동하는 로직으로 12번 라인 수정 */
-  if (url.pathname === RouteInstance["login"]()) {
+  if (url.pathname === RouteInstance["sns-verification"]()) {
     const accessToken = url.searchParams.get("accessToken");
     const refreshToken = url.searchParams.get("refreshToken");
 

--- a/apps/user/queries/auth.ts
+++ b/apps/user/queries/auth.ts
@@ -1,0 +1,20 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { getSnsVerificationToken, getUserVerificationStatus } from "@user/services/auth";
+
+export const authBaseKeys = {
+  all: () => ["auth"] as const,
+};
+
+export const authQueries = {
+  status: () =>
+    queryOptions({
+      queryKey: [...authBaseKeys.all(), "status"],
+      queryFn: getUserVerificationStatus,
+    }),
+  snsToken: () =>
+    queryOptions({
+      queryKey: [...authBaseKeys.all(), "snsToken"],
+      queryFn: getSnsVerificationToken,
+    }),
+};

--- a/apps/user/services/auth.ts
+++ b/apps/user/services/auth.ts
@@ -1,5 +1,11 @@
 import http from "../app/apiCore";
-import { LogoutApiResponse, SignupRequestBody, SignupApiResponse } from "./types/auth.dto";
+import {
+  LogoutApiResponse,
+  SignupRequestBody,
+  SignupApiResponse,
+  GetUserVerificationStatusApiResponse,
+  GetSnsVerificationTokenApiResponse,
+} from "./types/auth.dto";
 
 export const signup = (data: SignupRequestBody) =>
   http.post<SignupApiResponse>({
@@ -10,4 +16,14 @@ export const signup = (data: SignupRequestBody) =>
 export const logout = () =>
   http.post<LogoutApiResponse>({
     url: "/v1/auth/logout",
+  });
+
+export const getUserVerificationStatus = () =>
+  http.get<GetUserVerificationStatusApiResponse>({
+    url: "/v1/auth/status",
+  });
+
+export const getSnsVerificationToken = () =>
+  http.get<GetSnsVerificationTokenApiResponse>({
+    url: "/v1/auth/email-verification-token",
   });

--- a/apps/user/services/types/auth.dto.ts
+++ b/apps/user/services/types/auth.dto.ts
@@ -6,9 +6,20 @@ import {
 } from "@5unwan/core/api/types/common";
 
 export type SignupRequestBody = BaseSignupInfo & {
-  workoutSchedule: PreferredWorkout[];
+  workoutSchedule: Omit<PreferredWorkout, "workoutScheduleId">[];
 };
 
 export type SignupApiResponse = ResponseBase<{ accessToken: string; refreshToken: string }>;
 
 export type LogoutApiResponse = NoResponseData;
+
+export type GetUserVerificationStatusApiResponse = ResponseBase<{
+  status: UserVerificationStatus;
+  accessToken: string;
+}>;
+
+export type GetSnsVerificationTokenApiResponse = ResponseBase<{
+  verificationToken: string;
+}>;
+
+export type UserVerificationStatus = "REQUIRED_REGISTER" | "REQUIRED_SMS" | "NORMAL";

--- a/apps/user/services/types/myInformation.dto.ts
+++ b/apps/user/services/types/myInformation.dto.ts
@@ -25,7 +25,7 @@ type MyInformationResponse = {
   connectingStatus: TrainerConnectStatus;
   profilePictureUrl: string;
   sessionInfo: SessionInfo;
-  workoutSchedules: (PreferredWorkout & { workoutScheduleId: string })[];
+  workoutSchedules: PreferredWorkout[];
 };
 export type MyInformationApiResponse = ResponseBase<MyInformationResponse>;
 

--- a/packages/core/src/api/types/common.ts
+++ b/packages/core/src/api/types/common.ts
@@ -112,7 +112,6 @@ export type Gender = "MALE" | "FEMALE";
 export type BaseSignupInfo = {
   name: string;
   birthDate: string;
-  phoneNumber: string;
   gender: Gender;
   profileUrl: string;
 };

--- a/packages/ui/src/components/PhoneVerification/index.tsx
+++ b/packages/ui/src/components/PhoneVerification/index.tsx
@@ -1,7 +1,48 @@
+"use client";
+
+import { useRef } from "react";
+
+import { Button } from "../Button";
+import PhoneVerificationGuide from "./PhoneVerificationGuide";
+import PhoneVerificationImage from "./PhoneVerificationImage";
+import PhoneVerificationNotice from "./PhoneVerificationNotice";
+
 type PhoneVerificationProps = {
-  children: React.ReactNode;
+  onClick: () => void;
+  verificationToken?: string;
 };
 
-export default function PhoneVerification({ children }: PhoneVerificationProps) {
-  return <section className="flex h-full w-full flex-col items-center">{children}</section>;
+const generateSnsBody = (token?: string) => {
+  return `[Fitlink]\n${token}`;
+};
+function PhoneVerification({ onClick, verificationToken }: PhoneVerificationProps) {
+  const linkRef = useRef<HTMLAnchorElement>(null);
+  const handleButtonClick = () => {
+    linkRef.current?.click();
+    onClick();
+  };
+
+  return (
+    <main className="flex h-full w-full flex-col items-center">
+      <PhoneVerificationGuide />
+      <PhoneVerificationImage />
+      <PhoneVerificationNotice />
+      <Button
+        size="xl"
+        className="text-headline w-full"
+        onClick={handleButtonClick}
+        disabled={!verificationToken}
+      >
+        인증 메시지 보내기
+      </Button>
+      <a
+        ref={linkRef}
+        href={`sms:verification@fitlink.biz?body=${generateSnsBody(verificationToken)}`}
+        className="hidden"
+        aria-label="verification-link"
+      />
+    </main>
+  );
 }
+
+export default PhoneVerification;


### PR DESCRIPTION
# [FLIZ-216/user] feat: 휴대폰 인증 로직 구현

## 📝 작업 내용

user 서비스 휴대폰 인증 로직을 구현했습니다

흐름은 다음과 같습니다 :

1. /login : 소셜 로그인 버튼 클릭 (현재 카카오만 가능) 
2. /sns-verification 으로 redirection
3. /sns-verification 페이지 마운트 시 [이메일 인증 토큰 발급 API] 호출, 응답으로 받은 verificationToken을 휴대폰 인증 로직 모듈 (PhoneVerification 컴포넌트)로 주입
4. 인증 메세지 보내기 버튼 클릭 시 메세지 앱을 열어 verificationToken을 문자 내용으로 담은 문자 생성 + [유저 상태 polling API] 5초마다 호출하여 유저 인증 상태 조회
5. 사용자가 문자를 전송하면 서버에서 유저 인증 상태를 REQUIRED_REGISTER 로 변경, polling 중이던 API 응답으로 REQUIRED_REGISTER 값을 확인하면 /register 로 이동
6. /register 페이지에서 회원 정보 입력 및 회원 가입 진행 (기존 PhoneStep 제거)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
