### PR TITLE
[FLIZ-341/trainer]  fix: 예약 취소 거절 후, 캘린더 페이지에 들어가니, TypeError가 나타나며 캘린더 페이지가 죽는 이슈 해결

### DIFF
--- a/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/index.tsx
+++ b/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/index.tsx
@@ -77,4 +77,19 @@ export const SheetAdapter: Record<
       />
     );
   },
+  "예약 취소 거절": (commonProps, reservationContent) => {
+    return isReservationPast(reservationContent[0]) ? (
+      <ReservationOutcomeSheet
+        {...commonProps}
+        memberInformation={reservationContent[0]}
+        reservationStatus="예약 확정"
+      />
+    ) : (
+      <ReservationControlSheet
+        {...commonProps}
+        memberInformation={reservationContent[0]}
+        reservationStatus="예약 확정"
+      />
+    );
+  },
 };

--- a/apps/trainer/app/schedule-management/_constants/reservationConfig.ts
+++ b/apps/trainer/app/schedule-management/_constants/reservationConfig.ts
@@ -44,4 +44,9 @@ export const RESERVATION_CONFIG: Record<
     content: (reservationContent) => reservationContent.memberInfo.name,
     ptStatus: () => "고정 예약",
   },
+  "예약 취소 거절": {
+    style: "bg-brand-primary-500 hover:bg-brand-primary-600",
+    content: (reservationContent) => reservationContent.memberInfo.name,
+    ptStatus: () => "예약 확정",
+  },
 };

--- a/packages/core/src/api/types/common.ts
+++ b/packages/core/src/api/types/common.ts
@@ -56,6 +56,7 @@ export type ReservationStatus =
   | "예약 취소"
   | "예약 변경 요청"
   | "예약 취소 요청"
+  | "예약 취소 거절"
   | "고정 예약";
 
 export type BaseMemberInfo = {


### PR DESCRIPTION
## 📝 작업 내용

- 확정된 예약을 취소할 경우 해당 예약의 상태가 예약 취소 거절 상태로 변경되게 되는데, 이에 대한 타입이 없어 누락된 타입을 추가하고 이 타입에 대한 대응을 통해 예약 취소 거절 Status에 대한 대응을 통해 이슈를 해결하였습니다.
   - 예약 취소 거절 상태를 예약 확정 상태로 컨버팅 하였습니다. 

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

