### PR TITLE
[FLIZ-373/user] feat: 유저 도메인 캘린더에서 선택한 날짜가 예약 페이지로 그대로 전달되는 기능 추가

### DIFF
--- a/apps/user/app/schedule-management/_components/Calendar/index.tsx
+++ b/apps/user/app/schedule-management/_components/Calendar/index.tsx
@@ -1,9 +1,11 @@
+/* eslint-disable no-magic-numbers */
 "use client";
 
 import { BaseReservationListItem } from "@5unwan/core/api/types/common";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { DayPicker } from "@ui/components/DayPicker/index";
-import { format, startOfMonth } from "date-fns";
+import { addHours, format, startOfMonth } from "date-fns";
+import { useRouter, useSearchParams } from "next/navigation";
 import React, { useState } from "react";
 
 import { myInformationQueries } from "@user/queries/myInformation";
@@ -17,7 +19,14 @@ import ReservationStatusSheet from "../BottomSheet/ReservationStatusSheet";
 import ConnectionFallback from "../Fallback/ConnectionFallback";
 
 export default function Calendar() {
-  const [selectedDate, setSelectedDate] = useState<Date>();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(() => {
+    const dateParam = searchParams.get("date");
+
+    return dateParam ? new Date(dateParam) : undefined;
+  });
   const [month, setMonth] = useState(new Date());
   const [isReservationStatusSheetOpen, setIsReservationStatusSheetOpen] = useState(false);
   const [selectedReservationContent, setSelectedReservationContent] =
@@ -40,6 +49,16 @@ export default function Calendar() {
     return <ConnectionFallback />;
   }
 
+  const handleDateChange = (date: Date | undefined) => {
+    setSelectedDate(date);
+
+    if (date) {
+      const params = new URLSearchParams();
+      params.set("date", addHours(date, 9).toISOString());
+      router.push(`?${params.toString()}`);
+    }
+  };
+
   return (
     <>
       {reservations && (
@@ -53,7 +72,7 @@ export default function Calendar() {
             Row: (props) => (
               <WeekRow
                 selectedDate={selectedDate}
-                onChangeSelectedDate={setSelectedDate}
+                onChangeSelectedDate={handleDateChange}
                 reservationContent={filterLatestReservationsByDate(reservations.data)}
                 onSelectedReservationContent={setSelectedReservationContent}
                 onChangeOpen={setIsReservationStatusSheetOpen}

--- a/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/index.tsx
+++ b/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 
 import { RequestReservationMode } from "@user/app/schedule-management/reservation/[mode]/types/requestReservation";
@@ -20,7 +21,12 @@ function ReservationContainer({
   reservationDateTime,
   firstDayOfMonthKorea,
 }: ReservationContainerProps) {
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date(reservationDate || new Date()));
+  const searchParams = useSearchParams();
+  const dateParam = searchParams.get("selectedDate");
+
+  const [selectedDate, setSelectedDate] = useState<Date>(
+    reservationDate ? new Date(reservationDate) : new Date(dateParam || Date.now()),
+  );
 
   return (
     <section className="flex h-full w-full flex-col overflow-hidden">

--- a/apps/user/constants/routes.ts
+++ b/apps/user/constants/routes.ts
@@ -78,8 +78,9 @@ class ROUTES {
     return (
       routeParams?: string,
       searchParams?: {
-        reservationDate: string | null;
-        reservationId: string | null;
+        reservationDate?: string | null;
+        reservationId?: string | null;
+        selectedDate?: string | null;
       },
     ) => {
       const filteredRoute = this["_reservation"](routeParams).filter(filterEmptyDynamicRoute);


### PR DESCRIPTION
## 📝 작업 내용

#### 유저 도메인 캘린더에서 선택한 날짜가 예약 페이지로 그대로 전달되는 기능 추가
- 캘린더에서 선택한 날짜가 `예약 가능한 기간 정책(2주)`에 해당하면 예약 페이지에 선택한 날짜를 전달하여 캘린더에서 선택한 날짜가 예약 페이지에서도 `Focus` 되도록 기능을 구현하였습니다.
