### PR TITLE
[FLIZ-327/trainer] fix: 휴무일 삭제 시 다이얼로그 안 닫히는 버그 및 오류 시 토스트 메시지 작업 추가

### DIFF
--- a/apps/trainer/app/my-page/_components/DeleteMyDayOffDialog/index.tsx
+++ b/apps/trainer/app/my-page/_components/DeleteMyDayOffDialog/index.tsx
@@ -31,7 +31,7 @@ export default function DeleteMyDayOffDialog({
 }: DeleteMyDayOffDialogProps) {
   const queryClient = useQueryClient();
 
-  const { mutate, isError } = useMutation({
+  const { mutate } = useMutation({
     mutationFn: (params: {
       requestPath: { dayOffId: number };
       requestBody: DeleteTimeOffRequestBody;
@@ -45,7 +45,6 @@ export default function DeleteMyDayOffDialog({
     },
   });
 
-  console.log(isError);
   const handleDeleteDayOff = () => {
     if (!deleteDayOffData) return;
 


### PR DESCRIPTION
## 📝 작업 내용
기존 휴무일 삭제 시, 상위 state가 true값으로 남아있어서 다이얼로그가 안 닫히던 버그를 수정하였습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
