### PR TITLE
[FLIZ-305/user] fix: 로그인 링크 redirection 경로 버그 해결

### DIFF
--- a/apps/trainer/constants/url.ts
+++ b/apps/trainer/constants/url.ts
@@ -6,4 +6,4 @@ export const BASE_URL =
 export const BASE_ROUTE_HANDLER_URL =
   process.env.NODE_ENV === "development"
     ? `http://localhost:3000`
-    : process.env.NEXT_PUBLIC_DEV_BASE_URL || "https://dev.trainer.fitlink.biz";
+    : process.env.NEXT_PUBLIC_BASE_URL || "https://dev.trainer.fitlink.biz";

--- a/apps/trainer/constants/url.ts
+++ b/apps/trainer/constants/url.ts
@@ -4,4 +4,6 @@ export const BASE_URL =
     : `${process.env.NEXT_PUBLIC_PROD_API_BASE_URL}`;
 
 export const BASE_ROUTE_HANDLER_URL =
-  process.env.NODE_ENV === "development" ? `http://localhost:3000` : `https://fitlink.biz`;
+  process.env.NODE_ENV === "development"
+    ? `http://localhost:3000`
+    : process.env.NEXT_PUBLIC_DEV_BASE_URL || "https://dev.trainer.fitlink.biz";

--- a/apps/user/app/login/_components/LoginButton/index.tsx
+++ b/apps/user/app/login/_components/LoginButton/index.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 
-import { BASE_URL } from "@user/constants/url";
+import { BASE_ROUTE_HANDLER_URL, BASE_URL } from "@user/constants/url";
 
-const generateLoginURI = (type: string) => `${BASE_URL}/oauth2/authorization/${type}`;
+const generateLoginURI = (type: string) =>
+  `${BASE_URL}/oauth2/authorization/${type}?state=${encodeURIComponent(BASE_ROUTE_HANDLER_URL)}`;
 
 type OAuthTypes = "kakao" | "naver" | "google";
 

--- a/apps/user/constants/url.ts
+++ b/apps/user/constants/url.ts
@@ -4,4 +4,6 @@ export const BASE_URL =
     : `${process.env.NEXT_PUBLIC_PROD_API_BASE_URL}`;
 
 export const BASE_ROUTE_HANDLER_URL =
-  process.env.NODE_ENV === "development" ? `http://localhost:3000` : `https://fitlink.biz`;
+  process.env.NODE_ENV === "development"
+    ? `http://localhost:3000`
+    : process.env.NEXT_PUBLIC_DEV_BASE_URL || "https://dev.user.fitlink.biz";

--- a/apps/user/constants/url.ts
+++ b/apps/user/constants/url.ts
@@ -6,4 +6,4 @@ export const BASE_URL =
 export const BASE_ROUTE_HANDLER_URL =
   process.env.NODE_ENV === "development"
     ? `http://localhost:3000`
-    : process.env.NEXT_PUBLIC_DEV_BASE_URL || "https://dev.user.fitlink.biz";
+    : process.env.NEXT_PUBLIC_BASE_URL || "https://dev.user.fitlink.biz";


### PR DESCRIPTION
# [FLIZ-305/user] fix: 로그인 링크 redirection 경로 버그 해결

## 📝 작업 내용

Oauth 로그인 후 서버에서 redirection 경로를 알 수 있도록 기존 로그인 링크에 query string을 추가하는 작업을 진행했습니다

### .env 환경 변수 업데이트
- user 및 trainer 서비스 환경 변수가 추가되었습니다. 로컬 프로젝트에 NEXT_PUBLIC_BASE_URL변수 추가 부탁드립니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
