### PR TITLE
[FLIZ-345/trainer] : 트레이너/유저 도메인에서 에러 체킹을 위한 콘솔로그 추가

### DIFF
--- a/apps/trainer/app/error.tsx
+++ b/apps/trainer/app/error.tsx
@@ -4,10 +4,12 @@ import { Button } from "@ui/components/Button";
 import Icon from "@ui/components/Icon";
 import { Text } from "@ui/components/Text";
 
-export default function Error({ reset }: { error: Error; reset: () => void }) {
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
   const handleReset = () => {
     reset();
   };
+
+  console.error("Error:", error);
 
   return (
     <main className="bg-background-primary flex h-full w-full flex-col items-center justify-between">

--- a/apps/trainer/app/schedule-management/_components/Calendar/WeekRow.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/WeekRow.tsx
@@ -43,6 +43,26 @@ export default function WeekRow({
 
   if (!reservationInformation || isLoading) return null;
 
+  console.log(
+    "예약 데이터 체크:",
+    reservationInformation.data.sort((a, b) => {
+      const aDate = new Date(a.reservationDates[0]);
+      const bDate = new Date(b.reservationDates[0]);
+
+      return aDate.getTime() - bDate.getTime();
+    }),
+  );
+
+  console.log(
+    "컨버팅 된 예약 데이터 체크->",
+    filterLatestReservationsByDate(reservationInformation.data).sort((a, b) => {
+      const aDate = new Date(a.reservationDates[0]);
+      const bDate = new Date(b.reservationDates[0]);
+
+      return aDate.getTime() - bDate.getTime();
+    }),
+  );
+
   return (
     <div className="flex h-full gap-[0.125rem]">
       {week.map((date) => (

--- a/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/index.tsx
+++ b/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useQuery } from "@tanstack/react-query";
-import { toZonedTime, format } from "date-fns-tz";
+import { format, addHours } from "date-fns";
 import { useState } from "react";
 
 import FixedReservationListFallback from "@trainer/app/schedule-management/_components/Fallback/FixedReservationListFallback";
@@ -23,15 +23,18 @@ function PendingReservationContainer({
   const [selectedMemberInformation, setSelectedMemberInformation] =
     useState<ReservationDetailPendingStatus | null>(null);
 
-  const timeZone = "Asia/Seoul";
-  const zonedDate = toZonedTime(formattedAdjustedDate, timeZone);
-  const formattedZonedDate = format(zonedDate, "yyyy-MM-dd'T'HH:mm");
+  const NINE_HOURS = 9;
+  const isProduction = process.env.NODE_ENV === "production";
+  const adjustedDate = isProduction
+    ? addHours(new Date(formattedAdjustedDate), NINE_HOURS)
+    : new Date(formattedAdjustedDate);
+  const formattedDate = format(adjustedDate, "yyyy-MM-dd'T'HH:mm");
 
   const { data: reservationPendingList, isLoading } = useQuery(
-    reservationQueries.pendingDetail(formattedZonedDate),
+    reservationQueries.pendingDetail(formattedDate),
   );
 
-  console.log("formattedAdjustedDate", formattedZonedDate);
+  console.log("formattedAdjustedDate", formattedDate);
   console.log("reservationPendingList", reservationPendingList);
 
   return (
@@ -75,7 +78,7 @@ function PendingReservationContainer({
       </section>
       <ApproveButton
         selectedMemberInformation={selectedMemberInformation}
-        selectedDate={formattedAdjustedDate}
+        selectedDate={formattedDate}
       />
     </section>
   );

--- a/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/index.tsx
+++ b/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/index.tsx
@@ -14,14 +14,18 @@ import MemberCardList from "./MemberCardList";
 type PendingReservationContainerProps = {
   formattedAdjustedDate: string;
   selectedDate: string;
+  emptyErrorCheckSelectedDate: Date;
 };
 
 function PendingReservationContainer({
   formattedAdjustedDate,
   selectedDate,
+  emptyErrorCheckSelectedDate,
 }: PendingReservationContainerProps) {
   const [selectedMemberInformation, setSelectedMemberInformation] =
     useState<ReservationDetailPendingStatus | null>(null);
+
+  console.log("쿼리파람 SelectedDate 체크:", emptyErrorCheckSelectedDate);
 
   const NINE_HOURS = 9;
   const isProduction = process.env.NODE_ENV === "production";

--- a/apps/user/app/error.tsx
+++ b/apps/user/app/error.tsx
@@ -4,10 +4,12 @@ import { Button } from "@ui/components/Button";
 import Icon from "@ui/components/Icon";
 import { Text } from "@ui/components/Text";
 
-export default function Error({ reset }: { error: Error; reset: () => void }) {
+export default function Error({ reset, error }: { error: Error; reset: () => void }) {
   const handleReset = () => {
     reset();
   };
+
+  console.log("Error:", error);
 
   return (
     <main className="bg-background-primary flex h-full w-full flex-col items-center justify-between">


### PR DESCRIPTION
## 📝 작업 내용

- 트레이너/유저 도메인에서 에러 체킹을 위한 콘솔로그 추가(캘린더, 에러.tsx, 예약대기 페이지)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
