### PR TITLE
[FLIZ-330/user] fix: Avatar 영역을 채우지 않는 Image 채우도록 수정

### DIFF
--- a/apps/trainer/app/notification/_components/NotificationItemContainer.tsx
+++ b/apps/trainer/app/notification/_components/NotificationItemContainer.tsx
@@ -44,7 +44,13 @@ function NotificationItemContainer({ notification, onClick }: NotificationItemCo
       createdAt={sendDate}
       image={
         profilePictureUrl && (
-          <Image width={50} height={50} src={profilePictureUrl} alt={`${name} 프로필`} />
+          <Image
+            width={50}
+            height={50}
+            src={profilePictureUrl}
+            alt={`${name} 프로필`}
+            className="h-full w-full"
+          />
         )
       }
       isCompleted={isProcessed}

--- a/apps/trainer/components/ProfileCard.tsx
+++ b/apps/trainer/components/ProfileCard.tsx
@@ -48,7 +48,13 @@ function UserInfo({
         <div className="flex h-full w-[5rem] items-center justify-center">
           <Avatar>
             {imgUrl ? (
-              <Image width={50} height={50} src={imgUrl} alt={`${userName} 프로필`} />
+              <Image
+                width={50}
+                height={50}
+                src={imgUrl}
+                alt={`${userName} 프로필`}
+                className="h-full w-full"
+              />
             ) : (
               <AvatarFallback />
             )}

--- a/apps/user/app/my-page/my-information/_components/ProfileImage.tsx
+++ b/apps/user/app/my-page/my-information/_components/ProfileImage.tsx
@@ -13,7 +13,13 @@ function ProfileImage({ name, profilePictureUrl }: ProfileImageProps) {
   return (
     <Avatar className=" mt-[1.563rem] h-[6.313rem] w-[6.313rem]">
       {profilePictureUrl ? (
-        <Image width={50} height={50} src={profilePictureUrl} alt={`${name} 프로필`} />
+        <Image
+          width={50}
+          height={50}
+          src={profilePictureUrl}
+          alt={`${name} 프로필`}
+          className="h-full w-full"
+        />
       ) : (
         <AvatarFallback />
       )}


### PR DESCRIPTION
# [FLIZ-330/user] fix: Avatar 영역을 채우지 않는 Image 채우도록 수정

## 📝 작업 내용

user, trainer 서비스에서 Avatar 영역을 채우지 않는 Image에 대해 h-full w-full style을 적용하여 영역을 채우도록 수정했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
