### PR TITLE
[FLIZ-209/user] feat: 유저 도메인 API 작업

### DIFF
--- a/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
@@ -28,7 +28,7 @@ export default function TimeBlock({
 }: TimeBlockProps) {
   const reservationBlockConfig =
     reservationContent.length > 0 && reservationContent[0].status !== "휴무일"
-      ? RESERVATION_CONFIG[reservationContent[0].status]
+      ? RESERVATION_CONFIG[reservationContent[0].status as keyof typeof RESERVATION_CONFIG]
       : null;
   const reservationBlockStyle = reservationBlockConfig?.style;
   const reservationBlockContent = reservationBlockConfig?.content(reservationContent[0]);
@@ -36,8 +36,15 @@ export default function TimeBlock({
     reservationContents: reservationContent,
   });
 
-  const currentStatus: Exclude<ReservationStatus, "휴무일"> | null =
-    reservationContent.length > 0 && reservationContent[0].status !== "휴무일"
+  const currentStatus: Exclude<
+    ReservationStatus,
+    "휴무일" | "예약 취소 요청" | "예약 변경 요청" | "예약 취소"
+  > | null =
+    reservationContent.length > 0 &&
+    reservationContent[0].status !== "휴무일" &&
+    reservationContent[0].status !== "예약 취소 요청" &&
+    reservationContent[0].status !== "예약 변경 요청" &&
+    reservationContent[0].status !== "예약 취소"
       ? reservationContent[0].status
       : null;
 

--- a/apps/trainer/app/schedule-management/_components/Calendar/index.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/index.tsx
@@ -108,7 +108,7 @@ const MOCK_RESERVATION_DATA: ReservationStatusApiResponse["data"] = {
       sessionInfoId: 6,
       isDayOff: false,
       dayOfWeek: "WEDNESDAY",
-      reservationDate: ["2025-04-30T18:00"],
+      reservationDates: ["2025-04-30T18:00"],
       status: "예약 확정",
       memberInfo: {
         memberId: 5,
@@ -120,7 +120,7 @@ const MOCK_RESERVATION_DATA: ReservationStatusApiResponse["data"] = {
       sessionInfoId: 11,
       isDayOff: false,
       dayOfWeek: "TUESDAY",
-      reservationDate: ["2025-04-01T11:00"],
+      reservationDates: ["2025-04-01T11:00"],
       status: "수업 완료",
       memberInfo: {
         memberId: 12,
@@ -132,7 +132,7 @@ const MOCK_RESERVATION_DATA: ReservationStatusApiResponse["data"] = {
       sessionInfoId: 3,
       isDayOff: false,
       dayOfWeek: "MONDAY",
-      reservationDate: ["2025-04-28T15:00"],
+      reservationDates: ["2025-04-28T15:00"],
       status: "예약 대기",
       memberInfo: {
         memberId: 13,
@@ -144,7 +144,7 @@ const MOCK_RESERVATION_DATA: ReservationStatusApiResponse["data"] = {
       sessionInfoId: 4,
       isDayOff: false,
       dayOfWeek: "MONDAY",
-      reservationDate: ["2025-04-28T15:00"],
+      reservationDates: ["2025-04-28T15:00"],
       status: "예약 대기",
       memberInfo: {
         memberId: 14,
@@ -156,7 +156,7 @@ const MOCK_RESERVATION_DATA: ReservationStatusApiResponse["data"] = {
       sessionInfoId: 5,
       isDayOff: false,
       dayOfWeek: "MONDAY",
-      reservationDate: ["2025-04-28T15:00"],
+      reservationDates: ["2025-04-28T15:00"],
       status: "예약 대기",
       memberInfo: {
         memberId: 15,
@@ -168,7 +168,7 @@ const MOCK_RESERVATION_DATA: ReservationStatusApiResponse["data"] = {
       sessionInfoId: null,
       isDayOff: true,
       dayOfWeek: "THURSDAY",
-      reservationDate: ["2025-04-03"],
+      reservationDates: ["2025-04-03"],
       status: "휴무일",
       memberInfo: {
         memberId: null,
@@ -180,7 +180,7 @@ const MOCK_RESERVATION_DATA: ReservationStatusApiResponse["data"] = {
       sessionInfoId: null,
       isDayOff: true,
       dayOfWeek: "FRIDAY",
-      reservationDate: ["2025-04-04"],
+      reservationDates: ["2025-04-04"],
       status: "휴무일",
       memberInfo: {
         memberId: null,
@@ -192,7 +192,7 @@ const MOCK_RESERVATION_DATA: ReservationStatusApiResponse["data"] = {
       sessionInfoId: null,
       isDayOff: false,
       dayOfWeek: "WEDNESDAY",
-      reservationDate: ["2025-04-02T11:00"],
+      reservationDates: ["2025-04-02T11:00"],
       status: "예약 불가",
       memberInfo: {
         memberId: null,

--- a/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/index.tsx
+++ b/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/index.tsx
@@ -18,7 +18,7 @@ type ReservationSheetRenderer = (
 ) => JSX.Element;
 
 export const SheetAdapter: Record<
-  Exclude<ReservationStatus, "휴무일">,
+  Exclude<ReservationStatus, "휴무일" | "예약 취소 요청" | "예약 변경 요청" | "예약 취소">,
   ReservationSheetRenderer
 > = {
   "예약 불가": (commonProps) => <ReservationNotAllowedCancelSheet {...commonProps} />,

--- a/apps/trainer/app/schedule-management/_constants/reservationConfig.ts
+++ b/apps/trainer/app/schedule-management/_constants/reservationConfig.ts
@@ -17,7 +17,10 @@ type ReservationConfig = {
 };
 
 export const RESERVATION_CONFIG: Record<
-  Exclude<ModifiedReservationListItem["status"], "휴무일">,
+  Exclude<
+    ModifiedReservationListItem["status"],
+    "휴무일" | "예약 취소 요청" | "예약 변경 요청" | "예약 취소"
+  >,
   ReservationConfig
 > = {
   "수업 완료": {

--- a/apps/trainer/app/schedule-management/_libs/CalendarUtils.ts
+++ b/apps/trainer/app/schedule-management/_libs/CalendarUtils.ts
@@ -17,9 +17,9 @@ export const parsedReservationContent = (
       return;
     }
 
-    return Array.isArray(content.reservationDate)
-      ? isEqual(date, content.reservationDate[0])
-      : isEqual(date, content.reservationDate);
+    return Array.isArray(content.reservationDates)
+      ? isEqual(date, content.reservationDates[0])
+      : isEqual(date, content.reservationDates);
   });
 };
 
@@ -31,7 +31,7 @@ export const isCheckDayOff = (
 
   return reservations.some((content) => {
     if (content.status === "휴무일") {
-      return isSameDay(date, new Date(content.reservationDate[0]));
+      return isSameDay(date, new Date(content.reservationDates[0]));
     }
   });
 };

--- a/apps/user/app/notification/page.tsx
+++ b/apps/user/app/notification/page.tsx
@@ -1,5 +1,7 @@
 import { Suspense } from "react";
 
+export const dynamic = "force-dynamic";
+
 import Fallback from "./_components/Fallback";
 import NotificationContainer from "./_components/NotificationContainer";
 

--- a/apps/user/app/schedule-management/_components/BottomSheet/ReservationCancelSheet.tsx
+++ b/apps/user/app/schedule-management/_components/BottomSheet/ReservationCancelSheet.tsx
@@ -16,6 +16,7 @@ import {
 import { ChangeEvent, useState } from "react";
 
 import RequestSuccessSheet from "./RequestSuccessSheet";
+import { useReservationCancelMutation } from "../../_hooks/mutation/useReservationCancelMutation";
 
 type ReservationCancelSheetProps = {
   reservationContent: BaseReservationListItem;
@@ -39,19 +40,27 @@ function ReservationCancelSheet({
   open,
   onChangeOpen,
 }: ReservationCancelSheetProps) {
-  const { status } = reservationContent;
+  const { status, reservationDates, reservationId } = reservationContent;
+
+  if (status === "예약 변경 요청") return;
+
   const [inputValue, setInputValue] = useState("");
   const [isRequestSuccessOpen, setIsRequestSuccessOpen] = useState(false);
+
+  const { reservationCancel } = useReservationCancelMutation();
 
   const handleChangeInput = (event: ChangeEvent<HTMLInputElement>) => {
     setInputValue(event.target.value);
   };
 
-  //TODO: 예약 취소 데이터 페칭 로직 추가
   const handleClickCancelReservation = () => {
+    reservationCancel({
+      reservationId: reservationId,
+      cancelReason: inputValue,
+      cancelDate: reservationDates[0],
+    });
+
     setIsRequestSuccessOpen(true);
-    //TODO: 에러 제거 용도로 작성해놓은 상태
-    reservationContent;
   };
 
   return (

--- a/apps/user/app/schedule-management/_components/BottomSheet/ReservationStatusSheet.tsx
+++ b/apps/user/app/schedule-management/_components/BottomSheet/ReservationStatusSheet.tsx
@@ -14,7 +14,6 @@ import {
   Sheet,
   SheetClose,
   SheetContent,
-  SheetDescription,
   SheetFooter,
   SheetHeader,
   SheetTitle,
@@ -28,6 +27,7 @@ import RouteInstance from "@user/constants/routes";
 
 import RequestSuccessSheet from "./RequestSuccessSheet";
 import ReservationCancelSheet from "./ReservationCancelSheet";
+import { useReservationCancelMutation } from "../../_hooks/mutation/useReservationCancelMutation";
 
 type ReservationStatusSheetProps = {
   open: boolean;
@@ -42,15 +42,17 @@ function ReservationStatusSheet({
 }: ReservationStatusSheetProps) {
   const router = useRouter();
 
-  const { status, reservationDate } = reservationContent;
-  const searchParams = new URLSearchParams({ reservationDate: reservationDate[0] });
-  const validateDates = reservationDate.map((content) => DateController(content).validate());
+  const { status, reservationDates, reservationId } = reservationContent;
+
+  const validateDates = reservationDates.map((content) => DateController(content).validate());
 
   const [isReservationCancelSheetOpen, setIsReservationCancelSheetOpen] = useState(false);
   const [isReservationCancelSuccessSheetOpen, setIsReservationCancelSuccessSheetOpen] =
     useState(false);
   const [isReservationRemindCancelPopupOpen, setIsReservationRemindCancelPopupOpen] =
     useState(false);
+
+  const { reservationCancel } = useReservationCancelMutation();
 
   const handleClickCancelButton = () => {
     if (status === "예약 대기") {
@@ -64,11 +66,24 @@ function ReservationStatusSheet({
 
   const handleClickChangeButton = () => {
     router.push(
-      RouteInstance.reservation("edit", { reservationDate: searchParams.get("reservationDate") }),
+      RouteInstance.reservation("edit", {
+        reservationDate: reservationDates[0],
+        reservationId: String(reservationId),
+      }),
     );
   };
 
+  /** TODO: 예약 대기에 대하여 취소 신청 로직
+   * 그런데, 예약 대기의 경우 1,2지망 총 2개의 시간대가 있을 수 있는데 이 2가지 시간대를 한번에 다 보내야하나?
+   * 아니면 반복분을 통해 인덱스 별로 따로 보내줘야하나?
+   */
   const handleClickRemindButton = () => {
+    reservationCancel({
+      reservationId: reservationId,
+      cancelReason: "예약 대기 취소 요청",
+      cancelDate: reservationDates[0],
+    });
+
     setIsReservationCancelSuccessSheetOpen(true);
   };
 
@@ -81,11 +96,11 @@ function ReservationStatusSheet({
           </SheetClose>
           <SheetHeader>
             <SheetTitle className="flex justify-center">{reservationContent?.status}</SheetTitle>
-            <SheetDescription className="flex justify-center">
+            <div className="text-body-1 flex justify-center">
               {status === "예약 대기" && (
                 <Badge className="mb-5 h-8 w-[6.313rem] rounded-full">예약 대기중</Badge>
               )}
-            </SheetDescription>
+            </div>
             <div className="bg-background-sub1 flex h-[5.625rem] w-full flex-col items-center justify-center rounded-[0.625rem]">
               {validateDates.map((validateDate) => (
                 <p key={validateDate?.toAbsolute()}>
@@ -95,30 +110,38 @@ function ReservationStatusSheet({
             </div>
           </SheetHeader>
           <SheetFooter>
-            <div className="flex h-[3.375rem] w-full gap-2">
+            {status === "예약 변경 요청" ? (
               <SheetClose asChild>
-                <Button
-                  onClick={handleClickCancelButton}
-                  className={cn(
-                    "bg-background-sub1 hover:bg-background-sub3 flex h-full w-full flex-1 items-center justify-center rounded-[0.625rem] transition-colors",
-                    reservationContent.status === "예약 대기" &&
-                      "bg-background-sub5 text-text-sub5 hover:bg-[#f5f5f5]",
-                  )}
-                >
-                  예약 취소
+                <Button className="bg-background-sub1  hover:bg-background-sub3 flex h-[3.375rem] w-full items-center justify-center ">
+                  확인
                 </Button>
               </SheetClose>
-              {status !== "예약 대기" && (
+            ) : (
+              <div className="flex h-[3.375rem] w-full gap-2">
                 <SheetClose asChild>
                   <Button
-                    onClick={handleClickChangeButton}
-                    className="bg-background-sub5 text-text-sub5 flex h-full w-full flex-1 items-center justify-center rounded-[0.625rem] transition-colors hover:bg-[#f5f5f5]"
+                    onClick={handleClickCancelButton}
+                    className={cn(
+                      "bg-background-sub1 hover:bg-background-sub3 flex h-full w-full flex-1 items-center justify-center rounded-[0.625rem] transition-colors",
+                      reservationContent.status === "예약 대기" &&
+                        "bg-background-sub5 text-text-sub5 hover:bg-[#f5f5f5]",
+                    )}
                   >
-                    예약 변경
+                    예약 취소
                   </Button>
                 </SheetClose>
-              )}
-            </div>
+                {status !== "예약 대기" && (
+                  <SheetClose asChild>
+                    <Button
+                      onClick={handleClickChangeButton}
+                      className="bg-background-sub5 text-text-sub5 flex h-full w-full flex-1 items-center justify-center rounded-[0.625rem] transition-colors hover:bg-[#f5f5f5]"
+                    >
+                      예약 변경
+                    </Button>
+                  </SheetClose>
+                )}
+              </div>
+            )}
           </SheetFooter>
         </SheetContent>
       </Sheet>

--- a/apps/user/app/schedule-management/_components/BottomSheet/ReservationStatusSheet.tsx
+++ b/apps/user/app/schedule-management/_components/BottomSheet/ReservationStatusSheet.tsx
@@ -73,10 +73,6 @@ function ReservationStatusSheet({
     );
   };
 
-  /** TODO: 예약 대기에 대하여 취소 신청 로직
-   * 그런데, 예약 대기의 경우 1,2지망 총 2개의 시간대가 있을 수 있는데 이 2가지 시간대를 한번에 다 보내야하나?
-   * 아니면 반복분을 통해 인덱스 별로 따로 보내줘야하나?
-   */
   const handleClickRemindButton = () => {
     reservationCancel({
       reservationId: reservationId,

--- a/apps/user/app/schedule-management/_components/Calendar/WeekCell.tsx
+++ b/apps/user/app/schedule-management/_components/Calendar/WeekCell.tsx
@@ -3,6 +3,7 @@
 
 import { BaseReservationListItem } from "@5unwan/core/api/types/common";
 import { Badge } from "@ui/components/Badge";
+import { cn } from "@ui/lib/utils";
 
 type WeekCellProps = {
   date: Date;
@@ -11,7 +12,7 @@ type WeekCellProps = {
 function WeekCell({ ptReservation }: WeekCellProps) {
   if (!ptReservation) return;
 
-  const { status, reservationDate } = ptReservation;
+  const { status, reservationDates } = ptReservation;
 
   const parsedTime = (reservationDate: string) => {
     const time = new Date(reservationDate).getHours();
@@ -21,16 +22,27 @@ function WeekCell({ ptReservation }: WeekCellProps) {
 
   return (
     <div className="flex flex-col items-center gap-[0.625rem]">
-      {reservationDate.map((date) => (
-        <Badge
-          key={date}
-          variant={status === "예약 대기" ? "secondary" : "brand"}
-          className="text-body-5 flex h-[1.063rem] min-w-[2.813rem] items-center justify-center rounded-[0.313rem] px-[0.063rem] py-[0.313rem]"
-        >
-          {parsedTime(date)}
-        </Badge>
-      ))}
-      <div className="text-body-6">{status}</div>
+      {status !== "예약 취소 요청" && status !== "예약 취소" && (
+        <>
+          {reservationDates.map((date) => (
+            <Badge
+              key={date}
+              variant={status === "예약 대기" ? "secondary" : "brand"}
+              className="text-body-5 flex h-[1.063rem] min-w-[2.813rem] items-center justify-center rounded-[0.313rem] px-[0.063rem] py-[0.313rem]"
+            >
+              {parsedTime(date)}
+            </Badge>
+          ))}
+        </>
+      )}
+      <div
+        className={cn("text-body-6 text-text-primary whitespace-pre-wrap", {
+          "font-bold": status === "예약 취소 요청",
+          "text-text-sub3": status === "예약 취소 요청",
+        })}
+      >
+        {status === "예약 취소 요청" ? "예약 취소\n요청중" : status}
+      </div>
     </div>
   );
 }

--- a/apps/user/app/schedule-management/_components/Calendar/WeekRow.tsx
+++ b/apps/user/app/schedule-management/_components/Calendar/WeekRow.tsx
@@ -23,14 +23,18 @@ export default function WeekRow({
   onChangeOpen,
 }: WeekRowProps) {
   const findReservationByDate = (date: Date) => {
-    return reservationContent.find((status) => isSameDay(status.reservationDate[0], date));
+    return reservationContent.find((status) => isSameDay(status.reservationDates[0], date));
   };
 
   const handleClickDate = (date: Date) => {
     const reservationContent = findReservationByDate(date);
 
     onChangeSelectedDate(date);
-    onSelectedReservationContent(reservationContent);
+    onSelectedReservationContent(
+      reservationContent?.status === "예약 취소 요청" || reservationContent?.status === "예약 취소"
+        ? undefined
+        : reservationContent,
+    );
     onChangeOpen(true);
   };
 

--- a/apps/user/app/schedule-management/_components/Calendar/index.tsx
+++ b/apps/user/app/schedule-management/_components/Calendar/index.tsx
@@ -1,52 +1,19 @@
 "use client";
 
 import { BaseReservationListItem } from "@5unwan/core/api/types/common";
+import { useQuery } from "@tanstack/react-query";
 import { DayPicker } from "@ui/components/DayPicker/index";
+import { format, startOfMonth } from "date-fns";
 import React, { useState } from "react";
+
+import { myInformationQueries } from "@user/queries/myInformation";
+import { reservationQueries } from "@user/queries/reservation";
 
 import Header from "./Header";
 import WeekRow from "./WeekRow";
 import { checkReservationIsFuture } from "../../_libs/checkReservationIsFuture";
+import { filterLatestReservationsByDate } from "../../_utils/reservationMerger";
 import ReservationStatusSheet from "../BottomSheet/ReservationStatusSheet";
-
-const mockReservations: BaseReservationListItem[] = [
-  {
-    reservationId: 1,
-    sessionInfoId: 6,
-    isDayOff: false,
-    dayOfWeek: "MONDAY",
-    reservationDate: ["2025-03-31T12:00"],
-    status: "예약 확정",
-    memberInfo: {
-      memberId: 4,
-      name: "홍길동",
-    },
-  },
-  {
-    reservationId: 2,
-    sessionInfoId: 7,
-    isDayOff: false,
-    dayOfWeek: "MONDAY",
-    reservationDate: ["2025-04-31T12:00"],
-    status: "예약 확정",
-    memberInfo: {
-      memberId: 5,
-      name: "최익",
-    },
-  },
-  {
-    reservationId: 11,
-    sessionInfoId: 8,
-    isDayOff: false,
-    dayOfWeek: "THURSDAY",
-    reservationDate: ["2025-04-28T04:00", "2025-04-28T06:00"],
-    status: "예약 대기",
-    memberInfo: {
-      memberId: 6,
-      name: "최용재",
-    },
-  },
-];
 
 export default function Calendar() {
   const [selectedDate, setSelectedDate] = useState<Date>();
@@ -55,29 +22,40 @@ export default function Calendar() {
   const [selectedReservationContent, setSelectedReservationContent] =
     useState<BaseReservationListItem>();
 
-  const canRenderSheet = checkReservationIsFuture(selectedReservationContent?.reservationDate[0]);
+  const canRenderSheet = checkReservationIsFuture(selectedReservationContent?.reservationDates[0]);
+
+  const firstDayOfMonth = startOfMonth(month);
+
+  const { data: myInformation } = useQuery(myInformationQueries.summary());
+
+  const { data: reservations } = useQuery({
+    ...reservationQueries.list(format(firstDayOfMonth, "yyyy-MM-dd")),
+    enabled: myInformation?.data?.connectingStatus === "CONNECTED",
+  });
 
   return (
     <>
-      <DayPicker
-        mode="single"
-        currentMonth={month}
-        onChangeMonth={setMonth}
-        className="md:max-w-mobile h-full w-full"
-        components={{
-          Caption: () => <Header month={month} onChangeMonth={setMonth} />,
-          Row: (props) => (
-            <WeekRow
-              selectedDate={selectedDate}
-              onChangeSelectedDate={setSelectedDate}
-              reservationContent={mockReservations}
-              onSelectedReservationContent={setSelectedReservationContent}
-              onChangeOpen={setIsReservationStatusSheetOpen}
-              {...props}
-            />
-          ),
-        }}
-      />
+      {reservations && (
+        <DayPicker
+          mode="single"
+          currentMonth={month}
+          onChangeMonth={setMonth}
+          className="md:max-w-mobile h-full w-full"
+          components={{
+            Caption: () => <Header month={month} onChangeMonth={setMonth} />,
+            Row: (props) => (
+              <WeekRow
+                selectedDate={selectedDate}
+                onChangeSelectedDate={setSelectedDate}
+                reservationContent={filterLatestReservationsByDate(reservations.data)}
+                onSelectedReservationContent={setSelectedReservationContent}
+                onChangeOpen={setIsReservationStatusSheetOpen}
+                {...props}
+              />
+            ),
+          }}
+        />
+      )}
 
       {canRenderSheet && selectedReservationContent && (
         <ReservationStatusSheet

--- a/apps/user/app/schedule-management/_components/ReservationAdder.tsx
+++ b/apps/user/app/schedule-management/_components/ReservationAdder.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable no-magic-numbers */
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { Button } from "@ui/components/Button";
 import {
   Dialog,
@@ -15,29 +17,24 @@ import Icon from "@ui/components/Icon";
 import { useRouter } from "next/navigation";
 import { ComponentPropsWithoutRef } from "react";
 
+import { myInformationQueries } from "@user/queries/myInformation";
+
 import RouteInstance from "@user/constants/routes";
 
-import { TrainerConnectStatus } from "../_types/addReservation";
 import { resolveTrainerConnectionFlow } from "../_utils/resolveTrainerConnectionFlow";
 
-type ReservationAdderProps = {
-  trainerConnectStatus: TrainerConnectStatus;
-  ptCount: number;
-};
-
-function ReservationAdder({ trainerConnectStatus, ptCount }: ReservationAdderProps) {
+function ReservationAdder() {
   const router = useRouter();
 
-  /** TODO: 트레이너 연결 상태 추출 */
-  // const { data: myInformation } = useSuspenseQuery(myInformationQueries.summary());
+  /** TODO: 내정보 API 호출 후, Response 내의 트레이너 연결 상태 추출 */
+  const { data: myInformation } = useQuery(myInformationQueries.summary());
 
   const onGoNewReservation = () => router.push(RouteInstance.reservation("new"));
-
   const onRequestConnect = () => router.push(RouteInstance["connect-trainer"]());
 
   const { popupData, onClickButton } = resolveTrainerConnectionFlow(
-    trainerConnectStatus,
-    ptCount,
+    myInformation?.data?.connectingStatus ?? "UNCONNECTED",
+    myInformation?.data?.sessionInfo?.totalCount ?? 0,
     onRequestConnect,
     onGoNewReservation,
   );

--- a/apps/user/app/schedule-management/_hooks/mutation/useReservationCancelMutation.ts
+++ b/apps/user/app/schedule-management/_hooks/mutation/useReservationCancelMutation.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { baseReservationKeys } from "@user/queries/reservation";
+
+import { cancelReservation } from "@user/services/reservations";
+
+type ReservationCancelMutationParams = {
+  reservationId: number;
+  cancelReason: string;
+  cancelDate: string;
+};
+
+export const useReservationCancelMutation = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, ...rest } = useMutation({
+    mutationFn: ({ reservationId, cancelDate, cancelReason }: ReservationCancelMutationParams) =>
+      cancelReservation({ reservationId }, { cancelReason, cancelDate }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: baseReservationKeys.lists() });
+    },
+  });
+
+  return { reservationCancel: mutate, ...rest };
+};

--- a/apps/user/app/schedule-management/_utils/reservationMerger.ts
+++ b/apps/user/app/schedule-management/_utils/reservationMerger.ts
@@ -1,0 +1,20 @@
+/* eslint-disable no-magic-numbers */
+import { BaseReservationListItem } from "@5unwan/core/api/types/common";
+
+const extractDateOnly = (dateString: string) => {
+  return dateString.split("T")[0];
+};
+
+export const filterLatestReservationsByDate = (reservations: BaseReservationListItem[]) => {
+  const dateMap: Record<string, BaseReservationListItem> = {};
+
+  for (let i = 0; i < reservations.length; i += 1) {
+    const reservation = reservations[i];
+    reservation.reservationDates.forEach((dateString) => {
+      const dateKey = extractDateOnly(dateString);
+      dateMap[dateKey] = reservation;
+    });
+  }
+
+  return Object.values(dateMap);
+};

--- a/apps/user/app/schedule-management/page.tsx
+++ b/apps/user/app/schedule-management/page.tsx
@@ -1,14 +1,21 @@
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+
+import { myInformationQueries } from "@user/queries/myInformation";
+
 import Calendar from "./_components/Calendar";
 import ReservationAdder from "./_components/ReservationAdder";
 
-function ScheduleManagement() {
-  /** TODO: 트레이너 연동 인증 로직으로 구현 */
+async function ScheduleManagement() {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery(myInformationQueries.summary());
 
   return (
     <main className="relative flex h-full w-full justify-center overflow-y-auto">
-      {/* <Link href={"http://3.34.169.105/oauth2/authorization/kakao"}>카카오 로그인</Link> */}
-      <Calendar />
-      <ReservationAdder trainerConnectStatus="CONNECTED" ptCount={1} />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <Calendar />
+        <ReservationAdder />
+      </HydrationBoundary>
     </main>
   );
 }

--- a/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/index.tsx
+++ b/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/index.tsx
@@ -21,7 +21,7 @@ function ReservationContainer({
   const [selectedDate, setSelectedDate] = useState<Date>(new Date(reservationDate || new Date()));
 
   return (
-    <section className="flex h-full flex-col overflow-hidden">
+    <section className="flex h-full w-full flex-col overflow-hidden">
       <TwoWeekCalendar selectedDate={selectedDate} onChangeSelectedDate={setSelectedDate} />
       <PtTimeSelector
         mode={mode}

--- a/apps/user/app/schedule-management/reservation/[mode]/_hooks/mutation/useReservationChangeMutation.ts
+++ b/apps/user/app/schedule-management/reservation/[mode]/_hooks/mutation/useReservationChangeMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { reservationChange } from "@user/services/reservations";
+
+type ReservationChangeMutationParams = {
+  reservationId: number;
+  reservationDate: string;
+  changeRequestDate: string;
+};
+
+export const useReservationChangeMutation = () => {
+  const { mutate, ...rest } = useMutation({
+    mutationFn: ({
+      reservationId,
+      reservationDate,
+      changeRequestDate,
+    }: ReservationChangeMutationParams) =>
+      reservationChange({ reservationId }, { reservationDate, changeRequestDate }),
+  });
+
+  return { reservationChange: mutate, ...rest };
+};

--- a/apps/user/app/schedule-management/reservation/[mode]/_hooks/mutation/useReservationRequestMutation.ts
+++ b/apps/user/app/schedule-management/reservation/[mode]/_hooks/mutation/useReservationRequestMutation.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { baseReservationKeys } from "@user/queries/reservation";
+
+import { directReservation } from "@user/services/reservations";
+import { DirectReservationRequestBody } from "@user/services/types/reservations.dto";
+
+export const useReservationRequestMutation = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, ...reset } = useMutation({
+    mutationFn: ({ trainerId, memberId, name, dates }: DirectReservationRequestBody) =>
+      directReservation({ trainerId, memberId, name, dates }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: baseReservationKeys.lists() });
+    },
+  });
+
+  return { reservationRequest: mutate, ...reset };
+};

--- a/apps/user/app/schedule-management/reservation/[mode]/page.tsx
+++ b/apps/user/app/schedule-management/reservation/[mode]/page.tsx
@@ -1,4 +1,7 @@
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import { notFound } from "next/navigation";
+
+import { myInformationQueries } from "@user/queries/myInformation";
 
 import Header from "./_components/Header";
 import ReservationContainer from "./_components/ReservationContainer";
@@ -19,21 +22,27 @@ export async function generateStaticParams() {
   return [{ mode: "new" }, { mode: "edit" }];
 }
 
-function Reservation({ params, searchParams }: ReservationParams) {
+async function Reservation({ params, searchParams }: ReservationParams) {
   const { mode } = params;
 
   if (mode !== "new" && mode !== "edit") notFound();
 
   const [reservationDate, reservationDateTime] = searchParams?.reservationDate?.split("T") ?? [];
 
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery(myInformationQueries.summary());
+
   return (
     <main className="flex h-full flex-col items-center overflow-hidden">
-      <Header mode={mode} />
-      <ReservationContainer
-        mode={mode}
-        reservationDate={reservationDate}
-        reservationDateTime={reservationDateTime}
-      />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <Header mode={mode} />
+        <ReservationContainer
+          mode={mode}
+          reservationDate={reservationDate}
+          reservationDateTime={reservationDateTime}
+        />
+      </HydrationBoundary>
     </main>
   );
 }

--- a/apps/user/constants/routes.ts
+++ b/apps/user/constants/routes.ts
@@ -79,6 +79,7 @@ class ROUTES {
       routeParams?: string,
       searchParams?: {
         reservationDate: string | null;
+        reservationId: string | null;
       },
     ) => {
       const filteredRoute = this["_reservation"](routeParams).filter(filterEmptyDynamicRoute);

--- a/apps/user/middleware.ts
+++ b/apps/user/middleware.ts
@@ -2,49 +2,42 @@
 
 import { NextResponse, NextRequest } from "next/server";
 
-import RouteInstance from "./constants/routes";
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "./constants/token";
 
 export function middleware(request: NextRequest) {
   const url = request.nextUrl.clone();
 
-  /** TODO: login 경로는 임시 경로로 추후 sns-verification 페이지 작업자가 해당 페이지로 이동하는 로직으로 12번 라인 수정 */
-  if (
-    url.pathname === RouteInstance["sns-verification"]() ||
-    url.pathname === RouteInstance["root"]()
-  ) {
-    const accessToken = url.searchParams.get("accessToken");
-    const refreshToken = url.searchParams.get("refreshToken");
+  const accessToken = url.searchParams.get("accessToken");
+  const refreshToken = url.searchParams.get("refreshToken");
 
-    if (accessToken) {
-      url.searchParams.delete("accessToken");
-      url.searchParams.delete("refreshToken");
+  if (accessToken) {
+    url.searchParams.delete("accessToken");
+    url.searchParams.delete("refreshToken");
 
-      const res = NextResponse.redirect(url);
+    const res = NextResponse.redirect(url);
 
-      /** TODO: maxAge에 설정된 시간은 협의 후 다시 설정 */
-      res.cookies.set(ACCESS_TOKEN_KEY, accessToken, {
-        httpOnly: false,
+    /** TODO: maxAge에 설정된 시간은 협의 후 다시 설정 */
+    res.cookies.set(ACCESS_TOKEN_KEY, accessToken, {
+      httpOnly: false,
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      maxAge: 60 * 60 * 24, // 1일
+      sameSite: "lax",
+    });
+    if (refreshToken) {
+      res.cookies.set(REFRESH_TOKEN_KEY, refreshToken, {
+        httpOnly: true,
         secure: process.env.NODE_ENV === "production",
         path: "/",
-        maxAge: 60 * 60 * 24, // 1일
+        maxAge: 60 * 60 * 24 * 7, // 7일
         sameSite: "lax",
       });
-      if (refreshToken) {
-        res.cookies.set(REFRESH_TOKEN_KEY, refreshToken, {
-          httpOnly: true,
-          secure: process.env.NODE_ENV === "production",
-          path: "/",
-          maxAge: 60 * 60 * 24 * 7, // 7일
-          sameSite: "lax",
-        });
-      }
-
-      return res;
     }
+
+    return res;
   }
 
   return NextResponse.next();
 }
 
-export const config = { matcher: [RouteInstance["login"]()] };
+export const config = { matcher: ["/", "/sns-verification"] };

--- a/apps/user/queries/myInformation.ts
+++ b/apps/user/queries/myInformation.ts
@@ -5,8 +5,12 @@ import {
   getMyInformationDetail,
   getMyPtHistory,
   getMyTrainerAvailableTime,
+  getTrainerAvailableTimes,
 } from "@user/services/myInformation";
-import { MyPtHistoryStatus } from "@user/services/types/myInformation.dto";
+import {
+  MyPtHistoryStatus,
+  TrainerAvailableTimesRequestPath,
+} from "@user/services/types/myInformation.dto";
 
 const PT_HISTORY_PAGE_SIZE = 3;
 const START_PAGE = 0;
@@ -49,5 +53,10 @@ export const myInformationQueries = {
     queryOptions({
       queryKey: [...myInformationBaseKeys.all(), "trainerAvailableTime", trainerId],
       queryFn: () => getMyTrainerAvailableTime(trainerId),
+    }),
+  trainerAvailableTimes: ({ trainerId }: TrainerAvailableTimesRequestPath) =>
+    queryOptions({
+      queryKey: [...myInformationBaseKeys.all(), "trainerAvailableTimes"] as const,
+      queryFn: () => getTrainerAvailableTimes({ trainerId }),
     }),
 };

--- a/apps/user/services/myInformation.ts
+++ b/apps/user/services/myInformation.ts
@@ -13,6 +13,8 @@ import {
   MyPtHistoryRequestPath,
   MyPtHistoryRequestQuery,
   MyTrainerAvailableTimeApiResponse,
+  TrainerAvailableTimesApiResponse,
+  TrainerAvailableTimesRequestPath,
 } from "./types/myInformation.dto";
 
 const USER_BASE_URL = "members";
@@ -62,4 +64,9 @@ export const getMyPtHistory = (
 export const getMyTrainerAvailableTime = (trainerId: number) =>
   http.get<MyTrainerAvailableTimeApiResponse>({
     url: `/v1/${USER_BASE_URL}/trainers/${trainerId}/available-times`,
+  });
+
+export const getTrainerAvailableTimes = ({ trainerId }: TrainerAvailableTimesRequestPath) =>
+  http.get<TrainerAvailableTimesApiResponse>({
+    url: `/v1/trainers/${trainerId}/available-times`,
   });

--- a/apps/user/services/reservations.ts
+++ b/apps/user/services/reservations.ts
@@ -17,17 +17,27 @@ import {
 const RESERVATION_BASE_URL = "reservations";
 
 export const getReservationStatus = ({ date }: ReservationStatusRequestQuery) =>
-  http.get<ReservationStatusApiResponse>({ url: `${RESERVATION_BASE_URL}`, params: { date } });
+  http.get<ReservationStatusApiResponse>({ url: `/v1/${RESERVATION_BASE_URL}`, params: { date } });
 
 export const getReservationDetailStatus = ({ reservationId }: ReservationDetailStatusRequestPath) =>
   http.get<ReservationDetailStatusApiResponse>({
-    url: `${RESERVATION_BASE_URL}/${reservationId}},`,
+    url: `/v1/${RESERVATION_BASE_URL}/${reservationId}`,
   });
 
-export const directReservation = ({ reservations }: DirectReservationRequestBody) =>
+export const directReservation = ({
+  trainerId,
+  memberId,
+  name,
+  dates,
+}: DirectReservationRequestBody) =>
   http.post<DirectReservationApiResponse>({
-    url: `${RESERVATION_BASE_URL}`,
-    data: { reservations },
+    url: `/v1/${RESERVATION_BASE_URL}`,
+    data: {
+      trainerId,
+      memberId,
+      name,
+      dates,
+    },
   });
 
 export const cancelReservation = (
@@ -35,12 +45,13 @@ export const cancelReservation = (
   requestBody: CancelReservationRequestBody,
 ) => {
   const { reservationId } = requestPath;
-  const { cancel_reason } = requestBody;
+  const { cancelReason, cancelDate } = requestBody;
 
   return http.post<CancelReservationApiResponse>({
-    url: `${RESERVATION_BASE_URL}/${reservationId}}/cancel`,
+    url: `/v1/${RESERVATION_BASE_URL}/${reservationId}/cancel`,
     data: {
-      cancel_reason,
+      cancelReason,
+      cancelDate,
     },
   });
 };
@@ -50,15 +61,13 @@ export const reservationChange = (
   requestBody: ReservationChangeRequestBody,
 ) => {
   const { reservationId } = requestPath;
-  const { reservationDate, reservationDay, changeDate, changeDay } = requestBody;
+  const { reservationDate, changeRequestDate } = requestBody;
 
   return http.post<ReservationChangeApiResponse>({
-    url: `${RESERVATION_BASE_URL}/${reservationId}`,
+    url: `/v1/${RESERVATION_BASE_URL}/${reservationId}/change-request`,
     data: {
       reservationDate,
-      reservationDay,
-      changeDate,
-      changeDay,
+      changeRequestDate,
     },
   });
 };

--- a/apps/user/services/types/myInformation.dto.ts
+++ b/apps/user/services/types/myInformation.dto.ts
@@ -87,3 +87,13 @@ export type MyTrainerAvailableTimeResponse = {
 };
 
 export type MyTrainerAvailableTimeApiResponse = ResponseBase<MyTrainerAvailableTimeResponse>;
+export type TrainerAvailableTimesRequestPath = {
+  trainerId: number;
+};
+type TrainerAvailableTimesResponse = {
+  currentSchedules: {
+    applyAt: string;
+    schedules: AvailablePtTime[];
+  };
+};
+export type TrainerAvailableTimesApiResponse = ResponseBase<TrainerAvailableTimesResponse>;

--- a/apps/user/services/types/reservations.dto.ts
+++ b/apps/user/services/types/reservations.dto.ts
@@ -2,7 +2,6 @@ import {
   BaseMemberInfo,
   BaseReservationDetail,
   BaseReservationListItem,
-  DayOfWeek,
   ReservationPathParams,
   ReservationStatus,
   ResponseBase,
@@ -11,9 +10,7 @@ import {
 export type ReservationStatusRequestQuery = {
   date?: string;
 };
-type ReservationStatusResponse = {
-  reservations: BaseReservationListItem[];
-};
+type ReservationStatusResponse = BaseReservationListItem[];
 export type ReservationStatusApiResponse = ResponseBase<ReservationStatusResponse>;
 
 export type ReservationDetailStatusRequestPath = ReservationPathParams;
@@ -24,25 +21,23 @@ type ReservationDetailStatusResponse = BaseReservationDetail<
 export type ReservationDetailStatusApiResponse = ResponseBase<ReservationDetailStatusResponse>;
 
 export type DirectReservationRequestBody = {
-  reservations: {
-    trainerId: number;
-    memberId: number;
-    name: string;
-    date: string[];
-    priority: number;
-  }[];
+  trainerId: number;
+  memberId: number;
+  name: string;
+  dates: string[];
+  // priority: number;
 };
 type DirectReservationResponse = {
-  reservation: {
-    reservationId: number;
-    status: Extract<ReservationStatus, "예약 대기">;
-  };
+  reservationId: number;
+  status: Extract<ReservationStatus, "예약 대기">;
+  reservationDate: string;
 };
 export type DirectReservationApiResponse = ResponseBase<DirectReservationResponse>;
 
 export type CancelReservationRequestPath = ReservationPathParams;
 export type CancelReservationRequestBody = {
-  cancel_reason: string;
+  cancelReason: string;
+  cancelDate: string;
 };
 type CancelReservationResponse = {
   reservationId: number;
@@ -52,9 +47,7 @@ export type CancelReservationApiResponse = ResponseBase<CancelReservationRespons
 export type ReservationChangeRequestPath = ReservationPathParams;
 export type ReservationChangeRequestBody = {
   reservationDate: string;
-  reservationDay: DayOfWeek;
-  changeDate: string;
-  changeDay: DayOfWeek;
+  changeRequestDate: string;
 };
 type ReservationChangeResponse = {
   reservationId: number;

--- a/packages/core/src/api/types/common.ts
+++ b/packages/core/src/api/types/common.ts
@@ -42,7 +42,15 @@ export type AvailablePtTime = {
   endTime: string | null;
 };
 
-export type ReservationStatus = "예약 확정" | "예약 대기" | "예약 불가" | "수업 완료" | "휴무일";
+export type ReservationStatus =
+  | "예약 확정"
+  | "예약 대기"
+  | "예약 불가"
+  | "수업 완료"
+  | "휴무일"
+  | "예약 취소"
+  | "예약 변경 요청"
+  | "예약 취소 요청";
 
 export type BaseMemberInfo = {
   memberId: number;
@@ -60,7 +68,7 @@ export type BaseReservationListItem = {
   sessionInfoId: number;
   isDayOff: boolean;
   dayOfWeek: DayOfWeek;
-  reservationDate: string[];
+  reservationDates: string[];
   status: ReservationStatus;
   memberInfo: BaseMemberInfo;
 };


### PR DESCRIPTION
## 📝 작업 내용

## 유저 도메인 API 작업 
- 유저 도메인에서 필요한 API를 모두 붙혀놓은 상태이며, 아직 Error 및 fallback에 대한 핸들링은 꼼꼼하게 되어있지 않은 상태입니다.
   - 우선 API를 빠르게 붙혀 기능테스트를 하면서 Error/Fallback을 핸들링할 예정입니다.
- 공통 DTO 타입 수정으로 인해 트레이너 도메인 코드에서 타입 에러가 발생하여 임시 수정해 놓았습니다.
- Notification 페이지가 SSG로 분류되어 빌드 타임에 API 요청을 하고 있어, 인증 오류 에러가 나타나 빌드하지 못하고 죽는 이슈가 있었습니다. 우선 **빠른 진행을 위해** `'force-dynamic'`로 SSG가 아닌 SSR로 방식으로 렌더링하도록 임시 해결을 해 놓았고, 엄청 크리티컬 한 건 아니지만 다른 페이지들과 크게 다른점은 없어 보이는데, 해당 페이지가 왜 SSG로 렌더링되는지 Notifiaction 페이지 작업자이신 @yjc2021 님께서 한번 확인 해주시면 감사하겠습니다. 저도 이거 이유가 궁금해서 같이 해결해보아도 좋을 것 같아요 :)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
