### PR TITLE
[FLIZ-340] feat: 트레이너 마이페이지 변경 예정시간 제거 기능 구현

### DIFF
--- a/apps/trainer/app/my-page/_components/DeleteScheduleBottomSheet.tsx
+++ b/apps/trainer/app/my-page/_components/DeleteScheduleBottomSheet.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import {
   Sheet,
   SheetContent,
@@ -7,6 +8,8 @@ import {
 } from "@ui/components/Sheet";
 import { VisuallyHidden } from "@ui/components/VisuallyHidden";
 import React, { useEffect } from "react";
+
+import { myInformationQueries } from "@trainer/queries/myInformation";
 
 import useDeleteScheduleMutation from "../edit-workout-schedule/_hooks/useDeleteScheduleMutation";
 import SheetItem from "../my-information/_components/BottomSheet/SheetItem";
@@ -19,8 +22,12 @@ type DeleteScheduleBottomSheetProps = {
 function DeleteScheduleBottomSheet({ open, onOpenChange }: DeleteScheduleBottomSheetProps) {
   const { deleteSchedule, isSuccess } = useDeleteScheduleMutation();
 
+  const { data: currentData } = useQuery(myInformationQueries.ptAvailableTime());
+
+  const previousChangeApplyAt = currentData?.data.scheduledChanges?.applyAt;
+
   const handleClickDeleteSchedule = () => {
-    deleteSchedule();
+    deleteSchedule({ applyAt: previousChangeApplyAt as string });
   };
 
   useEffect(() => {

--- a/apps/trainer/app/my-page/_components/DeleteScheduleBottomSheet.tsx
+++ b/apps/trainer/app/my-page/_components/DeleteScheduleBottomSheet.tsx
@@ -1,0 +1,56 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@ui/components/Sheet";
+import { VisuallyHidden } from "@ui/components/VisuallyHidden";
+import React, { useEffect } from "react";
+
+import useDeleteScheduleMutation from "../edit-workout-schedule/_hooks/useDeleteScheduleMutation";
+import SheetItem from "../my-information/_components/BottomSheet/SheetItem";
+
+type DeleteScheduleBottomSheetProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+function DeleteScheduleBottomSheet({ open, onOpenChange }: DeleteScheduleBottomSheetProps) {
+  const { deleteSchedule, isSuccess } = useDeleteScheduleMutation();
+
+  const handleClickDeleteSchedule = () => {
+    deleteSchedule();
+  };
+
+  useEffect(() => {
+    if (isSuccess) {
+      onOpenChange(false);
+    }
+  }, [isSuccess]);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="md:w-mobile md:inset-x-[calc((100%-480px)/2)]">
+        <SheetHeader>
+          <VisuallyHidden>
+            <SheetTitle>PT 수업 예정시간 삭제</SheetTitle>
+
+            <SheetDescription>
+              이 모달은 PT 수업 시간 설정과 관련된 기능을 제공합니다.
+            </SheetDescription>
+          </VisuallyHidden>
+          <SheetItem
+            icon={"Trash"}
+            label="PT 수업 예정 시간 삭제"
+            variant="danger"
+            onClick={handleClickDeleteSchedule}
+          />
+          {/* <SheetFooter></SheetFooter> */}
+        </SheetHeader>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export default DeleteScheduleBottomSheet;

--- a/apps/trainer/app/my-page/_components/EditScheduleBottomSheet.tsx
+++ b/apps/trainer/app/my-page/_components/EditScheduleBottomSheet.tsx
@@ -29,8 +29,9 @@ function EditScheduleBottomSheet({ open, onOpenChange }: EditScheduleBottomSheet
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="bottom" className="md:w-mobile md:inset-x-[calc((100%-480px)/2)]">
         <SheetHeader>
-          <SheetTitle>PT 수업 시간 설정</SheetTitle>
           <VisuallyHidden>
+            <SheetTitle>PT 수업 시간 설정</SheetTitle>
+
             <SheetDescription>
               이 모달은 PT 수업 시간 설정과 관련된 기능을 제공합니다.
             </SheetDescription>

--- a/apps/trainer/app/my-page/_components/MyDayOffContainer.tsx
+++ b/apps/trainer/app/my-page/_components/MyDayOffContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DayOfWeek } from "@5unwan/core/api/types/common";
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import Icon from "@ui/components/Icon";
 import React, { useState } from "react";
 
@@ -22,7 +22,7 @@ export type RequestDayOffInformation = {
 };
 
 export default function MyDayOffContainer() {
-  const { data: response } = useQuery(myInformationQueries.dayOff());
+  const { data: response } = useSuspenseQuery(myInformationQueries.dayOff());
 
   const [open, setOpen] = useState(false);
   const [deleteDayOffData, setDeleteDayOffData] = useState<RequestDayOffInformation | null>(null);

--- a/apps/trainer/app/my-page/_components/ScheduleInformation.tsx
+++ b/apps/trainer/app/my-page/_components/ScheduleInformation.tsx
@@ -5,6 +5,7 @@ import React, { useState } from "react";
 
 import PTSchedule from "@trainer/components/PTSchedule";
 
+import DeleteScheduleBottomSheet from "./DeleteScheduleBottomSheet";
 import EditScheduleBottomSheet from "./EditScheduleBottomSheet";
 import { PTScheduleProps } from "./MyAvailableTimeContainer";
 
@@ -14,20 +15,30 @@ type ScheduleInformationProps = {
 };
 
 export default function ScheduleInformation({ className, ptSchedule }: ScheduleInformationProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isEditScheduleOpen, setIsEditScheduleOpen] = useState(false);
+  const [isDeleteScheduleOpen, setIsDeleteScheduleOpen] = useState(false);
 
-  const handleClickSheetOpen = () => {
-    setIsOpen(true);
+  const handleClickCurrentScheduleSheetOpen = () => {
+    setIsEditScheduleOpen(true);
+  };
+
+  const handleClickChangeScheduleSheetOpen = () => {
+    setIsDeleteScheduleOpen(true);
   };
 
   return (
     <section className={cn("mt-[1.563rem] w-full ", className)}>
       <p className="text-headline mb-[0.625rem]">PT 수업 시간</p>
-      <EditScheduleBottomSheet open={isOpen} onOpenChange={setIsOpen} />
+      <EditScheduleBottomSheet open={isEditScheduleOpen} onOpenChange={setIsEditScheduleOpen} />
+      <DeleteScheduleBottomSheet
+        open={isDeleteScheduleOpen}
+        onOpenChange={setIsDeleteScheduleOpen}
+      />
       <PTSchedule
         currentSchedules={ptSchedule.currentSchedules}
         scheduledChanges={ptSchedule.scheduledChanges}
-        onClickEllipsis={handleClickSheetOpen}
+        onClickCurrentEllipsis={handleClickCurrentScheduleSheetOpen}
+        onClickChangeEllipsis={handleClickChangeScheduleSheetOpen}
       />
     </section>
   );

--- a/apps/trainer/app/my-page/_components/Skeleton/MyPTHistorySkeleton.tsx
+++ b/apps/trainer/app/my-page/_components/Skeleton/MyPTHistorySkeleton.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import MyPageItemSkeleton from "./MyPageItemSkeleton";
+
+function MyPTHistorySkeleton() {
+  return (
+    <div className="mt-[1.563rem] flex h-auto w-full flex-col gap-0.5">
+      <p className="text-headline">PT 수업 시간</p>
+      <MyPageItemSkeleton className="mt-[0.625rem] h-[5.4375rem]" />
+    </div>
+  );
+}
+
+export default MyPTHistorySkeleton;

--- a/apps/trainer/app/my-page/_components/Skeleton/index.tsx
+++ b/apps/trainer/app/my-page/_components/Skeleton/index.tsx
@@ -19,10 +19,6 @@ export default function MyPageSkeleton() {
         <MyPageItemSkeleton className="mt-[1.5625rem]" />
         <MyPageItemSkeleton />
       </div>
-      <div className="mt-[1.563rem] flex h-auto w-full flex-col gap-0.5">
-        <p className="text-headline">PT 수업 시간</p>
-        <MyPageItemSkeleton className="mt-[0.625rem] h-[5.4375rem]" />
-      </div>
     </section>
   );
 }

--- a/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleApplyAtStep/index.tsx
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleApplyAtStep/index.tsx
@@ -49,7 +49,7 @@ export default function EditScheduleApplyAtStep({ onNext }: EditScheduleApplyAtS
   };
 
   return (
-    <section className="bg-background-primary text-text-primary flex h-screen w-full flex-col  justify-between">
+    <section className="bg-background-primary text-text-primary flex h-full w-full flex-col  justify-between">
       <div>
         <Header title="변경 시점 적용" />
 

--- a/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleConfirmStep/index.tsx
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleConfirmStep/index.tsx
@@ -27,22 +27,26 @@ export default function EditScheduleConfirmStep({ context }: EditScheduleConfirm
 
   const { applyAt, availableTimes } = context;
 
-  const currentApplyAt = currentData?.data.currentSchedules?.applyAt;
+  availableTimes.forEach((time) => {
+    if (!time.startTime) {
+      time.startTime = "00:00";
+    }
+    if (!time.endTime) {
+      time.endTime = "23:00";
+    }
+  });
 
   const changeApplyAt = applyAt;
 
   const previousChangeApplyAt = currentData?.data.scheduledChanges?.applyAt;
-
-  const deleteTargetApplyAt =
-    currentApplyAt === changeApplyAt ? currentApplyAt : previousChangeApplyAt;
 
   const { deleteSchedule: deleteAvailablePtTimeMutate } = useDeleteScheduleMutation();
 
   const { addSchedule: addAvailablePtTimeMutate, isPending } = useAddScheduleMutation();
 
   const handleClickChangeSchedule = async () => {
-    if (deleteTargetApplyAt) {
-      await deleteAvailablePtTimeMutate();
+    if (previousChangeApplyAt) {
+      await deleteAvailablePtTimeMutate({ applyAt: previousChangeApplyAt });
     }
     await addAvailablePtTimeMutate({
       applyAt: changeApplyAt as string,

--- a/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleConfirmStep/index.tsx
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleConfirmStep/index.tsx
@@ -42,9 +42,7 @@ export default function EditScheduleConfirmStep({ context }: EditScheduleConfirm
 
   const handleClickChangeSchedule = async () => {
     if (deleteTargetApplyAt) {
-      await deleteAvailablePtTimeMutate({
-        applyAt: deleteTargetApplyAt as string,
-      });
+      await deleteAvailablePtTimeMutate();
     }
     await addAvailablePtTimeMutate({
       applyAt: changeApplyAt as string,
@@ -55,7 +53,7 @@ export default function EditScheduleConfirmStep({ context }: EditScheduleConfirm
   };
 
   return (
-    <section className="bg-background-primary text-text-primary flex h-screen w-full flex-col justify-between">
+    <section className="bg-background-primary text-text-primary flex h-full w-full flex-col justify-between">
       <div className="w-full text-center">
         <Header title="PT 수업 시간" />
         <p className="text-body-1 text-text-sub2 mt-[0.625rem]">

--- a/apps/trainer/app/my-page/edit-workout-schedule/_hooks/useDeleteScheduleMutation.ts
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_hooks/useDeleteScheduleMutation.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { myInformationQueries } from "@trainer/queries/myInformation";
 
@@ -7,8 +7,12 @@ import { deleteAvailablePtTime } from "@trainer/services/myInformation";
 export default function useDeleteScheduleMutation() {
   const queryClient = useQueryClient();
 
+  const { data: currentData } = useQuery(myInformationQueries.ptAvailableTime());
+
+  const previousChangeApplyAt = currentData?.data.scheduledChanges?.applyAt;
+
   const { mutateAsync, ...rest } = useMutation({
-    mutationFn: deleteAvailablePtTime,
+    mutationFn: () => deleteAvailablePtTime({ applyAt: previousChangeApplyAt as string }),
     onSuccess: () => {
       queryClient.invalidateQueries(myInformationQueries.ptAvailableTime());
     },

--- a/apps/trainer/app/my-page/edit-workout-schedule/_hooks/useDeleteScheduleMutation.ts
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_hooks/useDeleteScheduleMutation.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { myInformationQueries } from "@trainer/queries/myInformation";
 
@@ -7,12 +7,8 @@ import { deleteAvailablePtTime } from "@trainer/services/myInformation";
 export default function useDeleteScheduleMutation() {
   const queryClient = useQueryClient();
 
-  const { data: currentData } = useQuery(myInformationQueries.ptAvailableTime());
-
-  const previousChangeApplyAt = currentData?.data.scheduledChanges?.applyAt;
-
   const { mutateAsync, ...rest } = useMutation({
-    mutationFn: () => deleteAvailablePtTime({ applyAt: previousChangeApplyAt as string }),
+    mutationFn: deleteAvailablePtTime,
     onSuccess: () => {
       queryClient.invalidateQueries(myInformationQueries.ptAvailableTime());
     },

--- a/apps/trainer/app/my-page/page.tsx
+++ b/apps/trainer/app/my-page/page.tsx
@@ -4,13 +4,18 @@ import MyAvailableTimeContainer from "./_components/MyAvailableTimeContainer";
 import MyDayOffContainer from "./_components/MyDayOffContainer";
 import MyPageContainer from "./_components/MyPageContainer";
 import MyPageSkeleton from "./_components/Skeleton";
+import MyPTHistorySkeleton from "./_components/Skeleton/MyPTHistorySkeleton";
 
 export default function page() {
   return (
     <main className="bg-background-primary text-text-primary h-screen w-full">
       <Suspense fallback={<MyPageSkeleton />}>
         <MyPageContainer />
+      </Suspense>
+      <Suspense fallback={<MyPTHistorySkeleton />}>
         <MyAvailableTimeContainer />
+      </Suspense>
+      <Suspense fallback={<></>}>
         <MyDayOffContainer />
       </Suspense>
     </main>

--- a/apps/trainer/components/PTSchedule.tsx
+++ b/apps/trainer/components/PTSchedule.tsx
@@ -20,19 +20,30 @@ type PTSchedulesProps = {
     applyAt: string;
     schedules: SpanScheduleUnit[];
   }[];
-  onClickEllipsis: () => void;
+  onClickCurrentEllipsis: () => void;
+  onClickChangeEllipsis?: () => void;
 };
 
-function PTSchedule({ currentSchedules, scheduledChanges, onClickEllipsis }: PTSchedulesProps) {
+function PTSchedule({
+  currentSchedules,
+  scheduledChanges,
+  onClickCurrentEllipsis,
+  onClickChangeEllipsis,
+}: PTSchedulesProps) {
   return (
     <div className="flex flex-col items-center gap-[0.5rem]">
       <PTScheduleItem
         current={true}
         schedules={currentSchedules}
-        onClickEllipsis={onClickEllipsis}
+        onClickEllipsis={onClickCurrentEllipsis}
       />
       {scheduledChanges.map(({ applyAt, schedules }, index) => (
-        <PTScheduleItem key={`scheduled-${index}`} applyAt={applyAt} schedules={schedules} />
+        <PTScheduleItem
+          key={`scheduled-${index}`}
+          applyAt={applyAt}
+          schedules={schedules}
+          onClickEllipsis={onClickChangeEllipsis}
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
## 📝 작업 내용
* 트레이너의 마이페이지에서 변경 예정 시간을 제거할 수 있는 기능을 구현하였습니다.
* 기존 PT 변경 시간에 대하여 null값으로 들어오던 시간값은 시작값 기본 00시 끝값 23시로 넣어 처리하였습니다.
* PT 변경 시간 UI에 대하여 버튼이 보이지 않던 버그를 수정하였습니다.
* 트레이너 마이페이지 Suspense를 api호출 컴포넌트별로 분리하였습니다.


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
