### PR TITLE
[FLIZ-263/user] feat: authorization 로직 구현

### DIFF
--- a/apps/user/app/api/auth/reissue-token/route.ts
+++ b/apps/user/app/api/auth/reissue-token/route.ts
@@ -1,0 +1,39 @@
+/* eslint-disable no-magic-numbers */
+import { NextResponse } from "next/server";
+
+import { reissueToken } from "@user/services/auth";
+
+import { ACCESS_TOKEN_KEY } from "@user/constants/token";
+
+import { provideTokens } from "@user/utils/token";
+
+export async function POST() {
+  const refreshToken = await provideTokens("refreshToken")();
+
+  if (!refreshToken)
+    return NextResponse.json({ success: false, error: "Missing refresh token", status: 401 });
+
+  try {
+    const { data, success } = await reissueToken({ refreshToken: `${refreshToken}` });
+
+    if (!success)
+      return NextResponse.json({ success: false, error: "Invalid refresh token", status: 401 });
+
+    const { accessToken } = data;
+    const response = NextResponse.json({ success: true, accessToken });
+
+    if (accessToken) {
+      response.cookies.set(ACCESS_TOKEN_KEY, accessToken, {
+        httpOnly: false,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: 60 * 60 * 24, // 1 day
+        path: "/",
+      });
+    }
+
+    return response;
+  } catch (error) {
+    return NextResponse.json({ success: false, error: "Server error", status: 500 });
+  }
+}

--- a/apps/user/app/apiCore.ts
+++ b/apps/user/app/apiCore.ts
@@ -1,8 +1,8 @@
 import http, { initCoreApi } from "@5unwan/core/api/core";
-import { getCookie } from "cookies-next";
 
-import { ACCESS_TOKEN_KEY } from "@user/constants/token";
 import { BASE_URL } from "@user/constants/url";
+
+import { provideTokens } from "@user/utils/token";
 
 if (!BASE_URL) {
   throw new Error("NEXT_PUBLIC_API_BASE_URL 환경 변수가 설정되어 있지 않습니다.");
@@ -10,19 +10,7 @@ if (!BASE_URL) {
 
 initCoreApi({
   baseUrl: BASE_URL,
-  tokenProvider: async () => {
-    if (typeof window === "undefined") {
-      try {
-        const { cookies } = await import("next/headers");
-
-        return cookies().get(ACCESS_TOKEN_KEY)?.value ?? null;
-      } catch {
-        return null;
-      }
-    }
-
-    return getCookie(ACCESS_TOKEN_KEY) ?? null;
-  },
+  tokenProvider: provideTokens("accessToken"),
 });
 
 export default http;

--- a/apps/user/app/my-page/layout.tsx
+++ b/apps/user/app/my-page/layout.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from "react";
+
+import { requireAuth } from "@user/utils/auth";
+
+async function MyPageLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  await requireAuth();
+
+  return <>{children}</>;
+}
+
+export default MyPageLayout;

--- a/apps/user/app/notification/layout.tsx
+++ b/apps/user/app/notification/layout.tsx
@@ -1,10 +1,13 @@
 import Header from "@ui/components/Header";
-import React from "react";
+
+import { requireAuth } from "@user/utils/auth";
 
 type NotificationLayoutProps = Readonly<{
   children: React.ReactNode;
 }>;
-function NotificationLayout({ children }: NotificationLayoutProps) {
+async function NotificationLayout({ children }: NotificationLayoutProps) {
+  await requireAuth();
+
   return (
     <>
       <Header>

--- a/apps/user/app/refresh-session/loading.tsx
+++ b/apps/user/app/refresh-session/loading.tsx
@@ -1,0 +1,9 @@
+function LoadingPage() {
+  return (
+    <div>
+      <p>Refreshing session...</p>
+    </div>
+  );
+}
+
+export default LoadingPage;

--- a/apps/user/app/refresh-session/page.tsx
+++ b/apps/user/app/refresh-session/page.tsx
@@ -1,0 +1,30 @@
+// app/refresh-token/page.tsx
+"use client";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+import { saveReissuedTokens } from "@user/services/auth";
+
+export default function RefreshSessionPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const next = searchParams.get("next") || "/";
+
+  useEffect(() => {
+    const refresh = async () => {
+      try {
+        const {
+          data: { success },
+        } = await saveReissuedTokens();
+
+        if (success) router.replace(next);
+        else router.replace("/login");
+      } catch (err) {
+        router.replace("/login");
+      }
+    };
+    refresh();
+  }, []);
+
+  return <p>Refreshing session...</p>;
+}

--- a/apps/user/app/schedule-management/layout.tsx
+++ b/apps/user/app/schedule-management/layout.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from "react";
+
+import { requireAuth } from "@user/utils/auth";
+
+async function ScheduleManagementLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  await requireAuth();
+
+  return <>{children}</>;
+}
+
+export default ScheduleManagementLayout;

--- a/apps/user/constants/url.ts
+++ b/apps/user/constants/url.ts
@@ -2,3 +2,6 @@ export const BASE_URL =
   process.env.NODE_ENV === "development"
     ? `${process.env.NEXT_PUBLIC_DEV_API_BASE_URL}`
     : `${process.env.NEXT_PUBLIC_PROD_API_BASE_URL}`;
+
+export const BASE_ROUTE_HANDLER_URL =
+  process.env.NODE_ENV === "development" ? `http://localhost:3000` : `https://fitlink.biz`;

--- a/apps/user/middleware.ts
+++ b/apps/user/middleware.ts
@@ -1,43 +1,27 @@
-/* eslint-disable no-magic-numbers */
-
 import { NextResponse, NextRequest } from "next/server";
 
-import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "./constants/token";
+import { handleProtectedRoute } from "./middleware/handlers/handleProtectedRoute";
+import { handleTokenFromUrl } from "./middleware/handlers/handleTokenFromUrl";
+import {
+  isPublicTokenRoute,
+  PROTECTED_ROUTES,
+  PUBLIC_TOKEN_ROUTES,
+} from "./middleware/utils/routeMatchers";
 
 export function middleware(request: NextRequest) {
-  const url = request.nextUrl.clone();
+  const { pathname } = request.nextUrl.clone();
 
-  const accessToken = url.searchParams.get("accessToken");
-  const refreshToken = url.searchParams.get("refreshToken");
-
-  if (accessToken) {
-    url.searchParams.delete("accessToken");
-    url.searchParams.delete("refreshToken");
-
-    const res = NextResponse.redirect(url);
-
-    /** TODO: maxAge에 설정된 시간은 협의 후 다시 설정 */
-    res.cookies.set(ACCESS_TOKEN_KEY, accessToken, {
-      httpOnly: false,
-      secure: process.env.NODE_ENV === "production",
-      path: "/",
-      maxAge: 60 * 60 * 24, // 1일
-      sameSite: "lax",
-    });
-    if (refreshToken) {
-      res.cookies.set(REFRESH_TOKEN_KEY, refreshToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        path: "/",
-        maxAge: 60 * 60 * 24 * 7, // 7일
-        sameSite: "lax",
-      });
-    }
-
-    return res;
+  if (isPublicTokenRoute(pathname)) {
+    const tokenResponse = handleTokenFromUrl(request);
+    if (tokenResponse) return tokenResponse;
   }
+
+  const protectedResponse = handleProtectedRoute(request);
+  if (protectedResponse) return protectedResponse;
 
   return NextResponse.next();
 }
 
-export const config = { matcher: ["/", "/sns-verification"] };
+export const config = {
+  matcher: [...PUBLIC_TOKEN_ROUTES, ...PROTECTED_ROUTES],
+};

--- a/apps/user/middleware/handlers/handleProtectedRoute.ts
+++ b/apps/user/middleware/handlers/handleProtectedRoute.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import RouteInstance from "@user/constants/routes";
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@user/constants/token";
+
+import { isProtectedRoute } from "../utils/routeMatchers";
+
+export function handleProtectedRoute(request: NextRequest): NextResponse | void {
+  const { pathname } = request.nextUrl;
+  const isProtected = isProtectedRoute(pathname);
+
+  if (!isProtected) return;
+
+  const accessToken = request.cookies.get(ACCESS_TOKEN_KEY)?.value;
+  const refreshToken = request.cookies.get(REFRESH_TOKEN_KEY)?.value;
+
+  if (!accessToken && !refreshToken) {
+    const url = request.nextUrl.clone();
+    url.pathname = RouteInstance.login();
+
+    return NextResponse.redirect(url);
+  }
+}

--- a/apps/user/middleware/handlers/handleTokenFromUrl.ts
+++ b/apps/user/middleware/handlers/handleTokenFromUrl.ts
@@ -1,0 +1,37 @@
+/* eslint-disable no-magic-numbers */
+import { NextRequest, NextResponse } from "next/server";
+
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@user/constants/token";
+
+export function handleTokenFromUrl(request: NextRequest): NextResponse | void {
+  const url = request.nextUrl.clone();
+  const accessToken = url.searchParams.get("accessToken");
+  const refreshToken = url.searchParams.get("refreshToken");
+
+  if (!accessToken) return;
+
+  url.searchParams.delete("accessToken");
+  url.searchParams.delete("refreshToken");
+
+  const res = NextResponse.redirect(url);
+
+  res.cookies.set(ACCESS_TOKEN_KEY, accessToken, {
+    httpOnly: false,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 60 * 60 * 24,
+    sameSite: "lax",
+  });
+
+  if (refreshToken) {
+    res.cookies.set(REFRESH_TOKEN_KEY, refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 7,
+      sameSite: "lax",
+    });
+  }
+
+  return res;
+}

--- a/apps/user/middleware/utils/routeMatchers.ts
+++ b/apps/user/middleware/utils/routeMatchers.ts
@@ -1,0 +1,12 @@
+// middleware matcher에 사용하기 위해 static하게 유지
+export const PUBLIC_TOKEN_ROUTES = ["/", "login", "register", "/sns-verification"];
+
+export const PROTECTED_ROUTES = ["/schedule-management", "/my-page", "/notification"];
+
+export function isPublicTokenRoute(pathname: string): boolean {
+  return PUBLIC_TOKEN_ROUTES.includes(pathname);
+}
+
+export function isProtectedRoute(pathname: string): boolean {
+  return PROTECTED_ROUTES.some((route) => pathname.startsWith(route));
+}

--- a/apps/user/services/auth.ts
+++ b/apps/user/services/auth.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 
+import { BASE_ROUTE_HANDLER_URL } from "@user/constants/url";
+
 import http from "../app/apiCore";
 import {
   LogoutApiResponse,
@@ -11,6 +13,7 @@ import {
   SaveTokensApiResponse,
   ReissueTokenApiResponse,
   ReissueTokenRequestBody,
+  SaveReissuedTokensApiResponse,
 } from "./types/auth.dto";
 
 export const signup = (data: SignupRequestBody) =>
@@ -38,7 +41,20 @@ export const saveTokens = (data: SaveTokensBody) =>
   axios.post<SaveTokensApiResponse>("/api/auth/tokens", data);
 
 export const reissueToken = (data: ReissueTokenRequestBody) =>
-  http.post<ReissueTokenApiResponse>({
-    url: "/v1/auth/access-token",
-    data,
-  });
+  http.post<ReissueTokenApiResponse>(
+    {
+      url: "/v1/auth/access-token",
+      data,
+    },
+    "public",
+  );
+
+export const saveReissuedTokens = async () => {
+  return axios.post<SaveReissuedTokensApiResponse>(
+    `${BASE_ROUTE_HANDLER_URL}/api/auth/reissue-token`,
+    {},
+    {
+      withCredentials: true,
+    },
+  );
+};

--- a/apps/user/services/types/auth.dto.ts
+++ b/apps/user/services/types/auth.dto.ts
@@ -38,3 +38,8 @@ export type ReissueTokenRequestBody = {
 export type ReissueTokenApiResponse = ResponseBase<{
   accessToken: string;
 }>;
+
+export type SaveReissuedTokensApiResponse = {
+  success: boolean;
+  accessToken: string;
+};

--- a/apps/user/utils/auth.ts
+++ b/apps/user/utils/auth.ts
@@ -1,0 +1,59 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { getUserVerificationStatus } from "@user/services/auth";
+
+import RouteInstance from "@user/constants/routes";
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@user/constants/token";
+
+export async function requireAuth(nextPath = "/") {
+  const cookieStore = cookies();
+  const accessToken = cookieStore.get(ACCESS_TOKEN_KEY)?.value;
+  const refreshToken = cookieStore.get(REFRESH_TOKEN_KEY)?.value;
+
+  if (!accessToken && !refreshToken) {
+    redirect(RouteInstance.login());
+  }
+
+  if (accessToken && isTokenValid(accessToken)) {
+    try {
+      const { success, data } = await getUserVerificationStatus();
+      if (success) {
+        const { status: userStatus } = data;
+
+        if (userStatus === "NORMAL") return;
+        throw new Error("회원가입이 완료되지 않았습니다");
+      }
+
+      return;
+    } catch (error) {
+      redirect(RouteInstance.login());
+    }
+  }
+
+  if (refreshToken) {
+    redirect(`/refresh-session?next=${encodeURIComponent(nextPath)}`);
+  }
+
+  redirect(RouteInstance.login());
+}
+
+const SECONDS_TO_MILISECONDS = 1000;
+
+// expiration date만 확인
+function isTokenValid(token: string): boolean {
+  if (!token) return false;
+
+  try {
+    const [, payloadBase64] = token.split(".");
+    if (!payloadBase64) return false;
+
+    const payloadJson = Buffer.from(payloadBase64, "base64").toString();
+    const payload = JSON.parse(payloadJson);
+
+    // s 단위 JWT 'exp'를 ms 단위로 변환
+    return payload.exp * SECONDS_TO_MILISECONDS > Date.now();
+  } catch (error) {
+    return false;
+  }
+}

--- a/apps/user/utils/token.ts
+++ b/apps/user/utils/token.ts
@@ -1,0 +1,25 @@
+import { getCookie } from "cookies-next";
+
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@user/constants/token";
+
+const TOKEN_MAP = Object.freeze({
+  refreshToken: REFRESH_TOKEN_KEY,
+  accessToken: ACCESS_TOKEN_KEY,
+});
+
+export function provideTokens(type: "refreshToken" | "accessToken") {
+  return async function () {
+    if (typeof window === "undefined") {
+      try {
+        const { cookies } = await import("next/headers");
+
+        return cookies().get(TOKEN_MAP[type])?.value ?? null;
+      } catch (error) {
+        return null;
+      }
+    }
+
+    // http only인 refreshToken은 JS로 불러올 수 없습니다.
+    return getCookie(TOKEN_MAP[type]) ?? null;
+  };
+}


### PR DESCRIPTION
# [FLIZ-263/user] feat: authorization 로직 구현

<!-- 작업 패키지: root, ui, trainer, user, config-eslint, config-typescript, config-tailwind, storybook -->

## 📝 작업 내용

#168 와 동일하게 user 서비스 authorization 로직을 구현했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
