### PR TITLE
[FLIZ-246/trainer] feat: 이미지 파일 업로드 로직 구현

### DIFF
--- a/apps/trainer/app/register/_components/RegisterFunnel.tsx
+++ b/apps/trainer/app/register/_components/RegisterFunnel.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { AvailablePtTime, Gender } from "@5unwan/core/api/types/common";
+import { useMutation } from "@tanstack/react-query";
 import { useFunnel } from "@use-funnel/browser";
 import dynamic from "next/dynamic";
+
+import { registerUserProfileImage, uploadImage } from "@trainer/services/attachment";
+import { createPresignedUrl } from "@trainer/services/attachment";
 
 const BasicInfoStep = dynamic(() => import("@ui/components/FunnelSteps/BasicInfoStep"), {
   ssr: false,
@@ -30,13 +34,70 @@ function RegisterFunnel() {
     },
   });
 
+  const createPresignedUrlMutation = useMutation({
+    mutationFn: createPresignedUrl,
+  });
+  const uploadImageMutation = useMutation({
+    mutationFn: uploadImage,
+  });
+  const registerUserProfileImageMutation = useMutation({
+    mutationFn: registerUserProfileImage,
+  });
+
+  const handleUploadProfileImage = async (imageFile: File) => {
+    try {
+      const {
+        data: { presignedUrl, attachmentId },
+        status: createPresignedUrlStatus,
+        success: createPresignedUrlSuccess,
+        msg: createPresignedUrlMsg,
+      } = await createPresignedUrlMutation.mutateAsync({
+        fileName: imageFile.name,
+        contentLength: imageFile.size.toString(),
+        contentType: imageFile.type,
+      });
+
+      if (!createPresignedUrlSuccess)
+        throw new Error(
+          `Error occured during createPresignedUrl\nStatus:${createPresignedUrlStatus}\nMessage:${createPresignedUrlMsg}`,
+        );
+
+      await uploadImageMutation.mutateAsync({
+        presignedUrl,
+        imageFile,
+      });
+
+      const {
+        status: registerUserProfileImageStatus,
+        success: registerUserProfileImageSuccess,
+        msg: registerUserProfileImageMsg,
+      } = await registerUserProfileImageMutation.mutateAsync({
+        attachmentId,
+      });
+
+      if (!registerUserProfileImageSuccess)
+        throw new Error(
+          `Error occured during createPresignedUrl\nStatus:${registerUserProfileImageStatus}\nMessage:${registerUserProfileImageMsg}`,
+        );
+
+      return attachmentId;
+    } catch {
+      //TODO: 에러 처리 로직 추가
+    }
+  };
   switch (funnel.step) {
     case "basicInfo":
       return (
         <BasicInfoStep
-          onNext={(name, birthDate, gender, profileUrl) =>
-            funnel.history.push("trainerSchedule", { name, birthDate, gender, profileUrl })
-          }
+          onNext={async (name, birthDate, gender, profileImage) => {
+            const attachmentId = await handleUploadProfileImage(profileImage);
+            funnel.history.push("trainerSchedule", {
+              name,
+              birthDate,
+              gender,
+              attachmentId: attachmentId!,
+            });
+          }}
         />
       );
     case "trainerSchedule":
@@ -62,20 +123,20 @@ type BasicInfoStep = {
   name?: string;
   birthDate?: string;
   gender?: Gender;
-  profileUrl?: string;
+  attachmentId?: number;
   availableTimes?: AvailablePtTimeWithoutId[];
 };
 type TrainerScheduleStep = {
   name: string;
   birthDate: string;
   gender: Gender;
-  profileUrl: string;
+  attachmentId: number;
   availableTimes?: AvailablePtTimeWithoutId[];
 };
 type ResultStep = {
   name: string;
   birthDate: string;
   gender: Gender;
-  profileUrl: string;
+  attachmentId: number;
   availableTimes: AvailablePtTimeWithoutId[];
 };

--- a/apps/trainer/services/attachment.ts
+++ b/apps/trainer/services/attachment.ts
@@ -1,0 +1,35 @@
+import axios from "axios";
+
+import http from "@trainer/app/apiCore";
+
+import {
+  CreatePresignedUrlApiResponse,
+  CreatePresignedUrlRequestBody,
+  RegisterUserProfileImageApiResponse,
+  RegisterUserProfileImageRequestBody,
+} from "./types/attachment.dto";
+
+export const createPresignedUrl = (data: CreatePresignedUrlRequestBody) =>
+  http.post<CreatePresignedUrlApiResponse>({
+    url: "/v1/attachments/pre-signed-url",
+    data,
+  });
+
+export const uploadImage = ({
+  presignedUrl,
+  imageFile,
+}: {
+  presignedUrl: string;
+  imageFile: File;
+}) =>
+  axios.put(presignedUrl, imageFile, {
+    headers: {
+      "Content-Type": imageFile.type,
+    },
+  });
+
+export const registerUserProfileImage = (data: RegisterUserProfileImageRequestBody) =>
+  http.post<RegisterUserProfileImageApiResponse>({
+    url: "/v1/attachments/user-profile",
+    data,
+  });

--- a/apps/trainer/services/types/attachment.dto.ts
+++ b/apps/trainer/services/types/attachment.dto.ts
@@ -1,0 +1,15 @@
+import { ResponseBase } from "@5unwan/core/api/types/common";
+
+export type CreatePresignedUrlRequestBody = {
+  fileName: string;
+  contentLength: string;
+  contentType: string;
+};
+export type CreatePresignedUrlApiResponse = ResponseBase<{
+  presignedUrl: string;
+  attachmentId: number;
+}>;
+export type RegisterUserProfileImageRequestBody = {
+  attachmentId: number;
+};
+export type RegisterUserProfileImageApiResponse = ResponseBase<null>;


### PR DESCRIPTION
# [FLIZ-246/trainer] feat: 이미지 파일 업로드 로직 구현

## 📝 작업 내용

#145 와 동일하게 회원가입 플로우에 이미지 파일 업로드 로직을 구현했습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
