### PR TITLE
[FLIZ-325/trainer] fix: 예약 데이터가 2개 이상일 경우 서로 다른 데이터로 취급하여 예약 데이터를 나타내도록 유틸 함수 수정

### DIFF
--- a/apps/trainer/app/schedule-management/_utils/reservationMerger.ts
+++ b/apps/trainer/app/schedule-management/_utils/reservationMerger.ts
@@ -7,10 +7,9 @@ export const filterLatestReservationsByDate = (reservations: ModifiedReservation
 
   for (let i = 0; i < reservations.length; i += 1) {
     const reservation = reservations[i];
-    reservation.reservationDates.forEach((dateString) => {
-      const dateKey = dateString;
-      dateMap[dateKey] = reservation;
-    });
+    const dateKey = reservation.reservationDates[0];
+
+    dateMap[dateKey] = reservation;
   }
 
   return Object.values(dateMap);

--- a/apps/trainer/app/schedule-management/_utils/reservationMerger.ts
+++ b/apps/trainer/app/schedule-management/_utils/reservationMerger.ts
@@ -7,9 +7,16 @@ export const filterLatestReservationsByDate = (reservations: ModifiedReservation
 
   for (let i = 0; i < reservations.length; i += 1) {
     const reservation = reservations[i];
-    const dateKey = reservation.reservationDates[0];
+    reservation.reservationDates.forEach((dateString, index) => {
+      const dateKey = `${dateString}-${reservation.reservationId}`;
 
-    dateMap[dateKey] = reservation;
+      if (index === 0) dateMap[dateKey] = reservation;
+      else
+        dateMap[dateKey] = {
+          ...reservation,
+          reservationDates: [reservation.reservationDates[1], reservation.reservationDates[0]],
+        };
+    });
   }
 
   return Object.values(dateMap);


### PR DESCRIPTION
## 📝 작업 내용

- 예약 대기를 2개 이상의 시간으로 걸었음에도 하나의 예약으로 취급되는 에러 수정
