### PR TITLE
[FLIZ-371/user] feat: PTHistory 관련 전체 필터 제외 후 취소 필터 적용 및 미처리를 예약대기로 필터 이름 변경

### DIFF
--- a/apps/user/app/my-page/_components/PTHistory/PTHistoryCotainer.tsx
+++ b/apps/user/app/my-page/_components/PTHistory/PTHistoryCotainer.tsx
@@ -8,7 +8,7 @@ import PTHistoryFilter from "./PTHistoryFilter";
 import { PTHistoryLabel } from "./PTHistoryLabel";
 
 export default function PTHistoryContainer() {
-  const [historyFilter, setHistoryFilter] = useState<PtStatus>("NONE");
+  const [historyFilter, setHistoryFilter] = useState<PtStatus>("SESSION_COMPLETED");
 
   return (
     <section className="mt-[1.625rem] flex h-full flex-col overflow-hidden">

--- a/apps/user/app/my-page/_components/PTHistory/PTHistoryFilter.tsx
+++ b/apps/user/app/my-page/_components/PTHistory/PTHistoryFilter.tsx
@@ -3,12 +3,12 @@
 import { PtStatus } from "@5unwan/core/api/types/common";
 import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
 
-export const FILTER_OPTIONS: Record<Exclude<PtStatus, "SESSION_CANCELLED">, string> = {
-  NONE: "전체",
+export const FILTER_OPTIONS: Record<Exclude<PtStatus, "NONE">, string> = {
+  // NONE: "전체",
   SESSION_COMPLETED: "PT 완료",
   SESSION_NOT_ATTEND: "불참석",
-  SESSION_WAITING: "미처리",
-  // SESSION_CANCELLED: "취소",
+  SESSION_WAITING: "예약 대기",
+  SESSION_CANCELLED: "취소",
 };
 
 interface PTHistoryFilterProps {


### PR DESCRIPTION
## 📝 작업 내용
트레이너 회원관리 및 API와 통일성을 위하여 "전체" 필터를 제외하였습니다.
기존 "미처리"에 대한 필터명을 예약대기로 변경하였으며,
`SESSION_CANCELED` 필터를 추가하여 예약 취소에 대한 필터를 추가하였습니다.

\- 전체

\- PT 완료
\+ PT완료

\- 미처리
\+ 예약대기

\+ PT취소
 
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
