### PR TITLE
[FLIZ-320/trainer] feat: notification 도메인 mutation 성공 후 쿼리 invalidation 추가

### DIFF
--- a/apps/trainer/app/notification/_components/SheetRenderer/ConnectTrainerSheet.tsx
+++ b/apps/trainer/app/notification/_components/SheetRenderer/ConnectTrainerSheet.tsx
@@ -96,6 +96,9 @@ function ConnectTrainerSheet({ notificationId, open, onChangeOpen }: ConnectTrai
         requestPath: { notificationId },
         requestBody: { isApproved },
       }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationBaseKeys.lists() });
+    },
   });
   const setSessionMutation = useMutation({
     mutationFn: sessionCountEdit,
@@ -132,7 +135,6 @@ function ConnectTrainerSheet({ notificationId, open, onChangeOpen }: ConnectTrai
             onSuccess: () => {
               setIsAcceptActionSheetOpen(false);
               setIsAcceptSheetOpen(true);
-              queryClient.invalidateQueries({ queryKey: notificationBaseKeys.lists() });
             },
           },
         );

--- a/apps/trainer/app/notification/_components/SheetRenderer/ReservationCancelSheet.tsx
+++ b/apps/trainer/app/notification/_components/SheetRenderer/ReservationCancelSheet.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { Badge } from "@ui/components/Badge";
 import { Button } from "@ui/components/Button";
 import Icon from "@ui/components/Icon";
@@ -13,7 +13,7 @@ import {
 } from "@ui/components/Sheet";
 import { Suspense, useState } from "react";
 
-import { notificationQueries } from "@trainer/queries/notification";
+import { notificationBaseKeys, notificationQueries } from "@trainer/queries/notification";
 import { userManagementQueries } from "@trainer/queries/userManagement";
 
 import { processCancelReservation } from "@trainer/services/reservations";
@@ -104,8 +104,13 @@ function ReservationCancelSheet({
   onChangeOpen,
   eventDateDescription,
 }: ReservationCancelSheetProps) {
+  const queryClient = useQueryClient();
+
   const reservationCancelMutation = useMutation({
     mutationFn: processCancelReservation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationBaseKeys.lists() });
+    },
   });
 
   const [isDeclineSheetOpen, setIsDeclineSheetOpen] = useState(false);

--- a/apps/trainer/app/notification/_components/SheetRenderer/ReservationChangeSheet.tsx
+++ b/apps/trainer/app/notification/_components/SheetRenderer/ReservationChangeSheet.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { Badge } from "@ui/components/Badge";
 import { Button } from "@ui/components/Button";
 import Icon from "@ui/components/Icon";
@@ -14,7 +14,7 @@ import {
 import DateController from "@ui/lib/DateController";
 import { Suspense, useState } from "react";
 
-import { notificationQueries } from "@trainer/queries/notification";
+import { notificationBaseKeys, notificationQueries } from "@trainer/queries/notification";
 import { userManagementQueries } from "@trainer/queries/userManagement";
 
 import { processReservationChange } from "@trainer/services/reservations";
@@ -104,8 +104,13 @@ function ReservationChangeSheet({
   onChangeOpen,
   eventDateDescription,
 }: ReservationChangeSheetProps) {
+  const queryClient = useQueryClient();
+
   const reservationChangeMutation = useMutation({
     mutationFn: processReservationChange,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationBaseKeys.lists() });
+    },
   });
 
   const [isDeclineSheetOpen, setIsDeclineSheetOpen] = useState(false);

--- a/apps/trainer/app/notification/_components/SheetRenderer/SessionCompleteSheet.tsx
+++ b/apps/trainer/app/notification/_components/SheetRenderer/SessionCompleteSheet.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { Badge } from "@ui/components/Badge";
 import { Button } from "@ui/components/Button";
 import Icon from "@ui/components/Icon";
@@ -12,7 +12,7 @@ import {
 } from "@ui/components/Sheet";
 import { Suspense, useState } from "react";
 
-import { notificationQueries } from "@trainer/queries/notification";
+import { notificationBaseKeys, notificationQueries } from "@trainer/queries/notification";
 import { userManagementQueries } from "@trainer/queries/userManagement";
 
 import { createCompletedPt } from "@trainer/services/reservations";
@@ -107,9 +107,14 @@ function SessionCompleteSheet({
   eventDate,
   notificationId,
 }: SessionCompleteSheetProps) {
+  const queryClient = useQueryClient();
+
   const sessionMutation = useMutation({
     mutationFn: ({ memberId, reservationId, isJoin }: ReservationCompletionMutationParams) =>
       createCompletedPt({ reservationId }, { memberId, isJoin }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationBaseKeys.lists() });
+    },
   });
 
   const [isDeclineSheetOpen, setIsDeclineSheetOpen] = useState(false);

--- a/apps/trainer/app/notification/page.tsx
+++ b/apps/trainer/app/notification/page.tsx
@@ -7,7 +7,7 @@ import Header from "@ui/components/Header";
 import { useRouter } from "next/navigation";
 import { Suspense, useState } from "react";
 
-import { notificationQueries } from "@trainer/queries/notification";
+import { notificationBaseKeys, notificationQueries } from "@trainer/queries/notification";
 
 import { readNotification } from "@trainer/services/notification";
 
@@ -97,8 +97,7 @@ function AllNotificationPage() {
         context?.previousNotifications,
       );
     },
-    onSettled: () =>
-      queryClient.invalidateQueries({ queryKey: notificationQueries.list({}).queryKey }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: notificationBaseKeys.lists() }),
   });
 
   const handleSelectResult = () => {


### PR DESCRIPTION
# [FLIZ-320/trainer] feat: notification 도메인 mutation 성공 후 쿼리 invalidation 추가


<!-- 작업 패키지: root, ui, trainer, user, config-eslint, config-typescript, config-tailwind, storybook -->

## 📝 작업 내용

trainer 서비스 notification 페이지에서 사용되는 mutation의 onSuccess 콜백에 query invalidation 로직을 추가했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
