### PR TITLE
[FLIZ-291/ui] fix: 알림 내용에서 회원 이름 중복 버그 해결

### DIFF
--- a/apps/trainer/app/notification/_components/NotificationItemContainer.tsx
+++ b/apps/trainer/app/notification/_components/NotificationItemContainer.tsx
@@ -34,7 +34,7 @@ function NotificationItemContainer({ notification, onClick }: NotificationItemCo
 
   if (isError) return <NotificationItemError />;
 
-  const { name, profilePictureUrl } = data.data.userDetail;
+  const { profilePictureUrl } = data.data.userDetail;
 
   return (
     <NotificationItem
@@ -42,7 +42,6 @@ function NotificationItemContainer({ notification, onClick }: NotificationItemCo
       variant={type}
       createdAt={sendDate}
       avatarSrc={profilePictureUrl}
-      memberName={name}
       isCompleted={isProcessed}
       key={`notification-${notificationId}`}
       className="w-full"

--- a/packages/ui/src/components/NotificationItem/NotificationItem.tsx
+++ b/packages/ui/src/components/NotificationItem/NotificationItem.tsx
@@ -10,7 +10,7 @@ type Props = Omit<HTMLAttributes<HTMLLIElement>, "onClick"> & NotificationProps;
 
 type NotificationProps = {
   isCompleted: boolean;
-  memberName?: string;
+  // memberName?: string;
   avatarSrc?: string;
   message: string;
   eventDate?: Date | string;
@@ -23,7 +23,7 @@ type NotificationProps = {
 const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
   const {
     isCompleted,
-    memberName,
+    // memberName,
     avatarSrc,
     createdAt,
     message,
@@ -44,7 +44,7 @@ const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
   const eventDateController = eventDate ? DateController(eventDate).validate() : undefined;
   const createdDateController = DateController(createdAt).validate();
   const eventDetailController = eventDetail ? DateController(eventDetail).validate() : undefined;
-  const messageCompound = memberName ? `${memberName} ${message}` : message;
+  // const messageCompound = memberName ? `${memberName} ${message}` : message;
 
   return (
     <li
@@ -63,7 +63,7 @@ const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
       <NotificationContent
         isCompleted={isCompleted}
         createdAt={createdDateController?.toRelative()}
-        message={messageCompound}
+        message={message}
         eventDate={eventDateController?.toServiceFormat().untilMinutes}
         variant={variant}
         eventDetail={


### PR DESCRIPTION
# [FLIZ-291/ui] fix: 알림 내용에서 회원 이름 중복 버그 해결

## 📝 작업 내용

API 업데이트로 트레이너 알림 내역마다 content에 이름이 중복으로 렌더링되는 버그를 해결했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
