### PR TITLE
[FLIZ-260/trainer] feat: 회원가입 완료 후 토큰 최신화 로직 추가

### DIFF
--- a/apps/trainer/app/api/auth/tokens/route.ts
+++ b/apps/trainer/app/api/auth/tokens/route.ts
@@ -1,0 +1,39 @@
+/* eslint-disable no-magic-numbers */
+import { NextRequest, NextResponse } from "next/server";
+
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@trainer/constants/token";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { accessToken, refreshToken } = body;
+
+  if (!accessToken && !refreshToken)
+    return NextResponse.json({
+      success: false,
+    });
+
+  const response = NextResponse.json({
+    success: true,
+  });
+
+  if (accessToken) {
+    response.cookies.set(ACCESS_TOKEN_KEY, accessToken, {
+      httpOnly: false,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24, // 1 day
+      path: "/",
+    });
+  }
+  if (refreshToken) {
+    response.cookies.set(REFRESH_TOKEN_KEY, refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 7, // 7 days
+      path: "/",
+    });
+  }
+
+  return response;
+}

--- a/apps/trainer/app/register/_components/ResultStep.tsx
+++ b/apps/trainer/app/register/_components/ResultStep.tsx
@@ -5,6 +5,7 @@ import RequestStatus, { Status } from "@ui/components/RequestStatus";
 import { useRouter } from "next/navigation";
 import React from "react";
 
+import { saveTokens } from "@trainer/services/auth";
 import { SignupRequestBody, UserVerificationStatus } from "@trainer/services/types/auth.dto";
 
 import RouteInstance from "@trainer/constants/route";
@@ -73,8 +74,14 @@ const generateErrorMessage = (userStatus: UserSignupStatus) => {
 function ResultStep({ form }: ResultStepProps) {
   const initailizeFCM = useFCMToken();
   const { onSubmit, networkStatus, error } = useSignupForm({
-    onSuccess: () => {
-      initailizeFCM();
+    onSuccess: async ({ data }) => {
+      const {
+        data: { success },
+      } = await saveTokens(data);
+
+      if (success) initailizeFCM();
+
+      // TODO: success false 시 정책 구현
       // TODO: status 별 정책 구현
     },
   });

--- a/apps/trainer/services/auth.ts
+++ b/apps/trainer/services/auth.ts
@@ -1,3 +1,5 @@
+import axios from "axios";
+
 import http from "@trainer/app/apiCore";
 
 import {
@@ -6,6 +8,8 @@ import {
   SignupApiResponse,
   GetUserVerificationStatusApiResponse,
   GetSnsVerificationTokenApiResponse,
+  SaveTokensBody,
+  SaveTokensApiResponse,
 } from "./types/auth.dto";
 
 export const signup = (data: SignupRequestBody) =>
@@ -28,3 +32,6 @@ export const getSnsVerificationToken = () =>
   http.get<GetSnsVerificationTokenApiResponse>({
     url: "/v1/auth/email-verification-token",
   });
+
+export const saveTokens = (data: SaveTokensBody) =>
+  axios.post<SaveTokensApiResponse>("/api/auth/tokens", data);

--- a/apps/trainer/services/types/auth.dto.ts
+++ b/apps/trainer/services/types/auth.dto.ts
@@ -23,3 +23,11 @@ export type GetSnsVerificationTokenApiResponse = ResponseBase<{
 }>;
 
 export type UserVerificationStatus = "REQUIRED_REGISTER" | "REQUIRED_SMS" | "NORMAL";
+
+export type SaveTokensBody = {
+  accessToken: string;
+  refreshToken: string;
+};
+export type SaveTokensApiResponse = {
+  success: boolean;
+};


### PR DESCRIPTION
# [FLIZ-260/trainer] feat: 회원가입 완료 후 토큰 최신화 로직 추가

## 📝 작업 내용

회원가입 API 응답 데이터로 accessToken, refreshToken 쌍이 반환되는데, 이를 쿠키에 저장하기 위한 로직을 구현했습니다

토큰 중 refreshToken은 http-only로 설정해야 하기 때문에 클라이언트에서 쿠키 저장 로직을 만들 수 없었습니다. 그래서 Next Route Handler를 사용하여 토큰 저장 API를 만들어 회원가입 API 성공 시 Route Handler가 설정된 URI로 API 호출을 한번 더 하도록 설계했습니다

회원가입 자체를 RouteHandler를 이용하여 1개의 네트워크 요청으로 처리할까도 고민했지만, 별도의 axios config가 설정된 또 하나의 axiosInstance를 만들어야 한다는 점과, API 반환 데이터 형식을 맞추려고 할 시 로직의 복잡도 때문에 회원가입 API 와 토큰 저장 API를 분리했습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
