### PR TITLE
[FLIZ-247/core] feat: API 응답 에러 판별 로직 구현

### DIFF
--- a/apps/trainer/app/register/_components/ResultStep.tsx
+++ b/apps/trainer/app/register/_components/ResultStep.tsx
@@ -5,58 +5,47 @@ import RequestStatus, { Status } from "@ui/components/RequestStatus";
 import { useRouter } from "next/navigation";
 import React from "react";
 
-import {
-  SignupApiResponse,
-  SignupRequestBody,
-  UserVerificationStatus,
-} from "@trainer/services/types/auth.dto";
+import { SignupRequestBody, UserVerificationStatus } from "@trainer/services/types/auth.dto";
 
 import RouteInstance from "@trainer/constants/route";
 
 import { useFCMToken } from "../_hooks/useFCMToken";
 import { useSignupForm } from "../_hooks/useSignupForm";
 
-const DEFAULT_VERIFICATION_STATUS = "REQUIRED_SMS" as const;
-const USER_VERIFICATION_STATUS_LIST = ["REQUIRED_SMS", "NORMAL", "REQUIRED_REGISTER"] as const;
+const DEFAULT_VERIFICATION_STATUS = "DEFAULT" as const;
 
 type ResultStepProps = {
   form: SignupRequestBody;
 };
 
-const generateStatus = (
-  networkStatus: "error" | "idle" | "pending" | "success",
-  data?: SignupApiResponse,
-) => {
-  if (data === undefined || data === null) return networkStatus;
-  if (!data.success) return "error";
+type UserSignupStatus = UserVerificationStatus | "DEFAULT";
 
-  return "success";
-};
-
-const getUserStatusFromMessage = (message?: string): UserVerificationStatus => {
+const getUserStatusFromMessage = (message?: string): UserSignupStatus => {
   try {
     if (message === null || message === undefined) return DEFAULT_VERIFICATION_STATUS;
-    const [, detail] = message.split(". ");
-    const detailArray = new Array(detail);
 
-    const status = detailArray[1];
+    // eslint-disable-next-line no-magic-numbers
+    message = message.slice(1, -1).trim();
+    const pairs = message.split(", ").map((pair) => pair.split(": "));
+    const obj: { userId?: number; status?: UserVerificationStatus } = {};
+    pairs.forEach(([key, value]) => {
+      if (key !== "userId" && key !== "status") return;
+      if (!isNaN(Number(value))) {
+        obj["userId"] = Number(value);
+      } else {
+        obj["status"] = value as UserVerificationStatus;
+      }
+    });
 
-    if (USER_VERIFICATION_STATUS_LIST.some((value) => value === status))
-      return status as UserVerificationStatus;
+    if (obj["status"]) return obj["status"];
 
-    return DEFAULT_VERIFICATION_STATUS as UserVerificationStatus;
+    return DEFAULT_VERIFICATION_STATUS;
   } catch {
-    return DEFAULT_VERIFICATION_STATUS as UserVerificationStatus;
+    return DEFAULT_VERIFICATION_STATUS;
   }
 };
 
-const generateErrorMessage = (status: Status, userStatus: UserVerificationStatus) => {
-  if (status === "error")
-    return {
-      title: "회원가입에 실패했습니다",
-      description: "네트워크 연결 상태를 확인하고 다시 시도해주세요",
-    };
-
+const generateErrorMessage = (userStatus: UserSignupStatus) => {
   switch (userStatus) {
     case "NORMAL":
       return {
@@ -65,30 +54,35 @@ const generateErrorMessage = (status: Status, userStatus: UserVerificationStatus
       };
     case "REQUIRED_REGISTER":
       return {
-        title: "네트워크 연결 상태를 확인하고 다시 시도해주세요",
-        description: "",
+        title: "회원가입에 실패했습니다",
+        description: "네트워크 연결 상태를 확인하고 다시 시도해주세요",
       };
     case "REQUIRED_SMS":
       return {
         title: "회원가입에 실패했습니다",
         description: "휴대폰 인증이 필요합니다. 회원가입을 다시 시도해주세요",
       };
+    case "DEFAULT":
+      return {
+        title: "회원가입에 실패했습니다",
+        description: "회원가입을 다시 시도해주세요",
+      };
   }
 };
 
 function ResultStep({ form }: ResultStepProps) {
   const initailizeFCM = useFCMToken();
-  const { onSubmit, networkStatus, data } = useSignupForm({
-    onSuccess: ({ success }) => {
-      if (success) initailizeFCM();
+  const { onSubmit, networkStatus, error } = useSignupForm({
+    onSuccess: () => {
+      initailizeFCM();
       // TODO: status 별 정책 구현
     },
   });
   const router = useRouter();
-  const status = generateStatus(networkStatus, data);
-  const userStatus = getUserStatusFromMessage(data?.msg);
+  // const status = generateStatus(networkStatus, data);
+  const userStatus = getUserStatusFromMessage(error?.message);
 
-  const handleClick = (status: Status, userStatus: UserVerificationStatus) => () => {
+  const handleClick = (status: Status, userStatus: UserSignupStatus) => () => {
     if (status === "success") {
       router.replace(RouteInstance.root());
     } else if (status === "error") {
@@ -106,20 +100,20 @@ function ResultStep({ form }: ResultStepProps) {
     <div className="flex h-full flex-col">
       <div className="flex flex-1 items-center justify-center">
         <RequestStatus
-          status={status}
+          status={networkStatus}
           contentPerStatus={{
             success: {
               title: "회원가입이 완료되었습니다",
             },
-            error: generateErrorMessage(networkStatus, userStatus),
+            error: generateErrorMessage(userStatus),
           }}
         />
       </div>
       <div className="h-[3.375rem] w-full">
         <SignupButton
-          status={status}
+          status={networkStatus}
           userStatus={userStatus}
-          onClick={handleClick(status, userStatus)}
+          onClick={handleClick(networkStatus, userStatus)}
         ></SignupButton>
       </div>
     </div>
@@ -128,16 +122,16 @@ function ResultStep({ form }: ResultStepProps) {
 
 export default ResultStep;
 
-const generateButtonContent = (status: Status, userStatus: UserVerificationStatus) => {
+const generateButtonContent = (status: Status, userStatus: UserSignupStatus) => {
   if (status === "success") return "홈으로 가기";
   if (userStatus === "REQUIRED_REGISTER") return "재시도 하기";
-  if (userStatus === "REQUIRED_SMS") return "회원가입 다시하기";
+  if (userStatus === "REQUIRED_SMS" || userStatus === "DEFAULT") return "회원가입 다시하기";
   if (userStatus === "NORMAL") return "로그인 하기";
 };
 
 type SignupButtonProps = {
   status: Status;
-  userStatus: UserVerificationStatus;
+  userStatus: UserSignupStatus;
   onClick: () => void;
 };
 function SignupButton({ status, userStatus, onClick }: SignupButtonProps) {

--- a/apps/trainer/app/register/_hooks/useSignupForm.ts
+++ b/apps/trainer/app/register/_hooks/useSignupForm.ts
@@ -1,17 +1,19 @@
 "use client";
 
 import { MutateOptions, useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 
 import { signup } from "@trainer/services/auth";
 import { SignupApiResponse, SignupRequestBody } from "@trainer/services/types/auth.dto";
 
 export const useSignupForm = (
   persistentOptions?: Omit<
-    MutateOptions<SignupApiResponse, Error, SignupRequestBody, unknown>,
+    MutateOptions<SignupApiResponse, AxiosError, SignupRequestBody, unknown>,
     "mutationFn"
   >,
 ) => {
   const {
+    error,
     mutate,
     status: networkStatus,
     data,
@@ -22,10 +24,10 @@ export const useSignupForm = (
 
   const onSubmit = (
     signupForm: SignupRequestBody,
-    options?: MutateOptions<SignupApiResponse, Error, SignupRequestBody, unknown>,
+    options?: MutateOptions<SignupApiResponse, AxiosError, SignupRequestBody, unknown>,
   ) => {
     mutate(signupForm, options);
   };
 
-  return { onSubmit, networkStatus, data };
+  return { onSubmit, networkStatus, data, error };
 };

--- a/apps/trainer/types/index.d.ts
+++ b/apps/trainer/types/index.d.ts
@@ -1,0 +1,8 @@
+import "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+declare module "@tanstack/react-query" {
+  interface Register {
+    defaultError: AxiosError;
+  }
+}

--- a/apps/user/app/register/_components/ResultStep.tsx
+++ b/apps/user/app/register/_components/ResultStep.tsx
@@ -5,56 +5,45 @@ import RequestStatus, { Status } from "@ui/components/RequestStatus";
 import { useRouter } from "next/navigation";
 import React from "react";
 
-import {
-  SignupApiResponse,
-  SignupRequestBody,
-  UserVerificationStatus,
-} from "@user/services/types/auth.dto";
+import { SignupRequestBody, UserVerificationStatus } from "@user/services/types/auth.dto";
 
 import { useFCMToken } from "../_hooks/useFCMToken";
 import { useSignupForm } from "../_hooks/useSignupForm";
 
-const DEFAULT_VERIFICATION_STATUS = "REQUIRED_SMS" as const;
-const USER_VERIFICATION_STATUS_LIST = ["REQUIRED_SMS", "NORMAL", "REQUIRED_REGISTER"] as const;
+const DEFAULT_VERIFICATION_STATUS = "DEFAULT" as const;
 
 type ResultStepProps = {
   form: SignupRequestBody;
 };
 
-const generateStatus = (
-  networkStatus: "error" | "idle" | "pending" | "success",
-  data?: SignupApiResponse,
-) => {
-  if (data === undefined || data === null) return networkStatus;
-  if (!data.success) return "error";
+type UserSignupStatus = UserVerificationStatus | "DEFAULT";
 
-  return "success";
-};
-
-const getUserStatusFromMessage = (message?: string): UserVerificationStatus => {
+const getUserStatusFromMessage = (message?: string): UserSignupStatus => {
   try {
     if (message === null || message === undefined) return DEFAULT_VERIFICATION_STATUS;
-    const [, detail] = message.split(". ");
-    const detailArray = new Array(detail);
 
-    const status = detailArray[1];
+    // eslint-disable-next-line no-magic-numbers
+    message = message.slice(1, -1).trim();
+    const pairs = message.split(", ").map((pair) => pair.split(": "));
+    const obj: { userId?: number; status?: UserVerificationStatus } = {};
+    pairs.forEach(([key, value]) => {
+      if (key !== "userId" && key !== "status") return;
+      if (!isNaN(Number(value))) {
+        obj["userId"] = Number(value);
+      } else {
+        obj["status"] = value as UserVerificationStatus;
+      }
+    });
 
-    if (USER_VERIFICATION_STATUS_LIST.some((value) => value === status))
-      return status as UserVerificationStatus;
+    if (obj["status"]) return obj["status"];
 
-    return DEFAULT_VERIFICATION_STATUS as UserVerificationStatus;
+    return DEFAULT_VERIFICATION_STATUS;
   } catch {
-    return DEFAULT_VERIFICATION_STATUS as UserVerificationStatus;
+    return DEFAULT_VERIFICATION_STATUS;
   }
 };
 
-const generateErrorMessage = (status: Status, userStatus: UserVerificationStatus) => {
-  if (status === "error")
-    return {
-      title: "회원가입에 실패했습니다",
-      description: "네트워크 연결 상태를 확인하고 다시 시도해주세요",
-    };
-
+const generateErrorMessage = (userStatus: UserSignupStatus) => {
   switch (userStatus) {
     case "NORMAL":
       return {
@@ -63,35 +52,40 @@ const generateErrorMessage = (status: Status, userStatus: UserVerificationStatus
       };
     case "REQUIRED_REGISTER":
       return {
-        title: "네트워크 연결 상태를 확인하고 다시 시도해주세요",
-        description: "",
+        title: "회원가입에 실패했습니다",
+        description: "네트워크 연결 상태를 확인하고 다시 시도해주세요",
       };
     case "REQUIRED_SMS":
       return {
         title: "회원가입에 실패했습니다",
         description: "휴대폰 인증이 필요합니다. 회원가입을 다시 시도해주세요",
       };
+    case "DEFAULT":
+      return {
+        title: "회원가입에 실패했습니다",
+        description: "회원가입을 다시 시도해주세요",
+      };
   }
 };
 
 function ResultStep({ form }: ResultStepProps) {
   const initailizeFCM = useFCMToken();
-  const { onSubmit, networkStatus, data } = useSignupForm({
-    onSuccess: ({ success }) => {
-      if (success) initailizeFCM();
+  const { onSubmit, networkStatus, error } = useSignupForm({
+    onSuccess: () => {
+      initailizeFCM();
       // TODO: status 별 정책 구현
     },
   });
   const router = useRouter();
-  const status = generateStatus(networkStatus, data);
-  const userStatus = getUserStatusFromMessage(data?.msg);
+  // const status = generateStatus(networkStatus, data);
+  const userStatus = getUserStatusFromMessage(error?.message);
 
-  const handleClick = (status: Status, userStatus: UserVerificationStatus) => () => {
+  const handleClick = (status: Status, userStatus: UserSignupStatus) => () => {
     if (status === "success") {
       router.replace("/");
     } else if (status === "error") {
-      if (userStatus === "NORMAL" || userStatus === "REQUIRED_SMS") router.replace("/login");
-      else if (userStatus === "REQUIRED_REGISTER") onSubmit(form);
+      if (userStatus === "REQUIRED_REGISTER") onSubmit(form);
+      else router.replace("/login");
     }
   };
 
@@ -103,20 +97,20 @@ function ResultStep({ form }: ResultStepProps) {
     <div className="flex h-full flex-col">
       <div className="flex flex-1 items-center justify-center">
         <RequestStatus
-          status={status}
+          status={networkStatus}
           contentPerStatus={{
             success: {
               title: "회원가입이 완료되었습니다",
             },
-            error: generateErrorMessage(networkStatus, userStatus),
+            error: generateErrorMessage(userStatus),
           }}
         />
       </div>
       <div className="h-[3.375rem] w-full">
         <SignupButton
-          status={status}
+          status={networkStatus}
           userStatus={userStatus}
-          onClick={handleClick(status, userStatus)}
+          onClick={handleClick(networkStatus, userStatus)}
         ></SignupButton>
       </div>
     </div>
@@ -125,16 +119,16 @@ function ResultStep({ form }: ResultStepProps) {
 
 export default ResultStep;
 
-const generateButtonContent = (status: Status, userStatus: UserVerificationStatus) => {
+const generateButtonContent = (status: Status, userStatus: UserSignupStatus) => {
   if (status === "success") return "홈으로 가기";
   if (userStatus === "REQUIRED_REGISTER") return "재시도 하기";
-  if (userStatus === "REQUIRED_SMS") return "회원가입 다시하기";
+  if (userStatus === "REQUIRED_SMS" || userStatus === "DEFAULT") return "회원가입 다시하기";
   if (userStatus === "NORMAL") return "로그인 하기";
 };
 
 type SignupButtonProps = {
   status: Status;
-  userStatus: UserVerificationStatus;
+  userStatus: UserSignupStatus;
   onClick: () => void;
 };
 function SignupButton({ status, userStatus, onClick }: SignupButtonProps) {

--- a/apps/user/app/register/_hooks/useSignupForm.ts
+++ b/apps/user/app/register/_hooks/useSignupForm.ts
@@ -1,17 +1,19 @@
 "use client";
 
 import { MutateOptions, useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 
 import { signup } from "@user/services/auth";
 import { SignupApiResponse, SignupRequestBody } from "@user/services/types/auth.dto";
 
 export const useSignupForm = (
   persistentOptions?: Omit<
-    MutateOptions<SignupApiResponse, Error, SignupRequestBody, unknown>,
+    MutateOptions<SignupApiResponse, AxiosError, SignupRequestBody, unknown>,
     "mutationFn"
   >,
 ) => {
   const {
+    error,
     mutate,
     status: networkStatus,
     data,
@@ -22,10 +24,10 @@ export const useSignupForm = (
 
   const onSubmit = (
     signupForm: SignupRequestBody,
-    options?: MutateOptions<SignupApiResponse, Error, SignupRequestBody, unknown>,
+    options?: MutateOptions<SignupApiResponse, AxiosError, SignupRequestBody, unknown>,
   ) => {
     mutate(signupForm, options);
   };
 
-  return { onSubmit, networkStatus, data };
+  return { onSubmit, networkStatus, data, error };
 };

--- a/apps/user/types/index.d.ts
+++ b/apps/user/types/index.d.ts
@@ -1,0 +1,8 @@
+import "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+declare module "@tanstack/react-query" {
+  interface Register {
+    defaultError: AxiosError;
+  }
+}


### PR DESCRIPTION
# [FLIZ-247/core] feat: API 응답 에러 판별 로직 구현

## 📝 작업 내용

프로젝트 API 응답은 http 응답 status code를 200대로 설정하고, 올바르지 않은 요청일 경우 status 프로퍼티에 http 응답 status code 값을 전달해주고 있습니다.
API 엔드포인트가 올바르다면 http 응답이 실패하지 않기 때문에 axios layer에서 실패한 요청에 대해 Promise.reject를 반환하지 않습니다.

이를 해결하기 위해 axios reponse interceptor에서 response 안의 status 값을 파싱하여 200 <= status < 300 인 경우 response를 반환하고 그 외의 경우 Promise.reject(new AxiosError(...))를 반환해주고 있습니다.

- axios를 사용하기 때문에 http 요청 중 에러가 발생하면 AxiosError 타입의 에러가 발생합니다. 하지만 TanstackQuery는 Error 타입으로 에러를 사용하여 type inference가 안 되는 불편함이 있습니다. 이를 해결하기 위해 [tanstack 공식문서](https://tanstack.com/query/v5/docs/framework/react/typescript#registering-a-global-error)를 참고하여 global error 타입을 AxiosError로 설정했습니다

- 회원가입 프로세스의 ResultStep에서 응답의 에러 메시지와 status 값에 의존적인 로직이 있어 업데이트된 정책을 반영했습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
