### PR TITLE
FLIZ-332 fix: NotificationSidebar NavItem별 click 영역 수정

### DIFF
--- a/apps/trainer/components/NotificationAccordion.tsx
+++ b/apps/trainer/components/NotificationAccordion.tsx
@@ -58,21 +58,24 @@ export default function NotificationAccordion() {
   return (
     <Accordion type="multiple">
       <AccordionItem value="전체 알림">
-        <AccordionTrigger icon={<Bell />} className="border-0">
-          <span onClick={() => router.push(RouteInstance.notification())}>전체 알림</span>
+        <AccordionTrigger
+          icon={<Bell />}
+          onClick={() => router.push(RouteInstance.notification())}
+          className="border-0"
+        >
+          <span>전체 알림</span>
         </AccordionTrigger>
       </AccordionItem>
       {NOTIFICATION_ACCORDION_ITEMS.map(({ title, contents, icon, route }, index) => (
         <AccordionItem value={String(index)} key={`${index}-${title}`}>
-          <AccordionTrigger icon={icon}>
-            <span
-              onClick={() => {
-                if (!route) return;
-                router.push(RouteInstance.notification(route));
-              }}
-            >
-              {title}
-            </span>
+          <AccordionTrigger
+            icon={icon}
+            onClick={() => {
+              if (!route) return;
+              router.push(RouteInstance.notification(route));
+            }}
+          >
+            <span>{title}</span>
           </AccordionTrigger>
           {contents.map(({ content, route }) => (
             <AccordionContent


### PR DESCRIPTION
# [FLIZ-332/trainer] fix: NotificationSidebar NavItem별 click 영역 수정

## 📝 작업 내용

NotificationSidebar의 navItem 중 AccordionItem이 없는 navItem은 onClick 핸들러가 호출되는 영역이 span으로 제한되어 있는 버그가 존재했습니다. onClick 핸들러를 span에서 AccordionTrigger로 옮겨 클릭 영역을 넓히는 작업을 진행했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
