### PR TITLE
[FLIZ-334] feat: 마이페이지 useMutation() 훅으로 처리 및

### DIFF
--- a/apps/trainer/app/my-page/_components/MyPagePending.tsx
+++ b/apps/trainer/app/my-page/_components/MyPagePending.tsx
@@ -1,0 +1,12 @@
+import Spinner from "@ui/components/Spinner";
+import React from "react";
+
+function MyPagePending() {
+  return (
+    <section className="absolute left-0 top-0 flex h-full w-full items-center justify-center bg-black/30 backdrop-blur-md">
+      <Spinner />
+    </section>
+  );
+}
+
+export default MyPagePending;

--- a/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleApplyAtStep/index.tsx
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleApplyAtStep/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@ui/components/Button";
 import { DayPicker } from "@ui/components/DayPicker";
 import React from "react";
+import { toast } from "react-toastify";
 
 import Header from "../../../_components/Header";
 
@@ -8,16 +9,32 @@ type EditScheduleApplyAtStepProps = {
   onNext: (scheduleApplyAt: string) => void;
 };
 
+const DAYS_TO_ADD = 1;
 const MONTH_OFFSET = 1;
 const PAD_LENGTH = 2;
+
+const RESET_TIME = 0;
 const PAD_CHAR = "0";
 
-export default function EditScheduleApplyAtStep({ onNext }: EditScheduleApplyAtStepProps) {
-  const [selectedDate, setSelectedDate] = React.useState<Date>(new Date());
+const tomorrow = new Date();
+tomorrow.setDate(tomorrow.getDate() + DAYS_TO_ADD);
 
-  const handleClickChangeStartDate = (date: Date | undefined) => {
+export default function EditScheduleApplyAtStep({ onNext }: EditScheduleApplyAtStepProps) {
+  const [selectedDate, setSelectedDate] = React.useState<Date>(tomorrow);
+
+  const handleClickChangeApplyAtDate = (date: Date | undefined) => {
     if (date) {
-      setSelectedDate(date);
+      const today = new Date();
+      today.setHours(RESET_TIME, RESET_TIME, RESET_TIME, RESET_TIME); // 시간을 0으로 설정하여 날짜만 비교
+
+      const selectedDateOnly = new Date(date);
+      selectedDateOnly.setHours(RESET_TIME, RESET_TIME, RESET_TIME, RESET_TIME);
+
+      if (selectedDateOnly > today) {
+        setSelectedDate(date);
+      } else {
+        toast.error("오늘 이후의 날짜를 선택해주세요.");
+      }
     }
   };
 
@@ -39,7 +56,7 @@ export default function EditScheduleApplyAtStep({ onNext }: EditScheduleApplyAtS
         <DayPicker
           mode="single"
           selectedDate={selectedDate}
-          onChangeSelectedDate={handleClickChangeStartDate}
+          onChangeSelectedDate={handleClickChangeApplyAtDate}
         />
       </div>
 

--- a/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleConfirmStep/index.tsx
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleConfirmStep/index.tsx
@@ -1,19 +1,21 @@
 "use client";
 
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@ui/components/Button";
 import React from "react";
 
+import MyPagePending from "@trainer/app/my-page/_components/MyPagePending";
 import { myInformationQueries } from "@trainer/queries/myInformation";
 
-import { addAvailablePtTime, deleteAvailablePtTime } from "@trainer/services/myInformation";
 import { AvailablePtTimeEntry } from "@trainer/services/types/myInformation.dto";
 
 import { formatAvailableScheduleConfirm } from "@trainer/utils/avaliableScheduleUtils";
 
 import ScheduleChangeResultSheet from "./ScheduleChangeResultSheet";
 import Header from "../../../_components/Header";
+import useAddScheduleMutation from "../../_hooks/useAddScheduleMutation";
+import useDeleteScheduleMutation from "../../_hooks/useDeleteScheduleMutation";
 
 type EditScheduleConfirmStepProps = {
   context: {
@@ -34,31 +36,22 @@ export default function EditScheduleConfirmStep({ context }: EditScheduleConfirm
   const deleteTargetApplyAt =
     currentApplyAt === changeApplyAt ? currentApplyAt : previousChangeApplyAt;
 
-  const { mutateAsync: deleteAvailablePtTimeMutate } = useMutation({
-    mutationFn: deleteAvailablePtTime,
-  });
+  const { deleteSchedule: deleteAvailablePtTimeMutate } = useDeleteScheduleMutation();
 
-  const { mutateAsync: addAvailablePtTimeMutate } = useMutation({
-    mutationFn: addAvailablePtTime,
-  });
+  const { addSchedule: addAvailablePtTimeMutate, isPending } = useAddScheduleMutation();
 
   const handleClickChangeSchedule = async () => {
-    try {
-      if (deleteTargetApplyAt) {
-        await deleteAvailablePtTimeMutate({
-          applyAt: deleteTargetApplyAt as string,
-        });
-      }
-      await addAvailablePtTimeMutate({
-        applyAt: changeApplyAt as string,
-        availableTimes: context.availablePtTime as Omit<AvailablePtTimeEntry, "availableTimeId">[],
+    if (deleteTargetApplyAt) {
+      await deleteAvailablePtTimeMutate({
+        applyAt: deleteTargetApplyAt as string,
       });
-
-      await queryClient.invalidateQueries(myInformationQueries.ptAvailableTime());
-    } catch (error) {
-      // 에러 처리
-      console.log(error);
     }
+    await addAvailablePtTimeMutate({
+      applyAt: changeApplyAt as string,
+      availableTimes: context.availablePtTime as Omit<AvailablePtTimeEntry, "availableTimeId">[],
+    });
+
+    await queryClient.invalidateQueries(myInformationQueries.ptAvailableTime());
   };
 
   return (
@@ -87,6 +80,7 @@ export default function EditScheduleConfirmStep({ context }: EditScheduleConfirm
           변경
         </Button>
       </ScheduleChangeResultSheet>
+      {isPending && <MyPagePending />}
     </section>
   );
 }

--- a/apps/trainer/app/my-page/edit-workout-schedule/_hooks/useAddScheduleMutation.ts
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_hooks/useAddScheduleMutation.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { myInformationQueries } from "@trainer/queries/myInformation";
+
+import { addAvailablePtTime } from "@trainer/services/myInformation";
+
+export default function useAddScheduleMutation() {
+  const queryClient = useQueryClient();
+
+  const { mutateAsync, ...rest } = useMutation({
+    mutationFn: addAvailablePtTime,
+    onSuccess: () => {
+      queryClient.invalidateQueries(myInformationQueries.ptAvailableTime());
+    },
+  });
+
+  return { addSchedule: mutateAsync, ...rest };
+}

--- a/apps/trainer/app/my-page/edit-workout-schedule/_hooks/useDeleteScheduleMutation.ts
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_hooks/useDeleteScheduleMutation.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { myInformationQueries } from "@trainer/queries/myInformation";
+
+import { deleteAvailablePtTime } from "@trainer/services/myInformation";
+
+export default function useDeleteScheduleMutation() {
+  const queryClient = useQueryClient();
+
+  const { mutateAsync, ...rest } = useMutation({
+    mutationFn: deleteAvailablePtTime,
+    onSuccess: () => {
+      queryClient.invalidateQueries(myInformationQueries.ptAvailableTime());
+    },
+  });
+
+  return { deleteSchedule: mutateAsync, ...rest };
+}

--- a/apps/user/app/my-page/_components/MyPagePending.tsx
+++ b/apps/user/app/my-page/_components/MyPagePending.tsx
@@ -1,0 +1,12 @@
+import Spinner from "@ui/components/Spinner";
+import React from "react";
+
+function MyPagePending() {
+  return (
+    <section className="absolute left-0 top-0 flex h-full w-full items-center justify-center bg-black/30 backdrop-blur-md">
+      <Spinner />
+    </section>
+  );
+}
+
+export default MyPagePending;

--- a/apps/user/app/my-page/connect-trainer/_hooks/useRequestConnectTrainer.ts
+++ b/apps/user/app/my-page/connect-trainer/_hooks/useRequestConnectTrainer.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { myInformationQueries } from "@user/queries/myInformation";
+
+import { connectTrainer } from "@user/services/myInformation";
+
+export default function useRequestConnectTrainer() {
+  const queryClient = useQueryClient();
+
+  const { mutate, ...rest } = useMutation({
+    mutationFn: connectTrainer,
+    onSuccess: () => {
+      queryClient.invalidateQueries(myInformationQueries.summary());
+    },
+  });
+
+  return { requestConnectTrainer: mutate, ...rest };
+}

--- a/apps/user/app/my-page/edit-workout-schedules/_hooks/useEditPreferenceTimeMutation.ts
+++ b/apps/user/app/my-page/edit-workout-schedules/_hooks/useEditPreferenceTimeMutation.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { myInformationQueries } from "@user/queries/myInformation";
+
+import { editPreferredTime } from "@user/services/myInformation";
+
+export default function useEditPreferenceTimeMutation() {
+  const queryClient = useQueryClient();
+
+  const { mutate, ...rest } = useMutation({
+    mutationFn: editPreferredTime,
+    onSuccess: () => {
+      queryClient.invalidateQueries(myInformationQueries.summary());
+    },
+  });
+
+  return { editPreferenceTime: mutate, ...rest };
+}

--- a/apps/user/app/my-page/my-trainer-information/_components/TrainerUnlinkItem.tsx
+++ b/apps/user/app/my-page/my-trainer-information/_components/TrainerUnlinkItem.tsx
@@ -1,35 +1,28 @@
 "use client";
 
-import { useMutation } from "@tanstack/react-query";
-import { useQueryClient } from "@tanstack/react-query";
 import Icon from "@ui/components/Icon";
 import { ProfileItem } from "@ui/components/ProfileItem";
-import React, { useState } from "react";
-
-import { myInformationQueries } from "@user/queries/myInformation";
-
-import { disconnectTrainer } from "@user/services/myInformation";
+import React, { useEffect, useState } from "react";
 
 import UnlinkAlarmSheet from "./BottomSheet/UnlinkAlarmSheet";
 import UnlinkDialog from "./Dialog";
+import MyPagePending from "../../_components/MyPagePending";
+import useUnlinkTrainerMutation from "../_hooks/useUnlinkTrainerMutation";
 
 export default function TrainerUnlinkItem() {
-  const queryClient = useQueryClient();
-
   const [isOpenBottomSheet, setIsOpenBottomSheet] = useState(false);
 
-  const { mutate } = useMutation({
-    mutationFn: () => disconnectTrainer(),
-  });
+  const { unlinkTrainer, isSuccess, isPending } = useUnlinkTrainerMutation();
 
   const handleClickUnlinkTrainer = () => {
-    mutate(undefined, {
-      onSuccess: () => {
-        setIsOpenBottomSheet(true);
-        queryClient.invalidateQueries(myInformationQueries.summary());
-      },
-    });
+    unlinkTrainer(undefined);
   };
+
+  useEffect(() => {
+    if (isSuccess) {
+      setIsOpenBottomSheet(true);
+    }
+  }, [isSuccess]);
 
   return (
     <>
@@ -49,6 +42,7 @@ export default function TrainerUnlinkItem() {
         isOpenBottomSheet={isOpenBottomSheet}
         setIsOpenBottomSheet={setIsOpenBottomSheet}
       />
+      {isPending && <MyPagePending />}
     </>
   );
 }

--- a/apps/user/app/my-page/my-trainer-information/_hooks/useUnlinkTrainerMutation.ts
+++ b/apps/user/app/my-page/my-trainer-information/_hooks/useUnlinkTrainerMutation.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { myInformationQueries } from "@user/queries/myInformation";
+
+import { disconnectTrainer } from "@user/services/myInformation";
+
+export default function useUnlinkTrainerMutation() {
+  const queryClient = useQueryClient();
+
+  const { mutate, ...rest } = useMutation({
+    mutationFn: () => disconnectTrainer(),
+    onSuccess: () => {
+      queryClient.invalidateQueries(myInformationQueries.summary());
+    },
+  });
+
+  return { unlinkTrainer: mutate, ...rest };
+}

--- a/packages/ui/src/components/InputOTP.tsx
+++ b/packages/ui/src/components/InputOTP.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import { cn } from "../lib/utils";
 
 const inputOTPSlotVariants = cva(
-  "h-[60px] w-[52.08px] border text-sm rounded-l-md border-l rounded-r-md",
+  "bg-background-sub2 text-text-primary relative flex items-center justify-center text-4xl h-[60px] w-[52.08px] border rounded-l-md border-l rounded-r-md",
   {
     variants: {
       variant: {
@@ -56,15 +56,7 @@ const InputOTPSlot = React.forwardRef<
   const { char, hasFakeCaret } = inputOTPContext.slots[index];
 
   return (
-    <div
-      ref={ref}
-      className={cn(
-        inputOTPSlotVariants({ variant: variant }),
-        "bg-background-sub2 text-text-primary relative flex items-center justify-center text-4xl",
-        className,
-      )}
-      {...props}
-    >
+    <div ref={ref} className={cn(inputOTPSlotVariants({ variant: variant }), className)} {...props}>
       {char}
       {hasFakeCaret && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">


### PR DESCRIPTION
## 📝 작업 내용
* 기존 마이페이지에서 사용하던 useMutation()을 customHook으로 변환하였습니다.
* 마이페이지 post 요청 시, pending UI를 구현하여 pending 상태 시 보여줄 컴포넌트를 적용하였습니다.
* 유저와 트레이너의 상위 error.tsx에서 reset()만 호출 시, 캐싱된 데이터가 있는 경우 api 호출이 안 되는 것을 확인하고 캐싱 무효화를 위한 router.refresh()를 추가하였습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
