### PR TITLE
[FLIZ-377/trainer] feat: 트레이너 도메인 고정 예약 변경 기능 구현

### DIFF
--- a/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/ReservationControlSheet.tsx
+++ b/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/ReservationControlSheet.tsx
@@ -69,6 +69,7 @@ function ReservationControlSheet({
     useState(false);
   const [isTerminateFixedReservationSheetOpen, setIsTerminateFixedReservationSheetOpen] =
     useState(false);
+  const [isFixedReservationChangePopupOpen, setIsFixedReservationChangePopupOpen] = useState(false);
 
   const { data: userInformationDetail, isLoading: userInformationDetailLoading } = useQuery({
     ...userManagementQueries.detail(memberId as number),
@@ -110,6 +111,21 @@ function ReservationControlSheet({
     terminateFixedReservation(reservationId);
   };
 
+  const handleClickChangeFixedReservation = () => {
+    const url = new URL(window.location.href);
+    url.searchParams.set(
+      "fixReservationChangeMode",
+      JSON.stringify({
+        reservationId: reservationId,
+        reservationDate: format(selectedDate, "yyyy-MM-dd'T'HH:mm"),
+      }),
+    );
+    window.history.pushState({}, "", url);
+
+    onChangeOpen(false);
+    setIsFixedReservationChangePopupOpen(true);
+  };
+
   useEffect(() => {
     if (reservationCancelSuccess) {
       setIsReservationCancelSuccessSheetOpen(true);
@@ -131,7 +147,16 @@ function ReservationControlSheet({
               </SheetDescription>
             </VisuallyHidden>
             <div className="flex items-center justify-center gap-2">
-              {reservationStatus && <Badge className="h-8 w-24">{reservationStatus}</Badge>}
+              {reservationStatus === "고정 예약" ? (
+                <Badge
+                  onClick={handleClickChangeFixedReservation}
+                  className="h-8 w-24 hover:cursor-pointer"
+                >
+                  {"고정 예약 변경"}
+                </Badge>
+              ) : (
+                <Badge className="h-8 w-24">{reservationStatus}</Badge>
+              )}
               {reservationStatus === "고정 예약" && (
                 <Badge
                   onClick={handleClickTerminateFixedReservationDialogOpen}
@@ -275,6 +300,25 @@ function ReservationControlSheet({
           </SheetFooter>
         </SheetContent>
       </Sheet>
+
+      <Dialog
+        open={isFixedReservationChangePopupOpen}
+        onOpenChange={setIsFixedReservationChangePopupOpen}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>고정 예약 변경 날짜 선택</DialogTitle>
+            <DialogDescription className="whitespace-pre-line text-center">
+              {`시간 블록을 선택하면 고정 예약이 변경됩니다\n변경을 원하지 않을 시에는 상단의\n[고정 예약 변경 비활성화] 버튼을 눌러\n변경을 취소할 수 있습니다`}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button className="w-full">확인</Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/apps/trainer/app/schedule-management/fixed-reservation/select-pt-times/_hooks/mutations/useFixReservationChangeMutation.ts
+++ b/apps/trainer/app/schedule-management/fixed-reservation/select-pt-times/_hooks/mutations/useFixReservationChangeMutation.ts
@@ -1,4 +1,6 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { reservationBaseKeys } from "@trainer/queries/reservation";
 
 import { editFixedReservation } from "@trainer/services/reservations";
 import {
@@ -10,6 +12,8 @@ type FixReservationChangeMutationProps = EditFixedReservationRequestPath &
   EditFixedReservationRequestBody;
 
 export const useFixReservationChangeMutation = () => {
+  const queryClient = useQueryClient();
+
   const { mutate, ...rest } = useMutation({
     mutationFn: ({
       reservationId,
@@ -20,6 +24,9 @@ export const useFixReservationChangeMutation = () => {
         requestPath: { reservationId },
         requestBody: { reservationDate, changeRequestDate },
       }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: reservationBaseKeys.lists() });
+    },
   });
 
   return { fixReservationChange: mutate, ...rest };

--- a/apps/trainer/app/schedule-management/page.tsx
+++ b/apps/trainer/app/schedule-management/page.tsx
@@ -5,7 +5,6 @@ import { ko } from "date-fns/locale";
 
 import { reservationQueries } from "@trainer/queries/reservation";
 
-import CalendarHintGroup from "@trainer/components/CalendarHintGroup";
 import LoadingFallback from "@trainer/components/Fallback/LoadingFallback";
 
 import Calendar from "./_components/Calendar";
@@ -22,9 +21,6 @@ async function ScheduleManagement() {
   return (
     <main className="flex h-full flex-col">
       <HydrationBoundary state={dehydratedState}>
-        <div className="py-[0.875rem]">
-          <CalendarHintGroup />
-        </div>
         <Suspense fallback={<LoadingFallback />}>
           <Calendar />
         </Suspense>


### PR DESCRIPTION
## 📝 작업 내용

#### 트레이너 도메인 고정 예약 변경 기능 구현
- 캘린더에서 고정 예약 타임 블록을 선택하여 고정 에약 변경 Mode가 활성화되고, 캘린더의 특정 타임 블록을 선택해 고정 에약 변경이 가능합니다.
- 고정 예약 변경 Mode가 되면 캘린더에 border가 나타나고, 상단에 "고정 예약 비활성화" 버튼이 나타나 해당 버튼을 클릭하면 변경 모드가 해제되고, 데스크탑에서는 esc 키를 입력하면 버튼 클릭과 동일한 기능을 할 수 있습니다.
- 아래 스크린샷과 플로우를 설정 한 이유는, 기존의 고정 예약 페이지를 재활용하기에는 날짜를 마음대로 설정할 수 없다는 리스크가 있었습니다.
   - 고정 예약 변경은 트레이너가 직접 설정하는 것으로 정책상 트레이너에게는 예약에 관련하여 날짜 기간에 대한 제한이 없습니다. 따라서 캘린더에서 직접 타임 블럭을 선택하여 변경하는 방식이 보다 자유롭게 고정 예약을 변경할 수 있도록 구현해주었습니다.
  - 추가로 고정 예약 변경 시 예약 현황 데이터 Query를 Invalidate 해주었습니다.

### 📷 스크린샷 (선택)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/bcb19a3a-1d65-4ce9-beb4-e2aa0482d346" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/82de975b-ec7e-493f-b2df-d105b7ed4faf" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/34153851-8a47-4adc-9ab9-c8188bbaa610" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/e5bd90ba-184c-406d-bc3e-f5bd7f30cc7c" />



## 💬 리뷰 요구사항(선택)