### PR TITLE
[FLIZ-264/user, trainer] feat: BottomNavigation 라우팅 로직 추가

### DIFF
--- a/apps/trainer/components/BottomNavigation.tsx
+++ b/apps/trainer/components/BottomNavigation.tsx
@@ -1,25 +1,36 @@
+import { cn } from "@ui/lib/utils";
 import { Bell, Calendar, ContactRound, UserRound } from "lucide-react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import RouteInstance from "@trainer/constants/route";
 
 export default function BottomNavigation() {
-  const navigationItems = [
-    { icon: Calendar, label: "캘린더" },
-    { icon: ContactRound, label: "회원" },
-    { icon: Bell, label: "알림" },
-    { icon: UserRound, label: "마이페이지" },
-  ];
+  const navigationItems = Object.freeze([
+    { icon: Calendar, label: "캘린더", path: RouteInstance["schedule-management"]() },
+    { icon: ContactRound, label: "회원", path: RouteInstance["member-management"]() },
+    { icon: Bell, label: "알림", path: RouteInstance.notification() },
+    { icon: UserRound, label: "마이페이지", path: RouteInstance["my-page"]() },
+  ]);
+
+  const pathname = usePathname();
 
   return (
     <nav className="bg-background-primary border-background-sub2 md:max-w-mobile fixed bottom-0 z-10 flex h-[5.063rem] w-full justify-around border-t">
-      {navigationItems.map(({ icon: Icon, label }, index) => (
+      {navigationItems.map(({ icon: Icon, label, path }, index) => (
         <div key={`${label}-${index}`} className="flex flex-1 items-center justify-center">
-          <button className="text-background-sub4 hover:text-background-sub5 flex w-12 flex-col items-center justify-center gap-1">
+          <Link
+            href={path}
+            className={cn(
+              "text-background-sub4 hover:text-background-sub5 flex w-12 flex-col items-center justify-center gap-1 transition-colors",
+              {
+                "text-text-primary": pathname === path,
+              },
+            )}
+          >
             <Icon />
-            {/* TODO: 각 페이지 경로 네이밍이 정해지면 이동할 경로명 href 작성 */}
-            <Link href="" className="text-body-5">
-              {label}
-            </Link>
-          </button>
+            <span className="text-body-5">{label}</span>
+          </Link>
         </div>
       ))}
     </nav>

--- a/apps/trainer/components/Providers/FooterProvider.tsx
+++ b/apps/trainer/components/Providers/FooterProvider.tsx
@@ -4,12 +4,22 @@ import { cn } from "@ui/lib/utils";
 import { usePathname } from "next/navigation";
 import React from "react";
 
+import RouteInstance from "@trainer/constants/route";
+
 import BottomNavigation from "../BottomNavigation";
 
-// TODO[2025.03.18]: user 모든 경로 분류하기
 const PATHS = {
-  WITH_FOOTER: new Set(["/", "/schedule-management", "/member-management"]),
-  WITHOUT_FOOTER: new Set(["/register", "/login"]),
+  WITH_FOOTER: new Set([
+    RouteInstance["schedule-management"](),
+    RouteInstance["member-management"](),
+    RouteInstance.notification(),
+    RouteInstance["my-page"](),
+  ]),
+  WITHOUT_FOOTER: new Set([
+    RouteInstance.register(),
+    RouteInstance["sns-verification"](),
+    RouteInstance.login(),
+  ]),
 };
 
 const doesPathNeedFooter = (pathName: string) => PATHS.WITH_FOOTER.has(pathName);

--- a/apps/trainer/constants/route.ts
+++ b/apps/trainer/constants/route.ts
@@ -62,6 +62,8 @@ class ROUTES {
     "edit-verificated-phone",
   ];
 
+  private _notification = () => [...this._root(), "notification"];
+
   get root() {
     return () => {
       return this._root().join(ROUTE_DIVIDER) + "/";
@@ -180,6 +182,10 @@ class ROUTES {
     return () => {
       return this["_edit-verificated-phone"]().join(ROUTE_DIVIDER);
     };
+  }
+
+  get notification() {
+    return () => this._notification().join(ROUTE_DIVIDER);
   }
 }
 

--- a/apps/user/components/BottomNavigation.tsx
+++ b/apps/user/components/BottomNavigation.tsx
@@ -2,33 +2,38 @@
 
 import { cn } from "@ui/lib/utils";
 import { Bell, Calendar, UserRound } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 import React from "react";
 
-type NavigationItemsProp = {
-  label: string;
-  path: string;
-  icon: React.ElementType;
-};
-
-const NAVIGATION_ITEMS: NavigationItemsProp[] = [
-  { label: "캘린더", path: "", icon: Calendar },
-  { label: "알림", path: "alarm", icon: Bell },
-  { label: "마이페이지", path: "my-page", icon: UserRound },
-];
+import RouteInstance from "@user/constants/routes";
 
 export default function BottomNavigation() {
+  const navigationItems = Object.freeze([
+    { label: "캘린더", path: RouteInstance["schedule-management"](), icon: Calendar },
+    { label: "알림", path: RouteInstance.notification(), icon: Bell },
+    { label: "마이페이지", path: RouteInstance["my-page"](), icon: UserRound },
+  ]);
+
+  const pathname = usePathname();
+
   return (
-    <nav className="bg-background-primary border-background-sub2 md:max-w-mobile fixed bottom-0 z-10 flex h-[5.063rem] w-full justify-around border">
-      {NAVIGATION_ITEMS.map(({ label, icon: Icon }) => (
-        <button
-          key={`navigation-${label}`}
-          className={cn(
-            "text-body-6 text-text-sub4 mt-[0.5rem] flex flex-1 flex-col items-center whitespace-nowrap",
-          )}
-        >
-          <Icon />
-          <div className={cn("mt-[0.25rem]")}>{label}</div>
-        </button>
+    <nav className="bg-background-primary border-background-sub2 md:max-w-mobile fixed bottom-0 z-10 flex h-[5.063rem] w-full justify-around border-t">
+      {navigationItems.map(({ icon: Icon, label, path }, index) => (
+        <div key={`${label}-${index}`} className="flex flex-1 items-center justify-center">
+          <Link
+            href={path}
+            className={cn(
+              "text-background-sub4 hover:text-background-sub5 flex w-12 flex-col items-center justify-center gap-1 transition-colors",
+              {
+                "text-text-primary": pathname === path,
+              },
+            )}
+          >
+            <Icon />
+            <span className="text-body-5">{label}</span>
+          </Link>
+        </div>
       ))}
     </nav>
   );

--- a/apps/user/components/Providers/FooterProvider.tsx
+++ b/apps/user/components/Providers/FooterProvider.tsx
@@ -10,7 +10,7 @@ import BottomNavigation from "../BottomNavigation";
 
 const PATHS = {
   WITH_FOOTER: new Set([
-    "/",
+    RouteInstance.root(),
     RouteInstance["schedule-management"](),
     RouteInstance.notification(),
     RouteInstance["my-page"](),


### PR DESCRIPTION
# [FLIZ-264/user, trainer] feat: BottomNavigation 라우팅 로직 추가

## 📝 작업 내용

user, trainer 서비스 BottomNavigation에 항목별 라우팅 로직을 추가했습니다.
- Nextjs Link API를 사용하여 각각의 항목을 Link로 설정했습니다.
- FooterProvider의 BottomNavigation 여부 판별 로직에서 string 리터럴 경로를 모두 RouteInstance로 수정했습니다
- 두 서비스에서 BottomNavigation 스타일을 통일했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
