### PR TITLE
[FLIZ-242/user] feat: 이미지 파일 업로드 로직 구현

### DIFF
--- a/apps/user/app/register/_components/RegisterFunnel.tsx
+++ b/apps/user/app/register/_components/RegisterFunnel.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { Gender, PreferredWorkout } from "@5unwan/core/api/types/common";
+import { useMutation } from "@tanstack/react-query";
 import { useFunnel } from "@use-funnel/browser";
 import dynamic from "next/dynamic";
+
+import { registerUserProfileImage, uploadImage } from "@user/services/attachment";
+import { createPresignedUrl } from "@user/services/attachment";
 
 const BasicInfoStep = dynamic(() => import("@ui/components/FunnelSteps/BasicInfoStep"), {
   ssr: false,
@@ -30,13 +34,70 @@ function RegisterFunnel() {
     },
   });
 
+  const createPresignedUrlMutation = useMutation({
+    mutationFn: createPresignedUrl,
+  });
+  const uploadImageMutation = useMutation({
+    mutationFn: uploadImage,
+  });
+  const registerUserProfileImageMutation = useMutation({
+    mutationFn: registerUserProfileImage,
+  });
+
+  const handleUploadProfileImage = async (imageFile: File) => {
+    try {
+      const {
+        data: { presignedUrl, attachmentId },
+        status: createPresignedUrlStatus,
+        success: createPresignedUrlSuccess,
+        msg: createPresignedUrlMsg,
+      } = await createPresignedUrlMutation.mutateAsync({
+        fileName: imageFile.name,
+        contentLength: imageFile.size.toString(),
+        contentType: imageFile.type,
+      });
+
+      if (!createPresignedUrlSuccess)
+        throw new Error(
+          `Error occured during createPresignedUrl\nStatus:${createPresignedUrlStatus}\nMessage:${createPresignedUrlMsg}`,
+        );
+
+      await uploadImageMutation.mutateAsync({
+        presignedUrl,
+        imageFile,
+      });
+
+      const {
+        status: registerUserProfileImageStatus,
+        success: registerUserProfileImageSuccess,
+        msg: registerUserProfileImageMsg,
+      } = await registerUserProfileImageMutation.mutateAsync({
+        attachmentId,
+      });
+
+      if (!registerUserProfileImageSuccess)
+        throw new Error(
+          `Error occured during createPresignedUrl\nStatus:${registerUserProfileImageStatus}\nMessage:${registerUserProfileImageMsg}`,
+        );
+
+      return attachmentId;
+    } catch {
+      //TODO: 에러 처리 로직 추가
+    }
+  };
   switch (funnel.step) {
     case "basicInfo":
       return (
         <BasicInfoStep
-          onNext={(name, birthDate, gender, profileUrl) =>
-            funnel.history.push("workoutSchedule", { name, birthDate, gender, profileUrl })
-          }
+          onNext={async (name, birthDate, gender, profileImage) => {
+            const attachmentId = await handleUploadProfileImage(profileImage);
+            funnel.history.push("workoutSchedule", {
+              name,
+              birthDate,
+              gender,
+              attachmentId: attachmentId!,
+            });
+          }}
         />
       );
     case "workoutSchedule":
@@ -60,20 +121,20 @@ type BasicInfoStep = {
   name?: string;
   birthDate?: string;
   gender?: Gender;
-  profileUrl?: string;
+  attachmentId?: number;
   workoutSchedule?: Omit<PreferredWorkout, "workoutScheduleId">[];
 };
 type WorkoutScheduleStep = {
   name: string;
   birthDate: string;
   gender: Gender;
-  profileUrl: string;
+  attachmentId: number;
   workoutSchedule?: Omit<PreferredWorkout, "workoutScheduleId">[];
 };
 type ResultStep = {
   name: string;
   birthDate: string;
   gender: Gender;
-  profileUrl: string;
+  attachmentId: number;
   workoutSchedule: Omit<PreferredWorkout, "workoutScheduleId">[];
 };

--- a/apps/user/services/attachment.ts
+++ b/apps/user/services/attachment.ts
@@ -1,0 +1,35 @@
+import axios from "axios";
+
+import http from "@user/app/apiCore";
+
+import {
+  CreatePresignedUrlApiResponse,
+  CreatePresignedUrlRequestBody,
+  RegisterUserProfileImageApiResponse,
+  RegisterUserProfileImageRequestBody,
+} from "./types/attachment.dto";
+
+export const createPresignedUrl = (data: CreatePresignedUrlRequestBody) =>
+  http.post<CreatePresignedUrlApiResponse>({
+    url: "/v1/attachments/pre-signed-url",
+    data,
+  });
+
+export const uploadImage = ({
+  presignedUrl,
+  imageFile,
+}: {
+  presignedUrl: string;
+  imageFile: File;
+}) =>
+  axios.put(presignedUrl, imageFile, {
+    headers: {
+      "Content-Type": imageFile.type,
+    },
+  });
+
+export const registerUserProfileImage = (data: RegisterUserProfileImageRequestBody) =>
+  http.post<RegisterUserProfileImageApiResponse>({
+    url: "/v1/attachments/user-profile",
+    data,
+  });

--- a/apps/user/services/types/attachment.dto.ts
+++ b/apps/user/services/types/attachment.dto.ts
@@ -1,0 +1,15 @@
+import { ResponseBase } from "@5unwan/core/api/types/common";
+
+export type CreatePresignedUrlRequestBody = {
+  fileName: string;
+  contentLength: string;
+  contentType: string;
+};
+export type CreatePresignedUrlApiResponse = ResponseBase<{
+  presignedUrl: string;
+  attachmentId: number;
+}>;
+export type RegisterUserProfileImageRequestBody = {
+  attachmentId: number;
+};
+export type RegisterUserProfileImageApiResponse = ResponseBase<null>;

--- a/packages/core/src/api/types/common.ts
+++ b/packages/core/src/api/types/common.ts
@@ -113,5 +113,5 @@ export type BaseSignupInfo = {
   name: string;
   birthDate: string;
   gender: Gender;
-  profileUrl: string;
+  attachmentId: number;
 };

--- a/packages/ui/src/components/FunnelSteps/BasicInfoStep.tsx
+++ b/packages/ui/src/components/FunnelSteps/BasicInfoStep.tsx
@@ -17,21 +17,21 @@ import { formatDateStringFromResidentId } from "@ui/utils/formatDateStringFromRe
 
 const NAME_REGEX = /[a-zA-Z가-힣]+$/;
 const REQUIRED_FIELDS = Object.freeze({
-  profileUrl: true,
+  profileImage: true,
   name: true,
   gender: true,
   birthDate: true,
 });
 
 type BasicInfoForm = {
-  profileUrl?: string;
+  profileImage?: File;
   name?: string;
   gender?: Gender;
   birthDate?: string;
 };
 
 const formSchema = z.object({
-  profileUrl: z.string(),
+  profileImage: z.any(),
   name: z.string().regex(NAME_REGEX),
   gender: z.enum(["MALE", "FEMALE"]),
   birthDate: z.string().date(),
@@ -61,12 +61,12 @@ const areRequiredFormFiledsFilled = (
 };
 type zodErrors = z.inferFlattenedErrors<typeof formSchema>;
 type BasicInfoStepProps = {
-  onNext: (name: string, birthDate: string, gender: Gender, profileUrl: string) => void;
+  onNext: (name: string, birthDate: string, gender: Gender, profileImage: File) => void;
 };
 
 function BasicInfoStep({ onNext }: BasicInfoStepProps) {
   const formDataRef = React.useRef<{
-    profileUrl?: string;
+    profileImage?: File;
     name?: string;
     gender?: Gender;
     birthDate?: string;
@@ -98,7 +98,7 @@ function BasicInfoStep({ onNext }: BasicInfoStepProps) {
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
 
-    const { name, birthDate, gender, profileUrl } = formDataRef.current;
+    const { name, birthDate, gender, profileImage } = formDataRef.current;
 
     const { success, errors } = validateForm({
       ...formDataRef.current,
@@ -109,7 +109,7 @@ function BasicInfoStep({ onNext }: BasicInfoStepProps) {
 
       return;
     }
-    onNext(name!, formatDateStringFromResidentId(birthDate)!, gender!, profileUrl!);
+    onNext(name!, formatDateStringFromResidentId(birthDate)!, gender!, profileImage!);
   };
 
   React.useEffect(() => {
@@ -124,11 +124,11 @@ function BasicInfoStep({ onNext }: BasicInfoStepProps) {
       <form onSubmit={handleSubmit} className="flex flex-1 flex-col justify-between pt-[15px]">
         <div>
           <ProfileImagePicker
-            onFileChange={(fileUrl) => {
-              resetErrorField("profileUrl");
-              handleFieldChange("profileUrl", fileUrl);
+            onFileChange={(file) => {
+              resetErrorField("profileImage");
+              handleFieldChange("profileImage", file);
             }}
-            error={parseMessageFromZodError("profileUrl", errors)}
+            error={parseMessageFromZodError("profileImage", errors)}
           />
           <InputWithLabel id="a" error={parseMessageFromZodError("name", errors)}>
             <InputLabel>이름</InputLabel>

--- a/packages/ui/src/components/ProfileImagePicker.tsx
+++ b/packages/ui/src/components/ProfileImagePicker.tsx
@@ -6,7 +6,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "./Avatar";
 import { Button } from "./Button";
 
 type ProfileImagePickerProps = {
-  onFileChange: (fileUrl: string) => void;
+  onFileChange: (file: File) => void;
   error?: string | boolean;
 };
 
@@ -21,8 +21,10 @@ function ProfileImagePicker({ onFileChange, error }: ProfileImagePickerProps) {
   const handleFileChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
     const files = event.target.files;
     if (files && files.length) {
-      const newUrl = URL.createObjectURL(files[0]);
-      onFileChange(newUrl);
+      const targetFile = files[0];
+
+      const newUrl = URL.createObjectURL(targetFile);
+      onFileChange(targetFile);
       setImageUrl(newUrl);
     }
   };


### PR DESCRIPTION
# [FLIZ-242/user] feat: 이미지 파일 업로드 로직 구현

## 📝 작업 내용

업데이트된 이미지 파일 업로드 API 정책에 맞게 회원 서비스의 회원가입 단계(register) 중 이미지 파일 업로드 로직 및 API request를 수정했습니다.

- 변경된 API 정책은 다음과 같은 플로우를 요구합니다
   1. AWS S3 버킷 업로드용 presignedUrl API 요청 (Attachment > POST 이미지 업로드 url 생성)
   2. AWS에서 생성한 presignedUrl로 이미지 파일 업로드 API 요청 (Attachment > PUT 이미지 업로드)
   3. 회원 프로필 이미지로 S3에 저장한 이미지 파일 등록 API 요청 (Attachment > POST 유저 프로필 등록)
- API 요청은 번호 순서대로 동기적으로 요청합니다
- 2번 API에서 프로젝트에서 설정한 axios config (authorization, etc.)로 요청 시 요청이 실패합니다. 따라서 default config를 사용하기 위해 정의한 http 객체가 아닌 기본 axios API를 사용했습니다

- 회원가입 API에서 attachmentId가 없어도 요청이 성공합니다 (optional). 따라서 위 이미지 업로드 플로우에서 발생하는 API 에러에 대해서 별도의 UI 또는 navigation 정책을 수립하지 않았습니다. 


### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

