### PR TITLE
[FLIZ-318/user] refactor: 유저 도메인 mutation 요청 고도화 및 사용성 개선

### DIFF
--- a/apps/user/app/schedule-management/_components/BottomSheet/ReservationCancelSheet.tsx
+++ b/apps/user/app/schedule-management/_components/BottomSheet/ReservationCancelSheet.tsx
@@ -13,7 +13,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@ui/components/Sheet";
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 
 import RequestSuccessSheet from "./RequestSuccessSheet";
 import { useReservationCancelMutation } from "../../_hooks/mutation/useReservationCancelMutation";
@@ -47,7 +47,7 @@ function ReservationCancelSheet({
   const [inputValue, setInputValue] = useState("");
   const [isRequestSuccessOpen, setIsRequestSuccessOpen] = useState(false);
 
-  const { reservationCancel } = useReservationCancelMutation();
+  const { reservationCancel, isSuccess } = useReservationCancelMutation();
 
   const handleChangeInput = (event: ChangeEvent<HTMLInputElement>) => {
     setInputValue(event.target.value);
@@ -59,9 +59,13 @@ function ReservationCancelSheet({
       cancelReason: inputValue,
       cancelDate: reservationDates[0],
     });
-
-    setIsRequestSuccessOpen(true);
   };
+
+  useEffect(() => {
+    if (isSuccess) {
+      setIsRequestSuccessOpen(true);
+    }
+  }, [isSuccess]);
 
   return (
     <>
@@ -98,13 +102,15 @@ function ReservationCancelSheet({
         </SheetContent>
       </Sheet>
 
-      <RequestSuccessSheet
-        open={isRequestSuccessOpen}
-        onChangeOpen={setIsRequestSuccessOpen}
-        title={REQUEST_SUCCESS_MAP[status].title}
-        description={REQUEST_SUCCESS_MAP[status].description}
-        closeSheetText="확인"
-      />
+      {status !== "고정 예약" && (
+        <RequestSuccessSheet
+          open={isRequestSuccessOpen}
+          onChangeOpen={setIsRequestSuccessOpen}
+          title={REQUEST_SUCCESS_MAP[status].title}
+          description={REQUEST_SUCCESS_MAP[status].description}
+          closeSheetText="확인"
+        />
+      )}
     </>
   );
 }

--- a/apps/user/app/schedule-management/_components/BottomSheet/ReservationStatusSheet.tsx
+++ b/apps/user/app/schedule-management/_components/BottomSheet/ReservationStatusSheet.tsx
@@ -21,7 +21,7 @@ import {
 import DateController from "@ui/lib/DateController";
 import { cn } from "@ui/lib/utils";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import RouteInstance from "@user/constants/routes";
 
@@ -52,7 +52,7 @@ function ReservationStatusSheet({
   const [isReservationRemindCancelPopupOpen, setIsReservationRemindCancelPopupOpen] =
     useState(false);
 
-  const { reservationCancel } = useReservationCancelMutation();
+  const { reservationCancel, isSuccess } = useReservationCancelMutation();
 
   const handleClickCancelButton = () => {
     if (status === "예약 대기") {
@@ -79,9 +79,13 @@ function ReservationStatusSheet({
       cancelReason: "예약 대기 취소 요청",
       cancelDate: reservationDates[0],
     });
-
-    setIsReservationCancelSuccessSheetOpen(true);
   };
+
+  useEffect(() => {
+    if (isSuccess) {
+      setIsReservationCancelSuccessSheetOpen(true);
+    }
+  }, [isSuccess]);
 
   return (
     <>
@@ -106,7 +110,7 @@ function ReservationStatusSheet({
             </div>
           </SheetHeader>
           <SheetFooter>
-            {status === "예약 변경 요청" ? (
+            {status === "예약 변경 요청" || status === "고정 예약" ? (
               <SheetClose asChild>
                 <Button className="bg-background-sub1  hover:bg-background-sub3 flex h-[3.375rem] w-full items-center justify-center ">
                   확인

--- a/apps/user/app/schedule-management/_components/Calendar/index.tsx
+++ b/apps/user/app/schedule-management/_components/Calendar/index.tsx
@@ -22,7 +22,9 @@ export default function Calendar() {
   const [selectedReservationContent, setSelectedReservationContent] =
     useState<BaseReservationListItem>();
 
-  const canRenderSheet = checkReservationIsFuture(selectedReservationContent?.reservationDates[0]);
+  const canRenderSheet = checkReservationIsFuture(
+    selectedReservationContent?.reservationDates.sort()[0],
+  );
 
   const firstDayOfMonth = startOfMonth(month);
 

--- a/apps/user/app/schedule-management/_hooks/mutation/useReservationCancelMutation.ts
+++ b/apps/user/app/schedule-management/_hooks/mutation/useReservationCancelMutation.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
 
 import { baseReservationKeys } from "@user/queries/reservation";
 
@@ -18,6 +19,9 @@ export const useReservationCancelMutation = () => {
       cancelReservation({ reservationId }, { cancelReason, cancelDate }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: baseReservationKeys.lists() });
+    },
+    onError: (error) => {
+      toast.error(error.message);
     },
   });
 

--- a/apps/user/app/schedule-management/_libs/checkReservationIsFuture.ts
+++ b/apps/user/app/schedule-management/_libs/checkReservationIsFuture.ts
@@ -3,8 +3,8 @@ import { format } from "date-fns";
 export const checkReservationIsFuture = (reservationDate?: string) => {
   if (!reservationDate) return false;
 
-  const today = format(new Date(), "yyyy-MM-dd");
-  const parsedReservationDate = format(new Date(reservationDate), "yyyy-MM-dd");
+  const today = format(new Date(), "yyyy-MM-dd'T'HH:mm:ss");
+  const parsedReservationDate = format(new Date(reservationDate), "yyyy-MM-dd'T'HH:mm:ss");
 
   return today <= parsedReservationDate;
 };

--- a/apps/user/app/schedule-management/_utils/reservationMerger.ts
+++ b/apps/user/app/schedule-management/_utils/reservationMerger.ts
@@ -10,6 +10,9 @@ export const filterLatestReservationsByDate = (reservations: BaseReservationList
 
   for (let i = 0; i < reservations.length; i += 1) {
     const reservation = reservations[i];
+
+    if (reservation.status === "예약 취소") continue;
+
     reservation.reservationDates.forEach((dateString) => {
       const dateKey = extractDateOnly(dateString);
       dateMap[dateKey] = reservation;

--- a/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/PtTimeSelector/ReservationRequestor.tsx
+++ b/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/PtTimeSelector/ReservationRequestor.tsx
@@ -2,10 +2,9 @@ import { useQuery } from "@tanstack/react-query";
 import { Button } from "@ui/components/Button";
 import { format } from "date-fns";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
 
-import RequestSuccessSheet, {
-  RequestSucccessSheetTrigger,
-} from "@user/app/schedule-management/_components/BottomSheet/RequestSuccessSheet";
+import RequestSuccessSheet from "@user/app/schedule-management/_components/BottomSheet/RequestSuccessSheet";
 import { myInformationQueries } from "@user/queries/myInformation";
 
 import RouteInstance from "@user/constants/routes";
@@ -53,8 +52,9 @@ function ReservationRequestor({
   selectedTime,
 }: ReservationRequestorProps) {
   const router = useRouter();
-  const { reservationRequest } = useReservationRequestMutation();
-  const { reservationChange } = useReservationChangeMutation();
+  const { reservationRequest, isSuccess: reservationRequestSuccess } =
+    useReservationRequestMutation();
+  const { reservationChange, isSuccess: reservationChangeSuccess } = useReservationChangeMutation();
   const searchParams = useSearchParams();
 
   const { data: myInformation } = useQuery(myInformationQueries.summary());
@@ -79,25 +79,38 @@ function ReservationRequestor({
         changeRequestDate: formattedDateTimes[0],
       });
     }
+  };
+
+  const handleClickCloseButton = () => {
+    onChangeOpen(false);
 
     router.push(RouteInstance["schedule-management"]());
   };
 
+  useEffect(() => {
+    if (reservationRequestSuccess || reservationChangeSuccess) {
+      onChangeOpen(true);
+    }
+  }, [reservationRequestSuccess, reservationChangeSuccess]);
+
   return (
-    <RequestSuccessSheet
-      open={open}
-      onChangeOpen={onChangeOpen}
-      title={MODE_CONTENT_MAP[mode].title}
-      description={MODE_CONTENT_MAP[mode].description}
-      closeSheetText="확인"
-      onClickCloseButton={handleClickRequestButton}
-    >
-      <RequestSucccessSheetTrigger asChild>
-        <Button disabled={!isActive} className="h-[3.375rem] w-full">
-          {MODE_CONTENT_MAP[mode].buttonText}
-        </Button>
-      </RequestSucccessSheetTrigger>
-    </RequestSuccessSheet>
+    <>
+      <Button
+        disabled={!isActive}
+        onClick={handleClickRequestButton}
+        className="h-[3.375rem] w-full"
+      >
+        {MODE_CONTENT_MAP[mode].buttonText}
+      </Button>
+      <RequestSuccessSheet
+        open={open}
+        onChangeOpen={onChangeOpen}
+        title={MODE_CONTENT_MAP[mode].title}
+        description={MODE_CONTENT_MAP[mode].description}
+        closeSheetText="확인"
+        onClickCloseButton={handleClickCloseButton}
+      />
+    </>
   );
 }
 

--- a/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/index.tsx
+++ b/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/index.tsx
@@ -11,12 +11,14 @@ type ReservationContainerProps = {
   mode: RequestReservationMode;
   reservationDate?: string;
   reservationDateTime?: string;
+  firstDayOfMonthKorea: string;
 };
 
 function ReservationContainer({
   mode,
   reservationDate,
   reservationDateTime,
+  firstDayOfMonthKorea,
 }: ReservationContainerProps) {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date(reservationDate || new Date()));
 
@@ -27,6 +29,7 @@ function ReservationContainer({
         mode={mode}
         selectedDate={selectedDate}
         reservationDateTime={reservationDateTime}
+        firstDayOfMonthKorea={firstDayOfMonthKorea}
       />
     </section>
   );

--- a/apps/user/app/schedule-management/reservation/[mode]/_hooks/mutation/useReservationChangeMutation.ts
+++ b/apps/user/app/schedule-management/reservation/[mode]/_hooks/mutation/useReservationChangeMutation.ts
@@ -1,4 +1,6 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { reservationQueries } from "@user/queries/reservation";
 
 import { reservationChange } from "@user/services/reservations";
 
@@ -9,6 +11,8 @@ type ReservationChangeMutationParams = {
 };
 
 export const useReservationChangeMutation = () => {
+  const queryClient = useQueryClient();
+
   const { mutate, ...rest } = useMutation({
     mutationFn: ({
       reservationId,
@@ -16,6 +20,9 @@ export const useReservationChangeMutation = () => {
       changeRequestDate,
     }: ReservationChangeMutationParams) =>
       reservationChange({ reservationId }, { reservationDate, changeRequestDate }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: reservationQueries.list() });
+    },
   });
 
   return { reservationChange: mutate, ...rest };

--- a/apps/user/app/schedule-management/reservation/[mode]/page.tsx
+++ b/apps/user/app/schedule-management/reservation/[mode]/page.tsx
@@ -1,7 +1,10 @@
+/* eslint-disable no-magic-numbers */
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { startOfMonth, addHours, format } from "date-fns";
 import { notFound } from "next/navigation";
 
 import { myInformationQueries } from "@user/queries/myInformation";
+import { reservationQueries } from "@user/queries/reservation";
 
 import Header from "./_components/Header";
 import ReservationContainer from "./_components/ReservationContainer";
@@ -31,7 +34,14 @@ async function Reservation({ params, searchParams }: ReservationParams) {
 
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchQuery(myInformationQueries.summary());
+  const today = new Date();
+  const firstDayOfMonthUTC = startOfMonth(today);
+  const firstDayOfMonthKorea = format(addHours(firstDayOfMonthUTC, 9), "yyyy-MM-dd");
+
+  await Promise.all([
+    queryClient.prefetchQuery(myInformationQueries.summary()),
+    queryClient.prefetchQuery(reservationQueries.list(firstDayOfMonthKorea)),
+  ]);
 
   return (
     <main className="flex h-full flex-col items-center overflow-hidden">
@@ -41,6 +51,7 @@ async function Reservation({ params, searchParams }: ReservationParams) {
           mode={mode}
           reservationDate={reservationDate}
           reservationDateTime={reservationDateTime}
+          firstDayOfMonthKorea={firstDayOfMonthKorea}
         />
       </HydrationBoundary>
     </main>


### PR DESCRIPTION
## 📝 작업 내용

#### mutation 요청 고도화
- Mutation 성공/실패에 대한 핸들링
- 기존에 요청 성공시 보여주던 바텀 시트를 isSuccess로 핸들링
#### 사용성 개선
- 유저가 예약 요청시 해당 요일에 예약 변경 요청, 예약 확정, 예약 대기가 걸려있을 경우 추가 요청 X
- 고정 예약 바텀시트 열리지 않는 버그 해결
- 선택한 예약 정보가 과거 예약이라면 바텀시트가 열리지 않도록 수정