### PR TITLE
[FLIZ-285/trainer] feat: 트레이너 알림 action sheet 및 하위 페이지 API 연결

### DIFF
--- a/apps/trainer/app/notification/connect/page.tsx
+++ b/apps/trainer/app/notification/connect/page.tsx
@@ -1,19 +1,81 @@
 "use client";
 
 import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import Header from "@ui/components/Header";
 import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
-import { useState } from "react";
+import { Fragment, Suspense, useRef, useState } from "react";
+
+import { notificationQueries } from "@trainer/queries/notification";
 
 import NotificationSideBar from "@trainer/components/NotificationSideBar";
 
+import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+
+import EmptyList from "../_components/EmptyList";
 import NotificationItemContainer from "../_components/NotificationItemContainer";
+import NotificationListFallback from "../_components/NotificationListFallback";
 import NotificationSearch from "../_components/NotificationSearch";
 import ConnectTrainerSheet from "../_components/SheetRenderer/ConnectTrainerSheet";
+import { NotificationStatus } from "../_types";
+import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
+import handleNotificationFilter from "../_utils/handleNotificationFilter";
+
+type ConnectNotificationContentProps = {
+  status: NotificationStatus;
+  onNotificationClick: (notification: NotificationInfo) => () => void;
+};
+function ConnectNotificationContent({
+  status,
+  onNotificationClick,
+}: ConnectNotificationContentProps) {
+  const intersectionRef = useRef(null);
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useSuspenseInfiniteQuery(
+    notificationQueries.list({ type: "CONNECT" }),
+  );
+  const handleIntersect = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  useIntersectionObserver({
+    target: intersectionRef,
+    handleIntersect: handleIntersect,
+  });
+
+  const filteredNotificationCount = createFilteredNotificationCount(data, status);
+
+  return (
+    <>
+      <div className="my-4 flex items-center justify-between">
+        <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
+        <span className="text-body-3">최신순</span>
+      </div>
+      {data.pages[0].data.totalElements ? (
+        <ul>
+          {data.pages.map((group, index) => (
+            <Fragment key={`search-notificationGroup-${index}`}>
+              {group.data.content.filter(handleNotificationFilter(status)).map((notification) => (
+                <NotificationItemContainer
+                  notification={notification}
+                  onClick={onNotificationClick(notification)}
+                  key={`search-notification-${notification.notificationId}`}
+                />
+              ))}
+            </Fragment>
+          ))}
+          <div ref={intersectionRef} />
+        </ul>
+      ) : (
+        <EmptyList />
+      )}
+    </>
+  );
+}
 
 function ConnectNotificationPage() {
   const [isNotificationSearchOpen, setIsNotificationSearchOpen] = useState(false);
-  const [status, setStatus] = useState("all");
+  const [status, setStatus] = useState<NotificationStatus>("all");
   const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
   const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
 
@@ -41,7 +103,7 @@ function ConnectNotificationPage() {
         <Header.Left>
           <NotificationSideBar />
         </Header.Left>
-        <Header.Title content={"연동 승인"} />
+        <Header.Title content="연동 승인" />
         <Header.Right>
           <NotificationSearch
             isOpen={isNotificationSearchOpen}
@@ -53,21 +115,16 @@ function ConnectNotificationPage() {
       <ToggleGroup
         type="single"
         value={status}
-        onValueChange={setStatus}
+        onValueChange={setStatus as (value: string) => void}
         className="w-full justify-start"
       >
         <ToggleGroupItem value="all">전체</ToggleGroupItem>
         <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
         <ToggleGroupItem value="complete">처리</ToggleGroupItem>
       </ToggleGroup>
-      <ul>
-        {DUMMY_NOTIFICATION.map((notification) => (
-          <NotificationItemContainer
-            notification={notification as NotificationInfo}
-            onClick={handleNotificationClick(notification as NotificationInfo)}
-          />
-        ))}
-      </ul>
+      <Suspense fallback={<NotificationListFallback />}>
+        <ConnectNotificationContent status={status} onNotificationClick={handleNotificationClick} />
+      </Suspense>
       {selectedNotification && (
         <ConnectTrainerSheet
           open={isActionSheetOpen}
@@ -81,26 +138,26 @@ function ConnectNotificationPage() {
 
 export default ConnectNotificationPage;
 
-const DUMMY_NOTIFICATION = [
-  {
-    notificationId: 1,
-    type: "연동 승인",
-    content: "홍길동 회원이 연동 승인을 요청했습니다",
-    sendDate: "2025-04-06T17:25:15.882954",
-    isProcessed: false,
-  },
-  {
-    notificationId: 2,
-    type: "연동 승인",
-    content: "홍길동 회원이 연동 승인을 요청했습니다",
-    sendDate: "2025-04-06T17:25:15.882954",
-    isProcessed: false,
-  },
-  {
-    notificationId: 3,
-    type: "연동 승인",
-    content: "홍길동 회원이 연동 승인을 요청했습니다",
-    sendDate: "2025-04-06T17:25:15.882954",
-    isProcessed: false,
-  },
-];
+// const DUMMY_NOTIFICATION = [
+//   {
+//     notificationId: 1,
+//     type: "연동 승인",
+//     content: "홍길동 회원이 연동 승인을 요청했습니다",
+//     sendDate: "2025-04-06T17:25:15.882954",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 2,
+//     type: "연동 승인",
+//     content: "홍길동 회원이 연동 승인을 요청했습니다",
+//     sendDate: "2025-04-06T17:25:15.882954",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 3,
+//     type: "연동 승인",
+//     content: "홍길동 회원이 연동 승인을 요청했습니다",
+//     sendDate: "2025-04-06T17:25:15.882954",
+//     isProcessed: false,
+//   },
+// ];

--- a/apps/trainer/app/notification/disconnect/page.tsx
+++ b/apps/trainer/app/notification/disconnect/page.tsx
@@ -1,18 +1,78 @@
 "use client";
 
 import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import Header from "@ui/components/Header";
 import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
-import { useState } from "react";
+import { Fragment, Suspense, useRef, useState } from "react";
+
+import { notificationQueries } from "@trainer/queries/notification";
 
 import NotificationSideBar from "@trainer/components/NotificationSideBar";
 
+import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+
+import EmptyList from "../_components/EmptyList";
 import NotificationItemContainer from "../_components/NotificationItemContainer";
 import NotificationSearch from "../_components/NotificationSearch";
+import { NotificationStatus } from "../_types";
+import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
+import handleNotificationFilter from "../_utils/handleNotificationFilter";
 
+type DisconnectNotificationContentProps = {
+  status: NotificationStatus;
+  onNotificationClick: (notification: NotificationInfo) => () => void;
+};
+function DisconnectNotificationContent({
+  status,
+  onNotificationClick,
+}: DisconnectNotificationContentProps) {
+  const intersectionRef = useRef(null);
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useSuspenseInfiniteQuery(
+    notificationQueries.list({ type: "DISCONNECT" }),
+  );
+  const handleIntersect = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  useIntersectionObserver({
+    target: intersectionRef,
+    handleIntersect: handleIntersect,
+  });
+
+  const filteredNotificationCount = createFilteredNotificationCount(data, status);
+
+  return (
+    <>
+      <div className="my-4 flex items-center justify-between">
+        <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
+        <span className="text-body-3">최신순</span>
+      </div>
+      {data.pages[0].data.totalElements ? (
+        <ul>
+          {data.pages.map((group, index) => (
+            <Fragment key={`search-notificationGroup-${index}`}>
+              {group.data.content.filter(handleNotificationFilter(status)).map((notification) => (
+                <NotificationItemContainer
+                  notification={notification}
+                  onClick={onNotificationClick(notification)}
+                  key={`search-notification-${notification.notificationId}`}
+                />
+              ))}
+            </Fragment>
+          ))}
+          <div ref={intersectionRef} />
+        </ul>
+      ) : (
+        <EmptyList />
+      )}
+    </>
+  );
+}
 function DisconnectNotificationPage() {
   const [isNotificationSearchOpen, setIsNotificationSearchOpen] = useState(false);
-  const [status, setStatus] = useState("all");
+  const [status, setStatus] = useState<NotificationStatus>("all");
   const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
 
   const handleSelectResult = () => {
@@ -37,7 +97,7 @@ function DisconnectNotificationPage() {
         <Header.Left>
           <NotificationSideBar />
         </Header.Left>
-        <Header.Title content={"연동 해제"} />
+        <Header.Title content="연동 해제" />
         <Header.Right>
           <NotificationSearch
             isOpen={isNotificationSearchOpen}
@@ -49,48 +109,46 @@ function DisconnectNotificationPage() {
       <ToggleGroup
         type="single"
         value={status}
-        onValueChange={setStatus}
+        onValueChange={setStatus as (value: string) => void}
         className="w-full justify-start"
       >
         <ToggleGroupItem value="all">전체</ToggleGroupItem>
         <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
         <ToggleGroupItem value="complete">처리</ToggleGroupItem>
       </ToggleGroup>
-      <ul>
-        {DUMMY_NOTIFICATION.map((notification) => (
-          <NotificationItemContainer
-            notification={notification as NotificationInfo}
-            onClick={handleNotificationClick(notification as NotificationInfo)}
-          />
-        ))}
-      </ul>
+      <Suspense>
+        <DisconnectNotificationContent
+          status={status}
+          onNotificationClick={handleNotificationClick}
+        />
+      </Suspense>
     </div>
   );
 }
 
 export default DisconnectNotificationPage;
 
-const DUMMY_NOTIFICATION = [
-  {
-    notificationId: 3,
-    type: "연동 해제",
-    content: "홍길동 회원이 연동을 해제했습니다",
-    sendDate: "2025-04-05T17:25:15.883592",
-    isProcessed: false,
-  },
+// const DUMMY_NOTIFICATION = [
+//   {
+//     notificationId: 3,
+//     type: "연동 해제",
+//     content: "홍길동 회원이 연동을 해제했습니다",
+//     sendDate: "2025-04-05T17:25:15.883592",
+//     isProcessed: false,
+//   },
 
-  {
-    notificationId: 1,
-    type: "연동 해제",
-    content: "홍길동 회원이 연동을 해제했습니다",
-    sendDate: "2025-04-05T17:25:15.883592",
-    isProcessed: false,
-  },
-  {
-    notificationId: 5,
-    type: "연동 해제",
-    content: "홍길동 회원이 연동을 해제했습니다",
-    sendDate: "2025-04-05T17:25:15.883592",
-    isProcessed: false,
-  },
-];
+//   {
+//     notificationId: 1,
+//     type: "연동 해제",
+//     content: "홍길동 회원이 연동을 해제했습니다",
+//     sendDate: "2025-04-05T17:25:15.883592",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 5,
+//     type: "연동 해제",
+//     content: "홍길동 회원이 연동을 해제했습니다",
+//     sendDate: "2025-04-05T17:25:15.883592",
+//     isProcessed: false,
+//   },
+// ];

--- a/apps/trainer/app/notification/page.tsx
+++ b/apps/trainer/app/notification/page.tsx
@@ -110,7 +110,7 @@ function AllNotificationPage() {
         <Header.Left>
           <NotificationSideBar />
         </Header.Left>
-        <Header.Title content={"PT 수업"} />
+        <Header.Title content="전체 알림" />
         <Header.Right>
           <NotificationSearch
             isOpen={isNotificationSearchOpen}

--- a/apps/trainer/app/notification/reservation-edit/page.tsx
+++ b/apps/trainer/app/notification/reservation-edit/page.tsx
@@ -1,20 +1,82 @@
 "use client";
 
 import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import Header from "@ui/components/Header";
 import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
-import { useState } from "react";
+import { Suspense, useState, Fragment, useRef } from "react";
+
+import { notificationQueries } from "@trainer/queries/notification";
 
 import NotificationSideBar from "@trainer/components/NotificationSideBar";
 
+import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+
+import EmptyList from "../_components/EmptyList";
 import NotificationItemContainer from "../_components/NotificationItemContainer";
+import NotificationListFallback from "../_components/NotificationListFallback";
 import NotificationSearch from "../_components/NotificationSearch";
 import SheetRenderer from "../_components/SheetRenderer";
+import { NotificationStatus } from "../_types";
+import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
+import handleNotificationFilter from "../_utils/handleNotificationFilter";
 import { parseEventDateFromContent } from "../_utils/parser";
+
+type ReservationEditNotificationContentProps = {
+  status: NotificationStatus;
+  onNotificationClick: (notification: NotificationInfo) => () => void;
+};
+function ReservationEditNotificationContent({
+  status,
+  onNotificationClick,
+}: ReservationEditNotificationContentProps) {
+  const intersectionRef = useRef(null);
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useSuspenseInfiniteQuery(
+    notificationQueries.list({ type: "RESERVATION_CHANGE_CANCEL" }),
+  );
+  const handleIntersect = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  useIntersectionObserver({
+    target: intersectionRef,
+    handleIntersect: handleIntersect,
+  });
+
+  const filteredNotificationCount = createFilteredNotificationCount(data, status);
+
+  return (
+    <>
+      <div className="my-4 flex items-center justify-between">
+        <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
+        <span className="text-body-3">최신순</span>
+      </div>
+      {data.pages[0].data.totalElements ? (
+        <ul>
+          {data.pages.map((group, index) => (
+            <Fragment key={`search-notificationGroup-${index}`}>
+              {group.data.content.filter(handleNotificationFilter(status)).map((notification) => (
+                <NotificationItemContainer
+                  notification={notification}
+                  onClick={onNotificationClick(notification)}
+                  key={`search-notification-${notification.notificationId}`}
+                />
+              ))}
+            </Fragment>
+          ))}
+          <div ref={intersectionRef} />
+        </ul>
+      ) : (
+        <EmptyList />
+      )}
+    </>
+  );
+}
 
 function ReservationEditNotificationPage() {
   const [isNotificationSearchOpen, setIsNotificationSearchOpen] = useState(false);
-  const [status, setStatus] = useState("all");
+  const [status, setStatus] = useState<NotificationStatus>("all");
   const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
   const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
 
@@ -45,7 +107,7 @@ function ReservationEditNotificationPage() {
         <Header.Left>
           <NotificationSideBar />
         </Header.Left>
-        <Header.Title content={"PT 예약 변경/취소"} />
+        <Header.Title content="PT 예약 변경/취소" />
         <Header.Right>
           <NotificationSearch
             isOpen={isNotificationSearchOpen}
@@ -57,21 +119,19 @@ function ReservationEditNotificationPage() {
       <ToggleGroup
         type="single"
         value={status}
-        onValueChange={setStatus}
+        onValueChange={setStatus as (value: string) => void}
         className="w-full justify-start"
       >
         <ToggleGroupItem value="all">전체</ToggleGroupItem>
         <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
         <ToggleGroupItem value="complete">처리</ToggleGroupItem>
       </ToggleGroup>
-      <ul>
-        {DUMMY_NOTIFICATION.map((notification) => (
-          <NotificationItemContainer
-            notification={notification as NotificationInfo}
-            onClick={handleNotificationClick(notification as NotificationInfo)}
-          />
-        ))}
-      </ul>
+      <Suspense fallback={<NotificationListFallback />}>
+        <ReservationEditNotificationContent
+          status={status}
+          onNotificationClick={handleNotificationClick}
+        />
+      </Suspense>
       {ActionSheet &&
         ActionSheet(
           {
@@ -87,35 +147,35 @@ function ReservationEditNotificationPage() {
 
 export default ReservationEditNotificationPage;
 
-const DUMMY_NOTIFICATION = [
-  {
-    notificationId: 2,
-    type: "예약 변경",
-    content:
-      "길동 회원님의 PT 예약 변경이 요청되었습니다.\n날짜: 04.21 (월) 오후 5시 -> 04.22 (화) 오후 5시",
-    sendDate: "2025-04-08T17:25:15.881664",
-    isProcessed: false,
-  },
-  {
-    notificationId: 3,
-    type: "예약 취소",
-    content: "홍길동 회원이 PT 예약 취소를 요청했습니다\n날짜: 1.1 (월) 오후 12시",
-    sendDate: "2025-04-07T17:25:15.882358",
-    isProcessed: false,
-  },
-  {
-    notificationId: 4,
-    type: "예약 변경",
-    content:
-      "길동 회원님의 PT 예약 변경이 요청되었습니다.\n날짜: 04.21 (월) 오후 5시 -> 04.22 (화) 오후 5시",
-    sendDate: "2025-04-08T17:25:15.881664",
-    isProcessed: false,
-  },
-  {
-    notificationId: 5,
-    type: "예약 취소",
-    content: "홍길동 회원이 PT 예약 취소를 요청했습니다\n날짜: 1.1 (월) 오후 12시",
-    sendDate: "2025-04-07T17:25:15.882358",
-    isProcessed: false,
-  },
-];
+// const DUMMY_NOTIFICATION = [
+//   {
+//     notificationId: 2,
+//     type: "예약 변경",
+//     content:
+//       "길동 회원님의 PT 예약 변경이 요청되었습니다.\n날짜: 04.21 (월) 오후 5시 -> 04.22 (화) 오후 5시",
+//     sendDate: "2025-04-08T17:25:15.881664",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 3,
+//     type: "예약 취소",
+//     content: "홍길동 회원이 PT 예약 취소를 요청했습니다\n날짜: 1.1 (월) 오후 12시",
+//     sendDate: "2025-04-07T17:25:15.882358",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 4,
+//     type: "예약 변경",
+//     content:
+//       "길동 회원님의 PT 예약 변경이 요청되었습니다.\n날짜: 04.21 (월) 오후 5시 -> 04.22 (화) 오후 5시",
+//     sendDate: "2025-04-08T17:25:15.881664",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 5,
+//     type: "예약 취소",
+//     content: "홍길동 회원이 PT 예약 취소를 요청했습니다\n날짜: 1.1 (월) 오후 12시",
+//     sendDate: "2025-04-07T17:25:15.882358",
+//     isProcessed: false,
+//   },
+// ];

--- a/apps/trainer/app/notification/reservation/page.tsx
+++ b/apps/trainer/app/notification/reservation/page.tsx
@@ -1,18 +1,79 @@
 "use client";
 
 import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import Header from "@ui/components/Header";
 import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
-import { useState } from "react";
+import { Fragment, Suspense, useRef, useState } from "react";
+
+import { notificationQueries } from "@trainer/queries/notification";
 
 import NotificationSideBar from "@trainer/components/NotificationSideBar";
 
+import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+
+import EmptyList from "../_components/EmptyList";
 import NotificationItemContainer from "../_components/NotificationItemContainer";
 import NotificationSearch from "../_components/NotificationSearch";
+import { NotificationStatus } from "../_types";
+import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
+import handleNotificationFilter from "../_utils/handleNotificationFilter";
+
+type ReservationNotificationContentProps = {
+  status: NotificationStatus;
+  onNotificationClick: (notification: NotificationInfo) => () => void;
+};
+function ReservationNotificationContent({
+  status,
+  onNotificationClick,
+}: ReservationNotificationContentProps) {
+  const intersectionRef = useRef(null);
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useSuspenseInfiniteQuery(
+    notificationQueries.list({ type: "RESERVATION_REQUEST" }),
+  );
+  const handleIntersect = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  useIntersectionObserver({
+    target: intersectionRef,
+    handleIntersect: handleIntersect,
+  });
+
+  const filteredNotificationCount = createFilteredNotificationCount(data, status);
+
+  return (
+    <>
+      <div className="my-4 flex items-center justify-between">
+        <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
+        <span className="text-body-3">최신순</span>
+      </div>
+      {data.pages[0].data.totalElements ? (
+        <ul>
+          {data.pages.map((group, index) => (
+            <Fragment key={`search-notificationGroup-${index}`}>
+              {group.data.content.filter(handleNotificationFilter(status)).map((notification) => (
+                <NotificationItemContainer
+                  notification={notification}
+                  onClick={onNotificationClick(notification)}
+                  key={`search-notification-${notification.notificationId}`}
+                />
+              ))}
+            </Fragment>
+          ))}
+          <div ref={intersectionRef} />
+        </ul>
+      ) : (
+        <EmptyList />
+      )}
+    </>
+  );
+}
 
 function ReservationNotificationPage() {
   const [isNotificationSearchOpen, setIsNotificationSearchOpen] = useState(false);
-  const [status, setStatus] = useState("all");
+  const [status, setStatus] = useState<NotificationStatus>("all");
   const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
 
   const handleSelectResult = () => {
@@ -37,7 +98,7 @@ function ReservationNotificationPage() {
         <Header.Left>
           <NotificationSideBar />
         </Header.Left>
-        <Header.Title content={"PT 예약 요청"} />
+        <Header.Title content="PT 예약 요청" />
         <Header.Right>
           <NotificationSearch
             isOpen={isNotificationSearchOpen}
@@ -49,54 +110,52 @@ function ReservationNotificationPage() {
       <ToggleGroup
         type="single"
         value={status}
-        onValueChange={setStatus}
+        onValueChange={setStatus as (value: string) => void}
         className="w-full justify-start"
       >
         <ToggleGroupItem value="all">전체</ToggleGroupItem>
         <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
         <ToggleGroupItem value="complete">처리</ToggleGroupItem>
       </ToggleGroup>
-      <ul>
-        {DUMMY_NOTIFICATION.map((notification) => (
-          <NotificationItemContainer
-            notification={notification as NotificationInfo}
-            onClick={handleNotificationClick(notification as NotificationInfo)}
-          />
-        ))}
-      </ul>
+      <Suspense>
+        <ReservationNotificationContent
+          status={status}
+          onNotificationClick={handleNotificationClick}
+        />
+      </Suspense>
     </div>
   );
 }
 
 export default ReservationNotificationPage;
 
-const DUMMY_NOTIFICATION = [
-  {
-    notificationId: 1,
-    type: "예약 요청",
-    content: "홍길동 회원님이 PT 예약을 요청하였습니다.\n날짜: 04.20 (일) 오후 6시",
-    sendDate: "2025-04-09T17:25:15.879023",
-    isProcessed: false,
-  },
-  {
-    notificationId: 2,
-    type: "예약 요청",
-    content: "홍길동 회원님이 PT 예약을 요청하였습니다.\n날짜: 04.20 (일) 오후 6시",
-    sendDate: "2025-04-09T17:25:15.879023",
-    isProcessed: false,
-  },
-  {
-    notificationId: 3,
-    type: "예약 요청",
-    content: "홍길동 회원님이 PT 예약을 요청하였습니다.\n날짜: 04.20 (일) 오후 6시",
-    sendDate: "2025-04-09T17:25:15.879023",
-    isProcessed: false,
-  },
-  {
-    notificationId: 4,
-    type: "예약 요청",
-    content: "홍길동 회원님이 PT 예약을 요청하였습니다.\n날짜: 04.20 (일) 오후 6시",
-    sendDate: "2025-04-09T17:25:15.879023",
-    isProcessed: false,
-  },
-];
+// const DUMMY_NOTIFICATION = [
+//   {
+//     notificationId: 1,
+//     type: "예약 요청",
+//     content: "홍길동 회원님이 PT 예약을 요청하였습니다.\n날짜: 04.20 (일) 오후 6시",
+//     sendDate: "2025-04-09T17:25:15.879023",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 2,
+//     type: "예약 요청",
+//     content: "홍길동 회원님이 PT 예약을 요청하였습니다.\n날짜: 04.20 (일) 오후 6시",
+//     sendDate: "2025-04-09T17:25:15.879023",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 3,
+//     type: "예약 요청",
+//     content: "홍길동 회원님이 PT 예약을 요청하였습니다.\n날짜: 04.20 (일) 오후 6시",
+//     sendDate: "2025-04-09T17:25:15.879023",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 4,
+//     type: "예약 요청",
+//     content: "홍길동 회원님이 PT 예약을 요청하였습니다.\n날짜: 04.20 (일) 오후 6시",
+//     sendDate: "2025-04-09T17:25:15.879023",
+//     isProcessed: false,
+//   },
+// ];

--- a/apps/trainer/app/notification/session/page.tsx
+++ b/apps/trainer/app/notification/session/page.tsx
@@ -1,20 +1,82 @@
 "use client";
 
 import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import Header from "@ui/components/Header";
 import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
-import { useState } from "react";
+import { useRef, useState, Fragment, Suspense } from "react";
+
+import { notificationQueries } from "@trainer/queries/notification";
 
 import NotificationSideBar from "@trainer/components/NotificationSideBar";
 
+import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+
+import EmptyList from "../_components/EmptyList";
 import NotificationItemContainer from "../_components/NotificationItemContainer";
+import NotificationListFallback from "../_components/NotificationListFallback";
 import NotificationSearch from "../_components/NotificationSearch";
 import SessionCompleteSheet from "../_components/SheetRenderer/SessionCompleteSheet";
+import { NotificationStatus } from "../_types";
+import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
+import handleNotificationFilter from "../_utils/handleNotificationFilter";
 import { parseEventDateFromContent } from "../_utils/parser";
+
+type SessionNotificationContentProps = {
+  status: NotificationStatus;
+  onNotificationClick: (notification: NotificationInfo) => () => void;
+};
+function SessionNotificationContent({
+  status,
+  onNotificationClick,
+}: SessionNotificationContentProps) {
+  const intersectionRef = useRef(null);
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage } = useSuspenseInfiniteQuery(
+    notificationQueries.list({ type: "SESSION" }),
+  );
+  const handleIntersect = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  useIntersectionObserver({
+    target: intersectionRef,
+    handleIntersect: handleIntersect,
+  });
+
+  const filteredNotificationCount = createFilteredNotificationCount(data, status);
+
+  return (
+    <>
+      <div className="my-4 flex items-center justify-between">
+        <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
+        <span className="text-body-3">최신순</span>
+      </div>
+      {data.pages[0].data.totalElements ? (
+        <ul>
+          {data.pages.map((group, index) => (
+            <Fragment key={`search-notificationGroup-${index}`}>
+              {group.data.content.filter(handleNotificationFilter(status)).map((notification) => (
+                <NotificationItemContainer
+                  notification={notification}
+                  onClick={onNotificationClick(notification)}
+                  key={`search-notification-${notification.notificationId}`}
+                />
+              ))}
+            </Fragment>
+          ))}
+          <div ref={intersectionRef} />
+        </ul>
+      ) : (
+        <EmptyList />
+      )}
+    </>
+  );
+}
 
 function SessionNotificationPage() {
   const [isNotificationSearchOpen, setIsNotificationSearchOpen] = useState(false);
-  const [status, setStatus] = useState("all");
+  const [status, setStatus] = useState<NotificationStatus>("all");
   const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
   const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
 
@@ -42,7 +104,7 @@ function SessionNotificationPage() {
         <Header.Left>
           <NotificationSideBar />
         </Header.Left>
-        <Header.Title content={"PT 수업"} />
+        <Header.Title content="PT 수업" />
         <Header.Right>
           <NotificationSearch
             isOpen={isNotificationSearchOpen}
@@ -54,22 +116,16 @@ function SessionNotificationPage() {
       <ToggleGroup
         type="single"
         value={status}
-        onValueChange={setStatus}
+        onValueChange={setStatus as (value: string) => void}
         className="w-full justify-start"
       >
         <ToggleGroupItem value="all">전체</ToggleGroupItem>
         <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
         <ToggleGroupItem value="complete">처리</ToggleGroupItem>
       </ToggleGroup>
-      <ul>
-        {DUMMY_NOTIFICATION.map((notification) => (
-          <NotificationItemContainer
-            key={`notification-${notification.notificationId}`}
-            notification={notification as NotificationInfo}
-            onClick={handleNotificationClick(notification as NotificationInfo)}
-          />
-        ))}
-      </ul>
+      <Suspense fallback={<NotificationListFallback />}>
+        <SessionNotificationContent status={status} onNotificationClick={handleNotificationClick} />
+      </Suspense>
       {selectedNotification && (
         <SessionCompleteSheet
           notificationId={selectedNotification.notificationId}
@@ -84,47 +140,47 @@ function SessionNotificationPage() {
 
 export default SessionNotificationPage;
 
-const DUMMY_NOTIFICATION = [
-  {
-    notificationId: 1,
-    type: "세션",
-    content: "홍길동 회원의 PT가 종료되었습니다\n날짜: 04.20 (일) 오후 6시",
-    sendDate: "2025-04-04T17:25:15.884254",
-    isProcessed: false,
-  },
-  {
-    notificationId: 2,
-    type: "세션",
-    content: "홍길동 회원의 PT가 종료되었습니다\n날짜: 04.20 (일) 오후 6시",
-    sendDate: "2025-04-04T17:25:15.884254",
-    isProcessed: false,
-  },
-  {
-    notificationId: 3,
-    type: "세션",
-    content: "홍길동 회원의 PT가 종료되었습니다\n날짜: 04.20 (일) 오후 6시",
-    sendDate: "2025-04-04T17:25:15.884254",
-    isProcessed: false,
-  },
-  {
-    notificationId: 4,
-    type: "세션",
-    content: "홍길동 회원의 PT가 종료되었습니다\n날짜: 04.20 (일) 오후 6시",
-    sendDate: "2025-04-04T17:25:15.884254",
-    isProcessed: false,
-  },
-  {
-    notificationId: 5,
-    type: "세션",
-    content: "홍길동 회원의 PT가 종료되었습니다\n날짜: 04.20 (일) 오후 6시",
-    sendDate: "2025-04-04T17:25:15.884254",
-    isProcessed: false,
-  },
-  {
-    notificationId: 6,
-    type: "세션",
-    content: "홍길동 회원의 PT가 종료되었습니다\n날짜: 04.20 (일) 오후 6시",
-    sendDate: "2025-04-04T17:25:15.884254",
-    isProcessed: false,
-  },
-];
+// const DUMMY_NOTIFICATION = [
+//   {
+//     notificationId: 1,
+//     type: "세션",
+//     content: "홍길동 회원의 PT가 종료되었습니다\n날짜: 04.20 (일) 오후 6시",
+//     sendDate: "2025-04-04T17:25:15.884254",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 2,
+//     type: "세션",
+//     content: "홍길동 회원의 PT가 종료되었습니다\n날짜: 04.20 (일) 오후 6시",
+//     sendDate: "2025-04-04T17:25:15.884254",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 3,
+//     type: "세션",
+//     content: "홍길동 회원의 PT가 종료되었습니다\n날짜: 04.20 (일) 오후 6시",
+//     sendDate: "2025-04-04T17:25:15.884254",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 4,
+//     type: "세션",
+//     content: "홍길동 회원의 PT가 종료되었습니다\n날짜: 04.20 (일) 오후 6시",
+//     sendDate: "2025-04-04T17:25:15.884254",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 5,
+//     type: "세션",
+//     content: "홍길동 회원의 PT가 종료되었습니다\n날짜: 04.20 (일) 오후 6시",
+//     sendDate: "2025-04-04T17:25:15.884254",
+//     isProcessed: false,
+//   },
+//   {
+//     notificationId: 6,
+//     type: "세션",
+//     content: "홍길동 회원의 PT가 종료되었습니다\n날짜: 04.20 (일) 오후 6시",
+//     sendDate: "2025-04-04T17:25:15.884254",
+//     isProcessed: false,
+//   },
+// ];

--- a/apps/trainer/components/NotificationAccordion.tsx
+++ b/apps/trainer/components/NotificationAccordion.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Accordion,
   AccordionContent,
@@ -5,74 +7,80 @@ import {
   AccordionTrigger,
 } from "@ui/components/Accordion";
 import { Bell, Calendar, Dumbbell, HeartHandshake } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useMemo } from "react";
 
-const VISIBILITY_COUNT = 0;
+import RouteInstance from "@trainer/constants/route";
 
-// TODO: 아코디언 클릭 시 이동할 경로의 네이밍이 정해지면 핸들러 붙히기
 export default function NotificationAccordion() {
-  // TODO: API가 만들어지고 나면 해당 API로 교체
-  const DUMMY_NOTIFICATION_ITEMS = [
-    {
-      title: "회원 연동",
-      contents: [
-        {
-          content: "연동 승인",
-          contentCount: 3,
-        },
-        {
-          content: "연동 해제",
-          contentCount: 2,
-        },
-      ],
-      icon: <HeartHandshake />,
-      titleCount: 5,
-    },
-    {
-      title: "PT 수업",
-      contents: [],
-      icon: <Dumbbell />,
-      titleCount: 0,
-    },
-    {
-      title: "PT 예약",
-      contents: [
-        {
-          content: "예약 요청",
-          contentCount: 0,
-        },
-        {
-          content: "예약 변경/취소",
-          contentCount: 0,
-        },
-      ],
-      icon: <Calendar />,
-      titleCount: 0,
-    },
-  ];
+  const NOTIFICATION_ACCORDION_ITEMS = useMemo(
+    () => [
+      {
+        title: "회원 연동",
+        contents: [
+          {
+            content: "연동 승인",
+            route: "connect",
+          },
+          {
+            content: "연동 해제",
+            route: "disconnect",
+          },
+        ],
+        icon: <HeartHandshake />,
+      },
+      {
+        title: "PT 수업",
+        contents: [],
+        icon: <Dumbbell />,
+        route: "session",
+      },
+      {
+        title: "PT 예약",
+        contents: [
+          {
+            content: "예약 요청",
+            route: "reservation",
+          },
+          {
+            content: "예약 변경/취소",
+            route: "reservation-edit",
+          },
+        ],
+        icon: <Calendar />,
+      },
+    ],
+    [],
+  );
+
+  const router = useRouter();
 
   return (
     <Accordion type="multiple">
       <AccordionItem value="전체 알림">
         <AccordionTrigger icon={<Bell />} className="border-0">
-          <span>전체 알림</span>
+          <span onClick={() => router.push(RouteInstance.notification())}>전체 알림</span>
         </AccordionTrigger>
       </AccordionItem>
-      {DUMMY_NOTIFICATION_ITEMS.map(({ title, contents, titleCount, icon }, index) => (
+      {NOTIFICATION_ACCORDION_ITEMS.map(({ title, contents, icon, route }, index) => (
         <AccordionItem value={String(index)} key={`${index}-${title}`}>
           <AccordionTrigger icon={icon}>
-            <span>{title}</span>
-            {titleCount > VISIBILITY_COUNT && (
-              <span className="bg-background-sub4 w-7 rounded-full text-center">{titleCount}</span>
-            )}
+            <span
+              onClick={() => {
+                if (!route) return;
+                router.push(RouteInstance.notification(route));
+              }}
+            >
+              {title}
+            </span>
           </AccordionTrigger>
-          {contents.map(({ content, contentCount }) => (
-            <AccordionContent key={`${content}-${contentCount}`}>
+          {contents.map(({ content, route }) => (
+            <AccordionContent
+              key={`${content}`}
+              onClick={() => router.push(RouteInstance.notification(route))}
+              className="cursor-pointer"
+            >
               <span>{content}</span>
-              {contentCount > VISIBILITY_COUNT && (
-                <span className="bg-background-sub4 w-7 rounded-full text-center">
-                  {contentCount}
-                </span>
-              )}
             </AccordionContent>
           ))}
         </AccordionItem>

--- a/apps/trainer/constants/route.ts
+++ b/apps/trainer/constants/route.ts
@@ -62,7 +62,7 @@ class ROUTES {
     "edit-verificated-phone",
   ];
 
-  private _notification = () => [...this._root(), "notification"];
+  private _notification = (routeParams?: string) => [...this._root(), "notification", routeParams];
 
   get root() {
     return () => {
@@ -187,7 +187,11 @@ class ROUTES {
   }
 
   get notification() {
-    return () => this._notification().join(ROUTE_DIVIDER);
+    return (routeParams?: string) => {
+      const filteredRoute = this["_notification"](routeParams).filter(filterEmptyDynamicRoute);
+
+      return filteredRoute.join(ROUTE_DIVIDER);
+    };
   }
 }
 

--- a/apps/trainer/queries/userManagement.ts
+++ b/apps/trainer/queries/userManagement.ts
@@ -42,6 +42,7 @@ export const userManagementQueries = {
     queryOptions({
       queryKey: [...userManagementBaseKeys.info(memberId)] as const,
       queryFn: () => getPtUserDetail({ memberId }),
+      enabled: !!memberId,
     }),
   ptHistory: (memberId: number, status: PtStatus) =>
     infiniteQueryOptions({

--- a/packages/core/src/api/types/common.ts
+++ b/packages/core/src/api/types/common.ts
@@ -105,7 +105,7 @@ export type NotificationDetailInfo = {
   content: string;
   sendDate: string;
   isProcessed: boolean;
-  userDetail: Omit<DetailedMemberInfo, "memberId">;
+  userDetail: Omit<DetailedMemberInfo, "memberId"> & { userId: number };
 };
 
 export type NotificationType =

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -31,6 +31,7 @@ function HeaderSection({ position, children, className }: HeaderSectionProps) {
   return (
     <div
       className={cn(
+        "cursor-pointer",
         {
           "col-start-1 col-end-2 justify-self-start": position === "left",
           "col-start-3 col-end-4 justify-self-end": position === "right",


### PR DESCRIPTION
# [FLIZ-285/trainer] feat: 트레이너 알림 action sheet 및 하위 페이지 API 연결

## 📝 작업 내용

- 트레이너 서비스 알림 도메인의 알림 action sheet 및 하위 페이지 API를 연결했습니다
- 데이터 로딩 중 UI 처리를 위해 Suspense를 사용했습니다
- 알림 사이드 바의 routing 로직을 추가했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
