### PR TITLE
[FLIZ-381/style] style: PWA 배경색상 bg-background-primary 색상으로 변경

### DIFF
--- a/apps/trainer/public/manifest.json
+++ b/apps/trainer/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "theme_color": "#5a57ff",
+  "theme_color": "#1C1C1C",
   "background_color": "#d1d6ff",
   "icons": [
     {

--- a/apps/user/public/manifest.json
+++ b/apps/user/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "theme_color": "#5a57ff",
+  "theme_color": "#1C1C1C",
   "background_color": "#d1d6ff",
   "icons": [
     {


### PR DESCRIPTION
## 📝 작업 내용

#### PWA 배경색상 bg-background-primary 색상으로 변경
- 양쪽 도메인 PWA 색상을 bg-primary 색상으로 변경하여 모바일에서 스크롤을 해도 이질감이 느껴지지 않도록 수정하였습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)