### PR TITLE
[FLIZ-379/root] feat: 트레이너 도메인 무한 스크롤 기능 구현

### DIFF
--- a/apps/trainer/app/member-management/[memberId]/_components/PtHistoryContainer/PtHistoryList.tsx
+++ b/apps/trainer/app/member-management/[memberId]/_components/PtHistoryContainer/PtHistoryList.tsx
@@ -14,7 +14,7 @@ import {
 } from "@ui/components/Sheet";
 import { VisuallyHidden } from "@ui/components/VisuallyHidden";
 import DateController from "@ui/lib/DateController";
-import React, { useRef, useState } from "react";
+import React, { forwardRef, useRef, useState } from "react";
 
 import { TargetMemberPtHistoryApiResponse } from "@trainer/services/types/userManagement.dto";
 
@@ -22,7 +22,7 @@ type PtHistoryListProps = {
   ptHistories?: TargetMemberPtHistoryApiResponse["data"]["content"];
 };
 
-function PtHistoryList({ ptHistories }: PtHistoryListProps) {
+const PtHistoryList = forwardRef<HTMLDivElement, PtHistoryListProps>(({ ptHistories }, ref) => {
   const [ptHistoryEditSheetOpen, setPtHistoryEditSheetOpen] = useState(false);
   const reservationFormatDateRef = useRef("");
 
@@ -46,6 +46,7 @@ function PtHistoryList({ ptHistories }: PtHistoryListProps) {
               onClick={() => handleClickPtHistoryEdit(status, date)}
             />
           ))}
+        <div ref={ref} />
       </section>
       <Sheet open={ptHistoryEditSheetOpen} onOpenChange={setPtHistoryEditSheetOpen}>
         <SheetHeader>
@@ -78,6 +79,5 @@ function PtHistoryList({ ptHistories }: PtHistoryListProps) {
       </Sheet>
     </>
   );
-}
-
+});
 export default PtHistoryList;

--- a/apps/trainer/app/schedule-management/_components/MemberListContainer/MemberCardList.tsx
+++ b/apps/trainer/app/schedule-management/_components/MemberListContainer/MemberCardList.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@ui/lib/utils";
-import React from "react";
+import React, { forwardRef } from "react";
 
 import { PtUser, PtUserListApiResponse } from "@trainer/services/types/userManagement.dto";
 
@@ -12,36 +12,35 @@ type MemberCardListProps = {
   onChangeSelectMemberInformation: (memberInformation: PtUser | null) => void;
 };
 
-function MemberCardList({
-  memberList,
-  selectedMemberInformation,
-  onChangeSelectMemberInformation,
-}: MemberCardListProps) {
-  const handleClickSelectMember = (selectedMemberId: number) => () => {
-    const selectedMember = memberList.find(({ memberId }) => memberId === selectedMemberId);
-    onChangeSelectMemberInformation(selectedMember ? selectedMember : null);
-  };
+const MemberCardList = forwardRef<HTMLDivElement, MemberCardListProps>(
+  ({ memberList, selectedMemberInformation, onChangeSelectMemberInformation }, ref) => {
+    const handleClickSelectMember = (selectedMemberId: number) => () => {
+      const selectedMember = memberList.find(({ memberId }) => memberId === selectedMemberId);
+      onChangeSelectMemberInformation(selectedMember ? selectedMember : null);
+    };
 
-  return (
-    <section className="flex h-full flex-col gap-[0.625rem] overflow-y-auto pt-[2.125rem] [&::-webkit-scrollbar]:hidden">
-      {memberList.map(({ memberId, name, birthDate, phoneNumber, profilePictureUrl }) => (
-        <MemberProfileCard
-          key={`${memberId}-${name}`}
-          memberId={memberId}
-          imgUrl={profilePictureUrl}
-          userBirth={new Date(birthDate)}
-          userName={name}
-          phoneNumber={phoneNumber}
-          className={cn(
-            selectedMemberInformation?.memberId === memberId && "border-brand-primary-500 border",
-          )}
-          onClick={handleClickSelectMember(memberId)}
-        >
-          <WorkoutSchedule memberId={memberId} />
-        </MemberProfileCard>
-      ))}
-    </section>
-  );
-}
+    return (
+      <section className="flex h-full flex-col gap-[0.625rem] overflow-y-auto pt-[2.125rem] [&::-webkit-scrollbar]:hidden">
+        {memberList.map(({ memberId, name, birthDate, phoneNumber, profilePictureUrl }) => (
+          <MemberProfileCard
+            key={`${memberId}-${name}`}
+            memberId={memberId}
+            imgUrl={profilePictureUrl}
+            userBirth={new Date(birthDate)}
+            userName={name}
+            phoneNumber={phoneNumber}
+            className={cn(
+              selectedMemberInformation?.memberId === memberId && "border-brand-primary-500 border",
+            )}
+            onClick={handleClickSelectMember(memberId)}
+          >
+            <WorkoutSchedule memberId={memberId} />
+          </MemberProfileCard>
+        ))}
+        <div ref={ref} />
+      </section>
+    );
+  },
+);
 
 export default MemberCardList;

--- a/apps/trainer/hooks/useIntersectionObserver.ts
+++ b/apps/trainer/hooks/useIntersectionObserver.ts
@@ -35,7 +35,7 @@ const useIntersectionObserver = ({
     return () => {
       observerRef.current?.disconnect();
     };
-  }, [target, options]);
+  }, [target, options, handleIntersect]);
 
   return observerRef;
 };

--- a/apps/trainer/queries/userManagement.ts
+++ b/apps/trainer/queries/userManagement.ts
@@ -47,7 +47,10 @@ export const userManagementQueries = {
     infiniteQueryOptions({
       queryKey: [...userManagementBaseKeys.info(memberId), status] as const,
       queryFn: ({ pageParam }) =>
-        getTargetMemberPtHistory({ status, page: pageParam, size: 10 }, { memberId }),
+        getTargetMemberPtHistory(
+          { status, page: pageParam, size: PT_HISTORY_PAGE_SIZE },
+          { memberId },
+        ),
       getNextPageParam: (lastPage, _allPages, lastPageParam) => {
         if (lastPage.data.content.length === EMPTY_PAGE) {
           return undefined;


### PR DESCRIPTION
## 📝 작업 내용

#### 트레이너 도메인 무한 스크롤 기능 구현
- 무한 스크롤 기능이 UI상 트레이너 도메인에만 존재하여 해당 도메인에만 기능을 구현하였습니다.
- intercationObserver의 useEffect 의존성 배열에 핸들러를 추가하여, 상위 핸들러가 재할당될때마다 콜백 함수가 재실행되도록 하여 무한 스크롤이 제대로 이루어지지 않는 이슈를 해결하였습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
