### PR TITLE
[FLIZ-301/root] fix: register 단계에서 userProfileImage 등록 API 오류 해결

### DIFF
--- a/apps/trainer/app/register/_components/RegisterFunnel.tsx
+++ b/apps/trainer/app/register/_components/RegisterFunnel.tsx
@@ -5,7 +5,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useFunnel } from "@use-funnel/browser";
 import dynamic from "next/dynamic";
 
-import { registerUserProfileImage, uploadImage } from "@trainer/services/attachment";
+import { uploadImage } from "@trainer/services/attachment";
 import { createPresignedUrl } from "@trainer/services/attachment";
 
 const BasicInfoStep = dynamic(() => import("@ui/components/FunnelSteps/BasicInfoStep"), {
@@ -40,9 +40,6 @@ function RegisterFunnel() {
   const uploadImageMutation = useMutation({
     mutationFn: uploadImage,
   });
-  const registerUserProfileImageMutation = useMutation({
-    mutationFn: registerUserProfileImage,
-  });
 
   const handleUploadProfileImage = async (imageFile: File) => {
     try {
@@ -66,19 +63,6 @@ function RegisterFunnel() {
         presignedUrl,
         imageFile,
       });
-
-      const {
-        status: registerUserProfileImageStatus,
-        success: registerUserProfileImageSuccess,
-        msg: registerUserProfileImageMsg,
-      } = await registerUserProfileImageMutation.mutateAsync({
-        attachmentId,
-      });
-
-      if (!registerUserProfileImageSuccess)
-        throw new Error(
-          `Error occured during createPresignedUrl\nStatus:${registerUserProfileImageStatus}\nMessage:${registerUserProfileImageMsg}`,
-        );
 
       return attachmentId;
     } catch {

--- a/apps/user/app/register/_components/RegisterFunnel.tsx
+++ b/apps/user/app/register/_components/RegisterFunnel.tsx
@@ -5,7 +5,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useFunnel } from "@use-funnel/browser";
 import dynamic from "next/dynamic";
 
-import { registerUserProfileImage, uploadImage } from "@user/services/attachment";
+import { uploadImage } from "@user/services/attachment";
 import { createPresignedUrl } from "@user/services/attachment";
 
 const BasicInfoStep = dynamic(() => import("@ui/components/FunnelSteps/BasicInfoStep"), {
@@ -40,9 +40,6 @@ function RegisterFunnel() {
   const uploadImageMutation = useMutation({
     mutationFn: uploadImage,
   });
-  const registerUserProfileImageMutation = useMutation({
-    mutationFn: registerUserProfileImage,
-  });
 
   const handleUploadProfileImage = async (imageFile: File) => {
     try {
@@ -66,19 +63,6 @@ function RegisterFunnel() {
         presignedUrl,
         imageFile,
       });
-
-      const {
-        status: registerUserProfileImageStatus,
-        success: registerUserProfileImageSuccess,
-        msg: registerUserProfileImageMsg,
-      } = await registerUserProfileImageMutation.mutateAsync({
-        attachmentId,
-      });
-
-      if (!registerUserProfileImageSuccess)
-        throw new Error(
-          `Error occured during createPresignedUrl\nStatus:${registerUserProfileImageStatus}\nMessage:${registerUserProfileImageMsg}`,
-        );
 
       return attachmentId;
     } catch {


### PR DESCRIPTION
# [FLIZ-301/root] fix: register 단계에서 userProfileImage 등록 API 오류 해결

## 📝 작업 내용

회원가입 > 유저 프로필 등록 단계에서 사용되지 않는 API를 호출하면서 API 실패 에러가 발생하여 attachmentId를 정상적으로 반환하지 않는 버그가 존재했습니다. 해당 API를 user / trainer 서비스에서 제거하여 userProfileImage가 등록되지 않던 버그를 해결했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
