### PR TITLE
[FLIZ-323/ui] refactor: 이미지 Next Image로 변경

### DIFF
--- a/apps/trainer/app/member-management/[memberId]/_components/MemberProfile.tsx
+++ b/apps/trainer/app/member-management/[memberId]/_components/MemberProfile.tsx
@@ -9,6 +9,7 @@ import { ProfileItem } from "@ui/components/ProfileItem";
 import PTPreference from "@ui/components/PTPreference";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
+import Image from "next/image";
 
 import { userManagementQueries } from "@trainer/queries/userManagement";
 
@@ -35,7 +36,9 @@ function MemberProfile({ memberId }: MemberProfileProps) {
       <section className="mb-5 w-full">
         <ProfileHeader>
           <ProfileHeader.Section>
-            <ProfileHeader.Avatar name={name} imageSrc={profilePictureUrl} />
+            <ProfileHeader.Avatar>
+              <Image width={50} height={50} src={profilePictureUrl} alt={`${name} 프로필`} />
+            </ProfileHeader.Avatar>
             <ProfileHeader.Name name={name} />
           </ProfileHeader.Section>
           <ProfileHeader.Section>

--- a/apps/trainer/app/my-page/_components/MyPageHeader.tsx
+++ b/apps/trainer/app/my-page/_components/MyPageHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import ProfileHeader from "@ui/components/ProfileHeader";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import React from "react";
 
@@ -23,7 +24,9 @@ function MyPageHeader({ name, imageSrc }: MyPageHeaderProps) {
     <section className="flex w-full justify-between">
       <ProfileHeader>
         <ProfileHeader.Section onClick={() => handleClickLogout(RouteInstance["my-information"]())}>
-          <ProfileHeader.Avatar name={name} imageSrc={imageSrc} />
+          <ProfileHeader.Avatar>
+            <Image width={50} height={50} src={imageSrc || ""} alt={`${name} 프로필`} />
+          </ProfileHeader.Avatar>
           <ProfileHeader.Name name={name} />
         </ProfileHeader.Section>
       </ProfileHeader>

--- a/apps/trainer/app/my-page/my-information/_components/MyInformationContainer.tsx
+++ b/apps/trainer/app/my-page/my-information/_components/MyInformationContainer.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { Avatar, AvatarFallback, AvatarImage } from "@ui/components/Avatar";
+import { Avatar, AvatarFallback } from "@ui/components/Avatar";
 import { Button } from "@ui/components/Button";
+import Image from "next/image";
 
 import { myInformationQueries } from "@trainer/queries/myInformation";
 
@@ -23,8 +24,17 @@ export default function MyInformationContainer() {
       <Header title="내 정보" />
 
       <Avatar className="mt-[1.563rem] h-[6.313rem] w-[6.313rem]">
-        <AvatarImage src={myDetailInformation.profilePictureUrl} />
-        <AvatarFallback>CN</AvatarFallback>
+        {myDetailInformation.profilePictureUrl ? (
+          <Image
+            width={50}
+            height={50}
+            src={myDetailInformation.profilePictureUrl}
+            alt={`${myDetailInformation.name} 프로필`}
+            className="h-full w-full"
+          />
+        ) : (
+          <AvatarFallback />
+        )}
       </Avatar>
 
       <EditProfileBottomSheet>

--- a/apps/trainer/app/notification/_components/NotificationItemContainer.tsx
+++ b/apps/trainer/app/notification/_components/NotificationItemContainer.tsx
@@ -1,6 +1,7 @@
 import { NotificationInfo } from "@5unwan/core/api/types/common";
 import { useQuery } from "@tanstack/react-query";
 import NotificationItem from "@ui/components/NotificationItem/NotificationItem";
+import Image from "next/image";
 import { MouseEventHandler } from "react";
 
 import { notificationQueries } from "@trainer/queries/notification";
@@ -34,14 +35,18 @@ function NotificationItemContainer({ notification, onClick }: NotificationItemCo
 
   if (isError) return <NotificationItemError />;
 
-  const { profilePictureUrl } = data.data.userDetail;
+  const { profilePictureUrl, name } = data.data.userDetail;
 
   return (
     <NotificationItem
       message={message}
       variant={type}
       createdAt={sendDate}
-      avatarSrc={profilePictureUrl}
+      image={
+        profilePictureUrl && (
+          <Image width={50} height={50} src={profilePictureUrl} alt={`${name} 프로필`} />
+        )
+      }
       isCompleted={isProcessed}
       key={`notification-${notificationId}`}
       className="w-full"

--- a/apps/trainer/app/notification/page.tsx
+++ b/apps/trainer/app/notification/page.tsx
@@ -107,7 +107,7 @@ function AllNotificationPage() {
   const handleNotificationClick = (notification: NotificationInfo) => () => {
     const { notificationId, type, content, sendDate, isProcessed } = notification;
 
-    const dateString = content.split("\n")[1].split("날짜: ")[1];
+    const dateString = content.split("\n")[1]?.split("날짜: ")[1];
 
     switch (type) {
       case "트레이너 연동 해제":

--- a/apps/trainer/components/ProfileCard.tsx
+++ b/apps/trainer/components/ProfileCard.tsx
@@ -1,7 +1,8 @@
-import { Avatar, AvatarFallback, AvatarImage } from "@ui/components/Avatar";
+import { Avatar, AvatarFallback } from "@ui/components/Avatar";
 import { Badge } from "@ui/components/Badge";
 import Icon from "@ui/components/Icon";
 import { cn } from "@ui/lib/utils";
+import Image from "next/image";
 import { ComponentProps, ReactNode } from "react";
 
 import { formatToMeridiem, formatPhoneNumber } from "@trainer/utils/ProfileCardUtils";
@@ -46,8 +47,11 @@ function UserInfo({
       <div className="flex h-[3.125rem] w-[11.25rem] items-center">
         <div className="flex h-full w-[5rem] items-center justify-center">
           <Avatar>
-            <AvatarImage src={imgUrl} />
-            <AvatarFallback />
+            {imgUrl ? (
+              <Image width={50} height={50} src={imgUrl} alt={`${userName} 프로필`} />
+            ) : (
+              <AvatarFallback />
+            )}
           </Avatar>
         </div>
         <div className="flex-1">

--- a/apps/trainer/next.config.mjs
+++ b/apps/trainer/next.config.mjs
@@ -28,6 +28,14 @@ const nextConfig = {
 
     return config;
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'fitlink-profiles.s3.ap-northeast-2.amazonaws.com',
+      }
+    ]
+  }
 };
 
 export default pwaConfig(nextConfig);

--- a/apps/user/app/my-page/_components/ProfileHeader.tsx
+++ b/apps/user/app/my-page/_components/ProfileHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Profile from "@ui/components/ProfileHeader";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import React from "react";
 
@@ -28,7 +29,14 @@ export default function ProfileHeader({ userName, profilePictureUrl }: HeaderPro
             handleClickRouting(RouteInstance["my-information"]());
           }}
         >
-          <Profile.Avatar name={userName} imageSrc={profilePictureUrl ?? ""} />
+          <Profile.Avatar>
+            <Image
+              width={50}
+              height={50}
+              src={profilePictureUrl || ""}
+              alt={`${userName} 프로필`}
+            />
+          </Profile.Avatar>
           <Profile.Name name={userName} />
         </Profile.Section>
       </Profile>

--- a/apps/user/app/my-page/my-information/_components/MyInformationAvatar.tsx
+++ b/apps/user/app/my-page/my-information/_components/MyInformationAvatar.tsx
@@ -16,7 +16,10 @@ export default function MyInformationAvatar() {
 
   return (
     <>
-      <ProfileImage profilePictureUrl={myDetailInformation?.profilePictureUrl ?? ""} />
+      <ProfileImage
+        name={myDetailInformation.name}
+        profilePictureUrl={myDetailInformation?.profilePictureUrl}
+      />
 
       <EditProfileBottomSheet>
         <Button className="mt-[1.25rem]" variant={"brand"} size={"sm"} corners={"pill"}>

--- a/apps/user/app/my-page/my-information/_components/ProfileImage.tsx
+++ b/apps/user/app/my-page/my-information/_components/ProfileImage.tsx
@@ -1,17 +1,22 @@
 "use client";
 
-import { Avatar, AvatarFallback, AvatarImage } from "@ui/components/Avatar";
+import { Avatar, AvatarFallback } from "@ui/components/Avatar";
+import Image from "next/image";
 import React from "react";
 
 interface ProfileImageProps {
+  name: string;
   profilePictureUrl: string | null;
 }
 
-function ProfileImage({ profilePictureUrl }: ProfileImageProps) {
+function ProfileImage({ name, profilePictureUrl }: ProfileImageProps) {
   return (
     <Avatar className=" mt-[1.563rem] h-[6.313rem] w-[6.313rem]">
-      <AvatarFallback />
-      <AvatarImage src={profilePictureUrl ?? ""} />
+      {profilePictureUrl ? (
+        <Image width={50} height={50} src={profilePictureUrl} alt={`${name} 프로필`} />
+      ) : (
+        <AvatarFallback />
+      )}
     </Avatar>
   );
 }

--- a/apps/user/app/my-page/my-trainer-information/_components/MyTrainerInformationContainer.tsx
+++ b/apps/user/app/my-page/my-trainer-information/_components/MyTrainerInformationContainer.tsx
@@ -17,7 +17,10 @@ export default function MyTrainerInformationContainer() {
 
   return (
     <>
-      <ProfileImage profilePictureUrl={myTrainerInformation?.trainerProfileUrl ?? ""} />
+      <ProfileImage
+        name={myTrainerInformation.trainerName ?? ""}
+        profilePictureUrl={myTrainerInformation?.trainerProfileUrl ?? ""}
+      />
 
       <ProfileItem className="mt-[1.5625rem] w-full" variant={"name"}>
         {myTrainerInformation?.trainerName}

--- a/packages/ui/src/components/NotificationItem/NotificationItem.tsx
+++ b/packages/ui/src/components/NotificationItem/NotificationItem.tsx
@@ -1,5 +1,5 @@
 import { NotificationType } from "@5unwan/core/api/types/common";
-import { forwardRef, HTMLAttributes, MouseEventHandler } from "react";
+import { forwardRef, HTMLAttributes, MouseEventHandler, ReactNode } from "react";
 
 import NotificationContent from "./NotificationContent";
 import NotificationThumbnail from "./NotificationThumbnail";
@@ -10,21 +10,18 @@ type Props = Omit<HTMLAttributes<HTMLLIElement>, "onClick"> & NotificationProps;
 
 type NotificationProps = {
   isCompleted: boolean;
-  // memberName?: string;
-  avatarSrc?: string;
   message: string;
   eventDate?: Date | string;
   eventDetail?: Date | string;
   createdAt: Date | string;
   variant: NotificationType;
   onClick?: MouseEventHandler<HTMLLIElement>;
+  image?: ReactNode;
 };
 
 const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
   const {
     isCompleted,
-    // memberName,
-    avatarSrc,
     createdAt,
     message,
     eventDate,
@@ -32,6 +29,7 @@ const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
     variant,
     onClick,
     className,
+    image,
     ...commonProps
   } = props;
 
@@ -44,7 +42,6 @@ const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
   const eventDateController = eventDate ? DateController(eventDate).validate() : undefined;
   const createdDateController = DateController(createdAt).validate();
   const eventDetailController = eventDetail ? DateController(eventDetail).validate() : undefined;
-  // const messageCompound = memberName ? `${memberName} ${message}` : message;
 
   return (
     <li
@@ -59,7 +56,7 @@ const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
       onClick={handleClick}
       {...commonProps}
     >
-      <NotificationThumbnail isCompleted={isCompleted} avatarSrc={avatarSrc} variant={variant} />
+      <NotificationThumbnail isCompleted={isCompleted} image={image} variant={variant} />
       <NotificationContent
         isCompleted={isCompleted}
         createdAt={createdDateController?.toRelative()}

--- a/packages/ui/src/components/NotificationItem/NotificationThumbnail.tsx
+++ b/packages/ui/src/components/NotificationItem/NotificationThumbnail.tsx
@@ -1,21 +1,19 @@
 import { NotificationType } from "@5unwan/core/api/types/common";
+import { ReactNode } from "react";
 
 import IconThumbnail from "./IconThumbnail";
-import { Avatar, AvatarFallback, AvatarImage } from "../../components/Avatar";
+import { Avatar, AvatarFallback } from "../../components/Avatar";
 
 type Props = {
-  avatarSrc?: string;
+  image?: ReactNode;
   variant: NotificationType;
   isCompleted: boolean;
 };
 
-function NotificationThumbnail({ avatarSrc, variant, isCompleted }: Props) {
-  return avatarSrc ? (
+function NotificationThumbnail({ image, variant, isCompleted }: Props) {
+  return image ? (
     <div className="relative h-fit w-fit">
-      <Avatar className="h-[3.125rem] w-[3.125rem]">
-        <AvatarImage src={avatarSrc} />
-        <AvatarFallback />
-      </Avatar>
+      <Avatar className="h-[3.125rem] w-[3.125rem]">{image ? image : <AvatarFallback />}</Avatar>
       <IconThumbnail
         size="sm"
         variant={variant}

--- a/packages/ui/src/components/ProfileHeader.tsx
+++ b/packages/ui/src/components/ProfileHeader.tsx
@@ -1,8 +1,8 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, ReactNode } from "react";
 
 import { cn } from "@ui/lib/utils";
 
-import { Avatar, AvatarFallback, AvatarImage } from "./Avatar";
+import { Avatar, AvatarFallback } from "./Avatar";
 import ChevronTrigger from "./ChevronTrigger";
 import { Text } from "./Text";
 
@@ -38,17 +38,11 @@ const ProfileHeaderSection = React.forwardRef<HTMLDivElement, ProfileHeaderSecti
 ProfileHeaderSection.displayName = "ProfileHeaderSection";
 
 type ProfileHeaderAvatarProps = {
-  name: string;
-  imageSrc: string;
+  children: ReactNode;
 };
 const ProfileHeaderAvatar = forwardRef<React.ElementRef<typeof Avatar>, ProfileHeaderAvatarProps>(
-  ({ name, imageSrc }, ref) => {
-    return (
-      <Avatar ref={ref}>
-        <AvatarImage src={imageSrc} alt={`${name}님 프로필`} />
-        <AvatarFallback />
-      </Avatar>
-    );
+  ({ children }, ref) => {
+    return <Avatar ref={ref}>{children ? children : <AvatarFallback />}</Avatar>;
   },
 );
 ProfileHeaderAvatar.displayName = "ProfileHeaderAvatar";


### PR DESCRIPTION
# [FLIZ-323/ui] refactor: 이미지 Next Image로 변경

## 📝 작업 내용

이미지 캐싱을 위해 Shadcn AvatarImage를 Next Image API로 교체하는 작업을 진행했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
