### PR TITLE
[FLIZ-218/root] chore: 포크 레포 커밋 싱크 워크플로우 작성

### DIFF
--- a/.github/workflows/deploy_yjc2021.yml
+++ b/.github/workflows/deploy_yjc2021.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+on:
+  push:
+    branches: ["dev"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+
+      - name: Prepare output
+        run: sh ./build.sh
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.YJC_AUTO_ACTIONS }}
+        with:
+          source-directory: "output"
+          destination-github-username: yjc2021
+          destination-repository-name: FitLink-FE
+          user-email: ${{ secrets.YJC_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: dev
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY


### PR DESCRIPTION
# [FLIZ-218/root] chore: 포크 레포 커밋 싱크 워크플로우 작성

## 📝 작업 내용

vercel 배포를 위해 포크 레포의 커밋 싱크를 맞추는 워크플로우를 추가했습니다. 기존 deploy.yml 과 코드는 동일하며, github 환경변수만 변경했습니다. 
FE 레포에도 YJC_EMAIL과 YJC_AUTO_ACTIONS 변수를 추가했습니다.


### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
