### PR TITLE
[FLIZ-370/root] feat: 마이페이지에 푸시 알림 허용 스위치 추가

### DIFF
--- a/apps/trainer/app/my-page/my-information/_components/MyInformationContainer.tsx
+++ b/apps/trainer/app/my-page/my-information/_components/MyInformationContainer.tsx
@@ -3,6 +3,8 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Avatar, AvatarFallback } from "@ui/components/Avatar";
 import { Button } from "@ui/components/Button";
+import { ProfileItem } from "@ui/components/ProfileItem";
+import PushPermissionSwitch from "@ui/components/PushPermissionSwitch";
 import Image from "next/image";
 
 import { myInformationQueries } from "@trainer/queries/myInformation";
@@ -58,6 +60,9 @@ export default function MyInformationContainer() {
           변경 <Icon name="ChevronRight" size="lg" />
         </section> */}
       </MemorizedProfileItem>
+      <ProfileItem variant="pushAlarm" className="w-full">
+        <PushPermissionSwitch />
+      </ProfileItem>
     </section>
   );
 }

--- a/apps/trainer/types/navigator.d.ts
+++ b/apps/trainer/types/navigator.d.ts
@@ -1,0 +1,4 @@
+// IOS Safari PWA 탐지를 위해 Navigator 인터페이스 확장
+declare interface Navigator {
+  standalone?: boolean;
+}

--- a/apps/user/app/my-page/my-information/_components/MyDetailInformations.tsx
+++ b/apps/user/app/my-page/my-information/_components/MyDetailInformations.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { ProfileItem } from "@ui/components/ProfileItem";
+import PushPermissionSwitch from "@ui/components/PushPermissionSwitch";
 import React from "react";
 
 import { myInformationQueries } from "@user/queries/myInformation";
@@ -21,6 +23,9 @@ export default function MyDetailInformations() {
       <MemorizedChangePhoneLink
         value={`${getFormattedPhoneNumber(myDetailInformation?.phoneNumber ?? "")}`}
       />
+      <ProfileItem variant="pushAlarm" className="w-full">
+        <PushPermissionSwitch />
+      </ProfileItem>
     </section>
   );
 }

--- a/apps/user/types/navigator.d.ts
+++ b/apps/user/types/navigator.d.ts
@@ -1,0 +1,4 @@
+// IOS Safari PWA 탐지를 위해 Navigator 인터페이스 확장
+declare interface Navigator {
+  standalone?: boolean;
+}

--- a/packages/ui/src/components/ProfileItem.tsx
+++ b/packages/ui/src/components/ProfileItem.tsx
@@ -3,13 +3,7 @@ import { ComponentProps } from "react";
 
 import { cn } from "@ui/lib/utils";
 
-const ProfileItemVariants: Record<
-  string,
-  {
-    icon: Icon;
-    content: string;
-  }
-> = {
+const ProfileItemVariants = {
   calendar: {
     icon: "CalendarMinus2",
     content: "휴무일 설정",
@@ -42,7 +36,17 @@ const ProfileItemVariants: Record<
     icon: "UserRoundX",
     content: "트레이너 연동 해제",
   },
-};
+  pushAlarm: {
+    icon: "Bell",
+    content: "푸시 알림 허용",
+  },
+} satisfies Record<
+  string,
+  {
+    icon: Icon;
+    content: string;
+  }
+>;
 
 type ProfileItemProps = ComponentProps<"div"> & {
   variant: keyof typeof ProfileItemVariants;

--- a/packages/ui/src/components/PushPermissionSwitch.tsx
+++ b/packages/ui/src/components/PushPermissionSwitch.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+
+import { getEnvironment } from "@ui/utils/getEnvironment";
+
+import { Button } from "./Button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "./Dialog";
+import { Switch } from "./Switch";
+
+function PushPermissionSwitch() {
+  const [isNotificationGranted, setIsNotificationGranted] = useState(false);
+  const [isDialopOpen, setIsDialogOpen] = useState(false);
+
+  const environmentRef = useRef<ReturnType<typeof getEnvironment>>("desktop-web");
+
+  useEffect(() => {
+    if (typeof Notification !== "undefined") {
+      setIsNotificationGranted(Notification.permission === "granted");
+    }
+    if (typeof navigator !== "undefined") {
+      environmentRef.current = getEnvironment();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isNotificationGranted) {
+      Notification.requestPermission().then((permission) => {
+        if (permission === "granted") {
+          setIsNotificationGranted(true);
+        } else {
+          setIsNotificationGranted(false);
+        }
+      });
+    }
+  }, [isNotificationGranted]);
+
+  const isMobilePwa = environmentRef.current === "mobile-pwa";
+
+  const handleToggle = (isNotificationGranted: boolean) => {
+    if (!isNotificationGranted) {
+      setIsDialogOpen(true);
+
+      return;
+    }
+    setIsNotificationGranted(isNotificationGranted);
+  };
+
+  const dialogDescription = `${isMobilePwa ? "앱 시스템 설정" : "브라우저 환경설정"}에서 [알림] 스위치를 꺼주세요`;
+
+  return (
+    <>
+      <Switch checked={isNotificationGranted} onCheckedChange={handleToggle} />
+      <Dialog open={isDialopOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>푸시 알림 해제 안내</DialogTitle>
+            <DialogDescription>{dialogDescription}</DialogDescription>
+          </DialogHeader>
+          <DialogClose asChild>
+            <Button size="lg" className="w-full">
+              확인
+            </Button>
+          </DialogClose>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+export default PushPermissionSwitch;

--- a/packages/ui/src/components/PushPermissionSwitch.tsx
+++ b/packages/ui/src/components/PushPermissionSwitch.tsx
@@ -17,7 +17,7 @@ import { Switch } from "./Switch";
 
 function PushPermissionSwitch() {
   const [isNotificationGranted, setIsNotificationGranted] = useState(false);
-  const [isDialopOpen, setIsDialogOpen] = useState(false);
+  const [isHelpDialopOpen, setIsHelpDialogOpen] = useState(false);
 
   const environmentRef = useRef<ReturnType<typeof getEnvironment>>("desktop-web");
 
@@ -45,24 +45,33 @@ function PushPermissionSwitch() {
   const isMobilePwa = environmentRef.current === "mobile-pwa";
 
   const handleToggle = (isNotificationGranted: boolean) => {
+    if (Notification.permission !== "default") {
+      setIsHelpDialogOpen(true);
+
+      return;
+    }
     if (!isNotificationGranted) {
-      setIsDialogOpen(true);
+      setIsHelpDialogOpen(true);
 
       return;
     }
     setIsNotificationGranted(isNotificationGranted);
   };
 
-  const dialogDescription = `${isMobilePwa ? "앱 시스템 설정" : "브라우저 환경설정"}에서 [알림] 스위치를 꺼주세요`;
+  const systemBasedDescription = `${isMobilePwa ? "앱 시스템 설정" : "브라우저 환경설정"}에서 [알림] 항목을 설정해주세요`;
 
   return (
     <>
       <Switch checked={isNotificationGranted} onCheckedChange={handleToggle} />
-      <Dialog open={isDialopOpen} onOpenChange={setIsDialogOpen}>
+      <Dialog open={isHelpDialopOpen} onOpenChange={setIsHelpDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>푸시 알림 해제 안내</DialogTitle>
-            <DialogDescription>{dialogDescription}</DialogDescription>
+            <DialogTitle>푸시 알림 재설정 안내</DialogTitle>
+            <DialogDescription>
+              푸시 알림을 다시 설정하려면
+              <br />
+              {systemBasedDescription}
+            </DialogDescription>
           </DialogHeader>
           <DialogClose asChild>
             <Button size="lg" className="w-full">

--- a/packages/ui/src/types/navigator.d.ts
+++ b/packages/ui/src/types/navigator.d.ts
@@ -1,0 +1,4 @@
+// IOS Safari PWA 탐지를 위해 Navigator 인터페이스 확장
+declare interface Navigator {
+  standalone?: boolean;
+}

--- a/packages/ui/src/utils/getEnvironment.ts
+++ b/packages/ui/src/utils/getEnvironment.ts
@@ -1,0 +1,13 @@
+export const getEnvironment = () => {
+  const ua = navigator.userAgent;
+
+  const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(ua);
+  const isStandalone =
+    window.matchMedia("(display-mode: standalone)").matches || window.navigator.standalone === true;
+
+  if (isStandalone && isMobile) return "mobile-pwa";
+  if (isStandalone) return "desktop-pwa";
+  if (isMobile) return "mobile-web";
+
+  return "desktop-web";
+};


### PR DESCRIPTION
# [FLIZ-370/root] feat: 마이페이지에 푸시 알림 허용 스위치 추가

## 📝 작업 내용

회원, 트레이너 서비스 마이페이지에 알림 설정 권한을 설정/해제 하는 기능을 추가했습니다
브라우저 알림 권한 설정은 Notification.requestPermission 함수로 진행하는데 Notification.permission === 'default' (설정하기 전 상태)에서만 정상적으로 실행됩니다. 한번 설정된 후에는 사용자가 직접 브라우저 또는 앱 시스템 환경 설정에서 권한을 수정해야 합니다. 해당 내용은 Notification.permission !== 'default' 인 상황에서 switch를 수정하려고 시도할 때 팝업으로 표시됩니다.

- 브라우저 내장 API인 Navigator과 Notification에 의존하기 때문에 별다른 처리 없이 로직을 설계할 시 서버 사이드에서 두 API에 접근을 시도하여 에러가 발생합니다. ( 'use client'는 "렌더링 시점"을 클라이언트로 보내지만, JS 코드 자체는 Node.js 서버에서 빌드/분석 시점에 실행될 수도 있습니다). 따라서 hydration이 정상적으로 이뤄지기 위해 브라우저 API 사용 부분은 default 값으로 초기에 설정하고, 컴포넌트 마운트 시 브라우저 API에 접근하도록 useEffect로 설계했습니다

- iOS에서 모바일 pwa를 판단할 때 window.navigator.standalone을 사용한다고 하여 Navigator 타입을 확장했습니다
- keyof typeof ProfileItemVariants 타입이 string인 불편함을 해결하기 위해 satisfies 를 활용하여 type을 수정했습니다
- ProfileItemVariants에 pushAlarm variant를 추가했습니다

브라우저 알림 권한 설정
### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
