### PR TITLE
FLIZ-314 feat: error-auth 페이지 구현

### DIFF
--- a/apps/trainer/app/auth-error/page.tsx
+++ b/apps/trainer/app/auth-error/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Button } from "@ui/components/Button";
+import Icon from "@ui/components/Icon";
+import { Text } from "@ui/components/Text";
+import { useRouter } from "next/navigation";
+import React from "react";
+
+import RouteInstance from "@trainer/constants/route";
+
+export default function AuthError() {
+  const router = useRouter();
+
+  const handleClickRouteToLogin = () => {
+    router.push(RouteInstance["login"]());
+  };
+
+  return (
+    <main className="flex h-full w-full flex-col items-center justify-between">
+      <section className="flex w-full flex-1 flex-col items-center justify-center">
+        <div className="bg-brand-primary-500 flex h-[3.125rem] w-[3.125rem] items-center justify-center rounded-full">
+          <Icon name="KeyRound" size={"lg"} />
+        </div>
+
+        <Text.Title1 className="mt-7 flex flex-col text-center">인증에 실패하였습니다</Text.Title1>
+        <Text.Subhead1 className="text-text-sub2 mt-2">다시 시도해주세요.</Text.Subhead1>
+      </section>
+
+      <Button
+        variant={"brand"}
+        className="mt-10 h-[3.375rem] w-full"
+        onClick={handleClickRouteToLogin}
+      >
+        <Text.Headline1>로그인 페이지 이동</Text.Headline1>
+      </Button>
+    </main>
+  );
+}

--- a/apps/user/auth-error/page.tsx
+++ b/apps/user/auth-error/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Button } from "@ui/components/Button";
+import Icon from "@ui/components/Icon";
+import { Text } from "@ui/components/Text";
+import { useRouter } from "next/navigation";
+
+import RouteInstance from "@user/constants/routes";
+
+export default function AuthError() {
+  const router = useRouter();
+
+  const handleClickRouteToLogin = () => {
+    router.push(RouteInstance["login"]());
+  };
+
+  return (
+    <main className="flex h-full w-full flex-col items-center justify-between">
+      <section className="flex w-full flex-1 flex-col items-center justify-center">
+        <div className="bg-brand-primary-500 flex h-[3.125rem] w-[3.125rem] items-center justify-center rounded-full">
+          <Icon name="KeyRound" size={"lg"} />
+        </div>
+
+        <Text.Title1 className="mt-7 flex flex-col gap-2 text-center">
+          인증에 실패하였습니다
+        </Text.Title1>
+        <Text.Subhead1 className="text-text-sub2 mt-2">다시 시도해주세요.</Text.Subhead1>
+      </section>
+
+      <Button
+        variant={"brand"}
+        className="mt-10 h-[3.375rem] w-full"
+        onClick={handleClickRouteToLogin}
+      >
+        <Text.Headline1>로그인 페이지 이동</Text.Headline1>
+      </Button>
+    </main>
+  );
+}


### PR DESCRIPTION
## 📝 작업 내용
`auth-error` 도메인에 표시될 페이지를 구현하였습니다.
인증 오류에 대해서는 BE에서 페이지를 리다이렉션을 시켜주어 해당 페이지로 어떠한 작업은 하지 아니하였으며, 페이지를 해당 라우트에서 표시할 수 있게 Next 파일 베이스 라우트에 맞게 구현하였습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
