### PR TITLE
[FLIZ-375/root] fix: 주민번호 Input이 채워진 경우 사용자가 input값을 핸들링하기 쉽도록 캐럿값 위치 조정

### DIFF
--- a/packages/ui/src/components/InputWithLabel/index.tsx
+++ b/packages/ui/src/components/InputWithLabel/index.tsx
@@ -1,4 +1,12 @@
-import { ChangeEvent, ComponentProps, forwardRef, ReactNode } from "react";
+import {
+  ChangeEvent,
+  ComponentProps,
+  forwardRef,
+  ReactNode,
+  useEffect,
+  useRef,
+  useCallback,
+} from "react";
 import { useState } from "react";
 
 import useInputWithLabelContext from "../../hooks/useInputWithLabelContext";
@@ -8,6 +16,8 @@ import InputWithLabelContext from "./context";
 
 const MAX_MASKED_LENGTH = 14;
 const MIN_MASKED_LENGTH = 0;
+
+const CARET_POSITION = 8;
 
 type InputWithLabelProps = ComponentProps<"div"> & {
   error?: boolean | string;
@@ -87,6 +97,7 @@ const ResidentNumberInput = forwardRef<HTMLInputElement, ResidentNumberInputProp
   ({ onChangeValue, ...props }, ref) => {
     const { id } = useInputWithLabelContext();
     const [idNumber, setIdNumber] = useState("");
+    const inputRef = useRef<HTMLInputElement | null>(null);
 
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value.replace(/[^0-9]/g, "");
@@ -98,15 +109,36 @@ const ResidentNumberInput = forwardRef<HTMLInputElement, ResidentNumberInputProp
       if (onChangeValue) onChangeValue(value);
     };
 
+    const setRef = (element: HTMLInputElement) => {
+      inputRef.current = element;
+      if (typeof ref === "function") {
+        ref(element);
+      } else if (ref && "current" in ref) {
+        ref.current = element;
+      }
+    };
+
+    const handleCaretOnInput = useCallback(() => {
+      if (inputRef.current && idNumber.length >= MAX_MASKED_LENGTH) {
+        inputRef.current.setSelectionRange(CARET_POSITION, CARET_POSITION);
+      }
+    }, [idNumber]);
+
+    useEffect(() => {
+      handleCaretOnInput();
+    }, [handleCaretOnInput]);
+
     return (
       <Input
         id={id}
-        ref={ref}
+        ref={setRef}
         type="text"
         placeholder="생년월일 - *******"
         maxLength={14}
         value={idNumber}
         onChange={handleChange}
+        onFocus={handleCaretOnInput}
+        onClick={handleCaretOnInput}
         className="text-title-1 h-fit w-full bg-transparent p-0 tracking-[0.625rem]"
         {...props}
       />


### PR DESCRIPTION
## 📝 작업 내용
사용자가 Register 과정의 주민번호 입력을 마친 후, 주민번호 수정을 위하여 input을 클릭했을 입력 수정을 위한 Caret의 위치가 자동적으로 14번째가 채워지는데, 이를 8번째 (주민번호 뒷자리 1번째)부터 수정할 수 있도록 Caret 위치를 자동적으로 조절하였습니다.

다른 정보 입력 시, callback 함수의 재할당을 막기 위하여 useCallback을 사용하여 해당 함수를 랩핑하였으며, 주민등록번호의 변경이 생길 때마다, 포커스 될 때마다 채워진 자릿 수를 확인하여 8번째로 caret이 이동할 수 있도록하여 수정에 편의를 두도록 하였습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
