### PR TITLE
[FLIZ-347] fix: InputOTP 키보드 타입 변경

### DIFF
--- a/apps/trainer/app/error.tsx
+++ b/apps/trainer/app/error.tsx
@@ -4,7 +4,12 @@ import { Button } from "@ui/components/Button";
 import Icon from "@ui/components/Icon";
 import { Text } from "@ui/components/Text";
 
-export default function Error({ reset }: { error: Error; reset: () => void }) {
+type ErrorProps = {
+  error: Error;
+  reset: () => void;
+};
+
+export default function Error({ reset }: ErrorProps) {
   const handleReset = () => {
     window.location.reload();
     reset();

--- a/apps/trainer/app/error.tsx
+++ b/apps/trainer/app/error.tsx
@@ -6,6 +6,7 @@ import { Text } from "@ui/components/Text";
 
 export default function Error({ reset }: { error: Error; reset: () => void }) {
   const handleReset = () => {
+    window.location.reload();
     reset();
   };
 

--- a/apps/user/app/error.tsx
+++ b/apps/user/app/error.tsx
@@ -6,6 +6,7 @@ import { Text } from "@ui/components/Text";
 
 export default function Error({ reset }: { error: Error; reset: () => void }) {
   const handleReset = () => {
+    window.location.reload();
     reset();
   };
 
@@ -24,7 +25,7 @@ export default function Error({ reset }: { error: Error; reset: () => void }) {
 
       <div className="flex w-full gap-2">
         <Button variant={"brand"} className="mt-10 h-[3.375rem] flex-1" onClick={handleReset}>
-          <Text.Headline1>다시 시도</Text.Headline1>
+          <Text.Headline1 onClick={reset}>다시 시도</Text.Headline1>
         </Button>
       </div>
     </main>

--- a/apps/user/app/error.tsx
+++ b/apps/user/app/error.tsx
@@ -4,7 +4,12 @@ import { Button } from "@ui/components/Button";
 import Icon from "@ui/components/Icon";
 import { Text } from "@ui/components/Text";
 
-export default function Error({ reset }: { error: Error; reset: () => void }) {
+type ErrorProps = {
+  error: Error;
+  reset: () => void;
+};
+
+export default function Error({ reset }: ErrorProps) {
   const handleReset = () => {
     window.location.reload();
     reset();

--- a/apps/user/app/my-page/_components/PTHistory/PTHistoryContent.tsx
+++ b/apps/user/app/my-page/_components/PTHistory/PTHistoryContent.tsx
@@ -3,6 +3,7 @@
 import { PtInfo, PtStatus } from "@5unwan/core/api/types/common";
 import { useQueryClient, useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import PTHistoryItem from "@ui/components/PTHistoryItem";
+import { cn } from "@ui/lib/utils";
 import { useRef } from "react";
 
 import { myInformationQueries } from "@user/queries/myInformation";
@@ -71,7 +72,12 @@ export default function PTHistoryContent({ historyFilter }: { historyFilter: PtS
 
         <div ref={intersectionRef} className="h-4 w-full">
           {isFetchingNextPage && (
-            <div className="mt-[1.25rem] flex flex-col gap-[0.625rem] overflow-y-auto pb-2">
+            <div
+              className={cn(
+                "flex flex-col gap-[0.625rem] overflow-y-auto pb-2",
+                !ptHistory && "mt-[1.25rem]",
+              )}
+            >
               <MyPageItemSkeleton className="min-h-[3.375rem]" />
               <MyPageItemSkeleton className="min-h-[3.375rem]" />
               <MyPageItemSkeleton className="min-h-[3.375rem]" />

--- a/packages/ui/src/components/InputOTP.tsx
+++ b/packages/ui/src/components/InputOTP.tsx
@@ -33,6 +33,8 @@ const InputOTP = React.forwardRef<
     containerClassName={cn("gap-2 has-[:disabled]:opacity-50", containerClassName)}
     className={cn("disabled:cursor-not-allowed", className)}
     {...props}
+    inputMode="text"
+    type="text"
   />
 ));
 InputOTP.displayName = "InputOTP";


### PR DESCRIPTION
## 📝 작업 내용
* 모바일  inputOTP 설정 시, 키보드 타입을 텍스트로 변경
* 에러 페이지 버튼 클릭 시, 강제 재로딩

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
