### PR TITLE
[FLIZ-331/trainer] fix: 알림 종류별 subpage에 footer 없는 버그 fix

### DIFF
--- a/apps/trainer/components/BottomNavigation.tsx
+++ b/apps/trainer/components/BottomNavigation.tsx
@@ -24,7 +24,7 @@ export default function BottomNavigation() {
             className={cn(
               "text-background-sub4 hover:text-background-sub5 flex w-12 flex-col items-center justify-center gap-1 transition-colors",
               {
-                "text-text-primary": pathname === path,
+                "text-text-primary": pathname.startsWith(path),
               },
             )}
           >

--- a/apps/trainer/components/Providers/FooterProvider.tsx
+++ b/apps/trainer/components/Providers/FooterProvider.tsx
@@ -9,20 +9,21 @@ import RouteInstance from "@trainer/constants/route";
 import BottomNavigation from "../BottomNavigation";
 
 const PATHS = {
-  WITH_FOOTER: new Set([
+  WITH_FOOTER: [
     RouteInstance["schedule-management"](),
     RouteInstance["member-management"](),
     RouteInstance.notification(),
     RouteInstance["my-page"](),
-  ]),
-  WITHOUT_FOOTER: new Set([
+  ],
+  WITHOUT_FOOTER: [
     RouteInstance.register(),
     RouteInstance["sns-verification"](),
     RouteInstance.login(),
-  ]),
+  ],
 };
 
-const doesPathNeedFooter = (pathName: string) => PATHS.WITH_FOOTER.has(pathName);
+const doesPathNeedFooter = (pathName: string) =>
+  PATHS.WITH_FOOTER.some((route) => pathName.startsWith(route));
 
 function FooterProvider({ children }: { children: React.ReactNode }) {
   const pathName = usePathname();


### PR DESCRIPTION
# [FLIZ-331/trainer] fix: 알림 종류별 subpage에 footer 없는 버그 fix

## 📝 작업 내용

trainer 서비스에서 pathname이 완전히 일치하지 않더라도 base 경로로 시작하는 경우 true로 판별하도록 수 있도록 Footer 필요 여부 로직을 수정했습니다
pathname이 완전히 일치하지 않더라도 base 경로로 시작하는 경우 true로 판별하도록 Footer Link 중 현재 path에 해당하는 Link 판별 로직을 수정했습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
