### PR TITLE
[FLIZ-286/trainer] fix: refresh-session 페이지 prerender 에러 해결

### DIFF
--- a/apps/trainer/app/refresh-session/loading.tsx
+++ b/apps/trainer/app/refresh-session/loading.tsx
@@ -1,0 +1,5 @@
+function Loading() {
+  return <p>Refreshing session...</p>;
+}
+
+export default Loading;


### PR DESCRIPTION
# [FLIZ-286/trainer] fix: refresh-session 페이지 prerender 에러 해결

## 📝 작업 내용

trainer 프로젝트 빌드 시 발생하는 prerender bug fix를 추가했습니다
refresh-session 페이지가 suspense boundary로 감싸져 있지 않아 발생한 버그를 해결했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
