### PR TITLE
[FLIZ-372/trainer] refactor: 캘린더 타임블록 UI 변경 수정, 예약 현황 데이터에서 최근 데이터가 과거 데이터를 OverWrite 할 수 있도록 컨버팅 함수 수정

### DIFF
--- a/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-magic-numbers */
 
 import { ReservationStatus } from "@5unwan/core/api/types/common";
+import Icon from "@ui/components/Icon";
 import { cn } from "@ui/lib/utils";
 import { format } from "date-fns";
 import { ComponentProps, useEffect, useState } from "react";
@@ -125,13 +126,13 @@ export default function TimeBlock({
       ) : (
         <div
           className={cn(
-            "bg-background-sub2 hover:bg-background-sub2 text-text-primary relative flex h-[3.9375rem] w-full cursor-not-allowed flex-col items-center justify-center gap-1 rounded-[0.125rem] p-1",
+            "bg-background-sub2 text-text-primary relative flex h-[3.9375rem] w-full cursor-not-allowed flex-col items-center justify-center gap-1 rounded-[0.125rem] p-1",
             isToday(date) && "bg-background-sub3 hover:bg-background-sub4",
             reservationBlockStyle,
           )}
           {...props}
         >
-          -
+          <Icon name="CircleOff" size="sm" className="text-gray-400" />
         </div>
       )}
     </>

--- a/apps/trainer/app/schedule-management/_utils/reservationMerger.ts
+++ b/apps/trainer/app/schedule-management/_utils/reservationMerger.ts
@@ -8,7 +8,7 @@ export const filterLatestReservationsByDate = (reservations: ModifiedReservation
   for (let i = 0; i < reservations.length; i += 1) {
     const reservation = reservations[i];
     reservation.reservationDates.forEach((dateString, index) => {
-      const dateKey = `${dateString}-${reservation.reservationId}`;
+      const dateKey = `${dateString}`;
 
       if (index === 0) dateMap[dateKey] = reservation;
       else


### PR DESCRIPTION
## 📝 작업 내용

- 캘린더 타임블록 UI 변경 수정
- 예약 현황 데이터에서 최근 데이터가 과거 데이터를 OverWrite 할 수 있도록 컨버팅 함수 수정 

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
