### PR TITLE
[FLIZ-308/trainer] feat: 고정 예약 시 요일, 및 시간을 트레이너가 PT 가능한 일정에 맞게 표기되도록 구현

### DIFF
--- a/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
@@ -2,10 +2,12 @@
 
 import { ReservationStatus } from "@5unwan/core/api/types/common";
 import { cn } from "@ui/lib/utils";
+import { format } from "date-fns";
 import { ComponentProps, useState } from "react";
 
 import ScheduleBottomSheet from "@trainer/app/schedule-management/_components/ScheduleBottomSheet";
 
+import { AvailablePtTimeApiResponse } from "@trainer/services/types/myInformation.dto";
 import { ModifiedReservationListItem } from "@trainer/services/types/reservations.dto";
 
 import { isToday } from "@trainer/utils/CalendarUtils";
@@ -18,14 +20,27 @@ type TimeBlockProps = ComponentProps<"div"> & {
   PTstatus?: string;
   isNotificationRead?: boolean;
   reservationContent: ModifiedReservationListItem[];
+  ptAvailableTime: AvailablePtTimeApiResponse;
 };
 
 export default function TimeBlock({
   date,
   isNotificationRead,
   reservationContent,
+  ptAvailableTime,
   ...props
 }: TimeBlockProps) {
+  const ptTimeInformation = (
+    ptAvailableTime.data.currentSchedules || ptAvailableTime.data.scheduledChanges
+  ).schedules?.find(({ dayOfWeek }) => dayOfWeek === format(date, "EEEE").toUpperCase());
+
+  console.log("ptTimeInformation", ptTimeInformation);
+  console.log("date", date.getHours());
+
+  const isAvailableTime =
+    Number(ptTimeInformation?.startTime.split(":")[0]) <= date.getHours() &&
+    Number(ptTimeInformation?.endTime.split(":")[0]) >= date.getHours();
+
   const reservationBlockConfig =
     reservationContent.length > 0 &&
     reservationContent[0].status !== "휴무일" &&
@@ -76,29 +91,44 @@ export default function TimeBlock({
 
   return (
     <>
-      <div
-        onClick={handleClickBlock}
-        className={cn(
-          "bg-background-sub1 hover:bg-background-sub2 text-text-primary relative flex h-[3.9375rem] w-full cursor-pointer flex-col items-center justify-center gap-1 rounded-[0.125rem] p-1",
-          isToday(date) && "bg-background-sub3 hover:bg-background-sub4",
-          reservationBlockStyle,
-        )}
-        {...props}
-      >
-        <span className="text-body-2 whitespace-pre-line">{reservationBlockContent}</span>
-        <span className="text-body-5">{reservationBlockPtStatus}</span>
-        {isNotificationRead && (
-          <span className="bg-notification absolute right-1 top-1 h-[4px] w-[4px] rounded-full" />
-        )}
-      </div>
+      {isAvailableTime ? (
+        <>
+          <div
+            onClick={handleClickBlock}
+            className={cn(
+              "bg-background-sub1 hover:bg-background-sub2 text-text-primary relative flex h-[3.9375rem] w-full cursor-pointer flex-col items-center justify-center gap-1 rounded-[0.125rem] p-1",
+              isToday(date) && "bg-background-sub3 hover:bg-background-sub4",
+              reservationBlockStyle,
+            )}
+            {...props}
+          >
+            <span className="text-body-2 whitespace-pre-line">{reservationBlockContent}</span>
+            <span className="text-body-5">{reservationBlockPtStatus}</span>
+            {isNotificationRead && (
+              <span className="bg-notification absolute right-1 top-1 h-[4px] w-[4px] rounded-full" />
+            )}
+          </div>
 
-      <ScheduleBottomSheet
-        open={isScheduleBottomSheetOpen}
-        onChangeOpen={setIsScheduleBottomSheetOpen}
-        selectedDate={date}
-      />
+          <ScheduleBottomSheet
+            open={isScheduleBottomSheetOpen}
+            onChangeOpen={setIsScheduleBottomSheetOpen}
+            selectedDate={date}
+          />
 
-      {RenderSheet}
+          {RenderSheet}
+        </>
+      ) : (
+        <div
+          className={cn(
+            "bg-background-sub2 hover:bg-background-sub2 text-text-primary relative flex h-[3.9375rem] w-full cursor-not-allowed flex-col items-center justify-center gap-1 rounded-[0.125rem] p-1",
+            isToday(date) && "bg-background-sub3 hover:bg-background-sub4",
+            reservationBlockStyle,
+          )}
+          {...props}
+        >
+          -
+        </div>
+      )}
     </>
   );
 }

--- a/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
@@ -34,9 +34,6 @@ export default function TimeBlock({
     ptAvailableTime.data.currentSchedules || ptAvailableTime.data.scheduledChanges
   ).schedules?.find(({ dayOfWeek }) => dayOfWeek === format(date, "EEEE").toUpperCase());
 
-  console.log("ptTimeInformation", ptTimeInformation);
-  console.log("date", date.getHours());
-
   const isAvailableTime =
     Number(ptTimeInformation?.startTime.split(":")[0]) <= date.getHours() &&
     Number(ptTimeInformation?.endTime.split(":")[0]) >= date.getHours();

--- a/apps/trainer/app/schedule-management/_components/Calendar/WeekRow.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/WeekRow.tsx
@@ -60,6 +60,7 @@ export default function WeekRow({
                 filterLatestReservationsByDate(reservationInformation.data),
                 mergeDate,
               )}
+              ptAvailableTime={ptAvailableTime}
             />
           ))}
         </DayColumn>

--- a/apps/trainer/app/schedule-management/fixed-reservation/_components/SelectTimeRouteButton.tsx
+++ b/apps/trainer/app/schedule-management/fixed-reservation/_components/SelectTimeRouteButton.tsx
@@ -20,7 +20,6 @@ function SelectTimeRouteButton({ selectedMemberInformation }: SelectTimeRouteBut
       RouteInstance["select-pt-times"]("", {
         memberId: String(selectedMemberInformation?.memberId),
         name: selectedMemberInformation?.name,
-        edit: "true",
       }),
     );
   };

--- a/apps/trainer/app/schedule-management/fixed-reservation/select-pt-times/page.tsx
+++ b/apps/trainer/app/schedule-management/fixed-reservation/select-pt-times/page.tsx
@@ -12,7 +12,6 @@ function SelectPtTimes({ searchParams }: SelectPtTimesProps) {
   const userInformation = {
     memberId: Number(searchParams.memberId),
     name: searchParams.name,
-    isEdit: searchParams.edit === "true",
   };
 
   return (

--- a/packages/ui/src/components/DayOfWeekPicker/Context.tsx
+++ b/packages/ui/src/components/DayOfWeekPicker/Context.tsx
@@ -6,6 +6,7 @@ type DayOfWeekPickerContext = {
   value?: Days;
   completed: boolean[];
   onItemClick: Dispatch<React.SetStateAction<Days | undefined>>;
+  disabledDays?: Days[];
 };
 
 const DayOfWeekPickerContext = createContext<DayOfWeekPickerContext | null>(null);

--- a/packages/ui/src/components/DayOfWeekPicker/context.tsx
+++ b/packages/ui/src/components/DayOfWeekPicker/context.tsx
@@ -6,6 +6,7 @@ type DayOfWeekPickerContext = {
   value?: Days;
   completed: boolean[];
   onItemClick: Dispatch<React.SetStateAction<Days | undefined>>;
+  disabledDays?: Days[];
 };
 
 const DayOfWeekPickerContext = createContext<DayOfWeekPickerContext | null>(null);

--- a/packages/ui/src/components/DayOfWeekPicker/index.tsx
+++ b/packages/ui/src/components/DayOfWeekPicker/index.tsx
@@ -2,7 +2,7 @@
 
 import React, { forwardRef, useCallback } from "react";
 
-import DayOfWeekPickerContext from "./context";
+import DayOfWeekPickerContext from "./Context";
 import { Days } from "./Days";
 import useControllableState from "../../hooks/useControllableState";
 import useDayOfWeekPickerContext from "../../hooks/useDayOfWeekPickerContext";
@@ -21,11 +21,19 @@ type WrapperProps = {
   onCurrentDayChange: (value: Days) => void;
   defaultDay?: Days;
   completed?: boolean[];
+  disabledDays?: Days[];
 };
 
 const DayOfWeekPicker = forwardRef<HTMLDivElement, DayOfWeekPickerProps>(
   (
-    { currentDay, onCurrentDayChange, completed, defaultDay = Days.Monday, ...commonProps },
+    {
+      currentDay,
+      onCurrentDayChange,
+      completed,
+      defaultDay = Days.Monday,
+      disabledDays,
+      ...commonProps
+    },
     ref,
   ) => {
     const [value, setValue] = useControllableState({
@@ -40,6 +48,7 @@ const DayOfWeekPicker = forwardRef<HTMLDivElement, DayOfWeekPickerProps>(
           value: value || defaultDay,
           completed: completed || Array.from(Array(DAYS_IN_WEEK), () => false),
           onItemClick: useCallback(setValue, [setValue]),
+          disabledDays: disabledDays || [],
         }}
       >
         <DayOfWeekPickerImpl ref={ref} {...commonProps} />
@@ -79,9 +88,13 @@ type ItemProps = {
 
 const DayOfWeekPickerItem = forwardRef<HTMLDivElement, DayOfWeekPickerItemProps>(
   ({ day, children }, ref) => {
-    const { value, onItemClick, completed } = useDayOfWeekPickerContext();
+    const { value, onItemClick, completed, disabledDays } = useDayOfWeekPickerContext();
     const isCurrent = value === day;
+    const isDisabled = disabledDays?.includes(day);
+
     const handleClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      if (isDisabled) return;
+
       e.preventDefault();
       onItemClick(day);
     };
@@ -90,9 +103,15 @@ const DayOfWeekPickerItem = forwardRef<HTMLDivElement, DayOfWeekPickerItemProps>
     return (
       <div
         className={cn(
-          "hover:bg-brand-primary-600 flex h-[30px] w-[30px] items-center justify-center rounded-full border-none transition-colors duration-150",
+          "flex h-[30px] w-[30px] items-center justify-center rounded-full border-none transition-colors duration-150",
+          {
+            "hover:bg-brand-primary-600": !isDisabled,
+          },
           {
             "bg-background-sub3": isCompleted,
+          },
+          {
+            "cursor-not-allowed bg-gray-200 opacity-50": isDisabled,
           },
           {
             "bg-brand-primary-500": isCurrent,

--- a/packages/ui/src/hooks/useDayOfWeekPickerContext.ts
+++ b/packages/ui/src/hooks/useDayOfWeekPickerContext.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 
-import DayOfWeekPickerContext from "../components/DayOfWeekPicker/context";
+import DayOfWeekPickerContext from "../components/DayOfWeekPicker/Context";
 
 export const useDayOfWeekPickerContext = () => {
   const context = useContext(DayOfWeekPickerContext);


### PR DESCRIPTION
## 📝 작업 내용

#### 고정 예약 시 요일, 및 시간을 트레이너가 PT 가능한 일정에 맞게 표기되도록 구현
- 트레이너의 PT 가능 일정에 따라 요일 및 시간이 필터링되어 페이지에 동적으로 나타나게 됩니다.
#### 캘린더 페이지에 트레이너가 PT 가능한 일정에 맞게 스케줄이 표기되도록 구현
- 트레이너의 PT 가능 일정에 따라 스케줄에 동적으로 반영되도록 구현하였습니다.