### PR TITLE
[FLIZ-368/ui] fix: 안드로이드 환경에서 휴대폰 인증 메시지 전송 지원

### DIFF
--- a/apps/trainer/app/notification/_components/SessionSetterSheet.tsx
+++ b/apps/trainer/app/notification/_components/SessionSetterSheet.tsx
@@ -1,6 +1,9 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import BrandSpinner from "@ui/components/BrandSpinner";
 import { Button } from "@ui/components/Button";
 import {
   Sheet,
+  SheetClose,
   SheetContent,
   SheetDescription,
   SheetFooter,
@@ -8,20 +11,30 @@ import {
   SheetTitle,
 } from "@ui/components/Sheet";
 import Stepper from "@ui/components/Stepper";
-import { useState } from "react";
+import { Suspense, useState } from "react";
+
+import { userManagementQueries } from "@trainer/queries/userManagement";
+
+import QueryErrorBoundary from "@trainer/components/QueryErrorBoundary";
+
+import SheetErrorFallback from "./SheetRenderer/SheetErrorFallback";
 
 // eslint-disable-next-line no-magic-numbers
 const INCREMENT_OPTIONS = [5, 10, 20];
 const DEFAULT_SESSION = 0;
 
-type SessionSetterSheetProps = {
-  isOpen: boolean;
-  onOpenChange: (isOpen: boolean) => void;
+type SessionSetterSheetContentProps = {
   onSubmit: (totalCount: number, remainingCount: number) => void;
+  memberId: number;
 };
 
-function SessionSetterSheet({ isOpen, onOpenChange, onSubmit }: SessionSetterSheetProps) {
+function SessionSetterSheetContent({ onSubmit, memberId }: SessionSetterSheetContentProps) {
+  const { data } = useSuspenseQuery(userManagementQueries.detail(memberId));
+  const { sessionInfo } = data.data;
+
   const [sessionValue, setSessionValue] = useState(DEFAULT_SESSION);
+
+  const hasPreviousSession = sessionInfo?.remainingCount || sessionInfo?.totalCount;
 
   const handleSessionAdderHintClick = (value: number) => () => {
     setSessionValue((prev) => prev + value);
@@ -31,35 +44,73 @@ function SessionSetterSheet({ isOpen, onOpenChange, onSubmit }: SessionSetterShe
     onSubmit(sessionValue, sessionValue);
   };
 
+  if (hasPreviousSession)
+    return (
+      <>
+        <SheetHeader className="items-center">
+          <SheetTitle>잔여 세션이 발견되었습니다</SheetTitle>
+          <SheetDescription>
+            이전 연동에서 추가된 세션 정보가 그대로 사용됩니다.
+            <br />
+            [회원관리] 탭에서 회원의 세션을 다시 설정하실 수 있습니다
+          </SheetDescription>
+        </SheetHeader>
+        <SheetFooter className="w-full">
+          <SheetClose asChild>
+            <Button className="w-full">확인</Button>
+          </SheetClose>
+        </SheetFooter>
+      </>
+    );
+
+  return (
+    <>
+      <SheetHeader className="items-center">
+        <SheetTitle>PT 횟수 입력</SheetTitle>
+        <SheetDescription>회원님의 PT 횟수를 입력하여 연동을 승인해주세요</SheetDescription>
+      </SheetHeader>
+      <div className="mb-[1.25rem] flex gap-2.5">
+        {INCREMENT_OPTIONS &&
+          INCREMENT_OPTIONS.map((value) => (
+            <Button
+              key={`increment-${value}`}
+              variant="negative"
+              className="text-headline h-[2rem] w-[4.875rem] rounded-full"
+              onClick={handleSessionAdderHintClick(value)}
+            >
+              +{value}회
+            </Button>
+          ))}
+      </div>
+      <Stepper value={sessionValue} onChangeValue={setSessionValue} className="border-none" />
+      <SheetFooter className="w-full">
+        <Button onClick={handleSubmit} className="w-full">
+          승인
+        </Button>
+      </SheetFooter>
+    </>
+  );
+}
+
+type SessionSetterSheetProps = {
+  memberId: number;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onSubmit: (totalCount: number, remainingCount: number) => void;
+};
+
+function SessionSetterSheet({ memberId, isOpen, onOpenChange, onSubmit }: SessionSetterSheetProps) {
   return (
     <Sheet open={isOpen} onOpenChange={onOpenChange}>
       <SheetContent
         side="bottom"
         className="md:w-mobile flex h-fit flex-col items-center md:inset-x-[calc((100%-480px)/2)]"
       >
-        <SheetHeader className="items-center">
-          <SheetTitle>PT 횟수 입력</SheetTitle>
-          <SheetDescription>회원님의 PT 횟수를 입력하여 연동을 승인해주세요</SheetDescription>
-        </SheetHeader>
-        <div className="mb-[1.25rem] flex gap-2.5">
-          {INCREMENT_OPTIONS &&
-            INCREMENT_OPTIONS.map((value) => (
-              <Button
-                key={`increment-${value}`}
-                variant="negative"
-                className="text-headline h-[2rem] w-[4.875rem] rounded-full"
-                onClick={handleSessionAdderHintClick(value)}
-              >
-                +{value}회
-              </Button>
-            ))}
-        </div>
-        <Stepper value={sessionValue} onChangeValue={setSessionValue} className="border-none" />
-        <SheetFooter className="w-full">
-          <Button onClick={handleSubmit} className="w-full">
-            승인
-          </Button>
-        </SheetFooter>
+        <QueryErrorBoundary fallback={SheetErrorFallback}>
+          <Suspense fallback={<BrandSpinner />}>
+            <SessionSetterSheetContent onSubmit={onSubmit} memberId={memberId} />
+          </Suspense>
+        </QueryErrorBoundary>
       </SheetContent>
     </Sheet>
   );

--- a/apps/trainer/app/notification/_components/SheetRenderer/ConnectTrainerSheet.tsx
+++ b/apps/trainer/app/notification/_components/SheetRenderer/ConnectTrainerSheet.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import BrandSpinner from "@ui/components/BrandSpinner";
 import { Button } from "@ui/components/Button";
 import Icon from "@ui/components/Icon";
 import {
@@ -103,6 +104,9 @@ function ConnectTrainerSheet({ notificationId, open, onChangeOpen }: ConnectTrai
   });
   const setSessionMutation = useMutation({
     mutationFn: sessionCountEdit,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationBaseKeys.lists() });
+    },
   });
 
   const [isDeclineSheetOpen, setIsDeclineSheetOpen] = useState(false);
@@ -117,7 +121,12 @@ function ConnectTrainerSheet({ notificationId, open, onChangeOpen }: ConnectTrai
     });
   };
   const handleAcceptClick = () => {
-    setIsAcceptActionSheetOpen(true);
+    processConnectionMutation.mutate(true, {
+      onSuccess: () => {
+        setIsAcceptSheetOpen(true);
+      },
+    });
+    // setIsAcceptActionSheetOpen(true);
   };
   const handleSubmit = (totalCount: number, remainingCount: number) => {
     processConnectionMutation.mutate(true, {
@@ -141,6 +150,9 @@ function ConnectTrainerSheet({ notificationId, open, onChangeOpen }: ConnectTrai
         );
       },
     });
+  };
+  const handleSessionSetterClick = () => {
+    setIsAcceptActionSheetOpen(true);
   };
 
   return (
@@ -180,11 +192,7 @@ function ConnectTrainerSheet({ notificationId, open, onChangeOpen }: ConnectTrai
           </SheetFooter>
         </SheetContent>
       </Sheet>
-      <SessionSetterSheet
-        isOpen={isAcceptActionSheetOpen}
-        onOpenChange={setIsAcceptActionSheetOpen}
-        onSubmit={handleSubmit}
-      />
+
       <Sheet open={isAcceptSheetOpen} onOpenChange={setIsAcceptSheetOpen}>
         <SheetContent side={"bottom"} className="md:w-mobile md:inset-x-[calc((100%-480px)/2)]">
           <SheetHeader className="items-center">
@@ -192,17 +200,49 @@ function ConnectTrainerSheet({ notificationId, open, onChangeOpen }: ConnectTrai
               <Icon name="Check" size="lg" />
             </Button>
             <SheetTitle className="text-center">연동 요청이 승인되었습니다</SheetTitle>
-            <VisuallyHidden>
-              <SheetDescription>
-                이 시트에서는 연동 요청의 승인 처리가 완료되었음을 알려줍니다.
-              </SheetDescription>
-            </VisuallyHidden>
+            <SheetDescription>연동된 회원의 세션(PT 횟수)을 설정해주세요</SheetDescription>
+          </SheetHeader>
+          <SheetFooter>
+            <Button size={"xl"} className="w-full" onClick={handleSessionSetterClick}>
+              회원 세션 설정하기
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+
+      {processConnectionMutation.data?.data.memberId && (
+        <SessionSetterSheet
+          memberId={processConnectionMutation.data?.data.memberId}
+          isOpen={isAcceptActionSheetOpen}
+          onOpenChange={setIsAcceptActionSheetOpen}
+          onSubmit={handleSubmit}
+        />
+      )}
+
+      <Sheet open={processConnectionMutation.status === "pending"}>
+        <SheetContent side={"bottom"} className="md:w-mobile md:inset-x-[calc((100%-480px)/2)]">
+          <SheetHeader>
+            <SheetTitle>연동 승인 여부를 처리 중입니다</SheetTitle>
+            <SheetDescription>잠시만 기다려주세요</SheetDescription>
+          </SheetHeader>
+          <div className="flex items-center justify-center">
+            <BrandSpinner />
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={processConnectionMutation.status === "success"}>
+        <SheetContent side={"bottom"} className="md:w-mobile md:inset-x-[calc((100%-480px)/2)]">
+          <SheetHeader>
+            <Button className="mb-7 h-[3.125rem] w-[3.125rem] rounded-full">
+              <Icon name="Check" size="lg" />
+            </Button>
+            <SheetTitle>회원의 세션이 설정되었습니다</SheetTitle>
+            <SheetDescription></SheetDescription>
           </SheetHeader>
           <SheetFooter>
             <SheetClose asChild>
-              <Button size={"xl"} className="w-full">
-                확인
-              </Button>
+              <Button className="w-full">확인</Button>
             </SheetClose>
           </SheetFooter>
         </SheetContent>

--- a/apps/trainer/components/MutationStatusSheet.tsx
+++ b/apps/trainer/components/MutationStatusSheet.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import BrandSpinner from "@ui/components/BrandSpinner";
+import { Button } from "@ui/components/Button";
+import Icon from "@ui/components/Icon";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@ui/components/Sheet";
+import { VisuallyHidden } from "@ui/components/VisuallyHidden";
+
+type MutationStatusSheetProps = {
+  status: "pending" | "error" | "success" | "idle";
+};
+
+function MutationStatusSheet({ status }: MutationStatusSheetProps) {
+  return (
+    <>
+      <Sheet open={status === "pending"}>
+        <SheetContent side={"bottom"} className="md:w-mobile md:inset-x-[calc((100%-480px)/2)]">
+          <SheetHeader>
+            <SheetTitle>요청 중입니다</SheetTitle>
+            <SheetDescription>잠시만 기다려주세요</SheetDescription>
+          </SheetHeader>
+          <div className="flex items-center justify-center">
+            <BrandSpinner />
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={status === "success"}>
+        <SheetContent side={"bottom"} className="md:w-mobile md:inset-x-[calc((100%-480px)/2)]">
+          <SheetHeader>
+            <Button className="mb-7 h-[3.125rem] w-[3.125rem] rounded-full">
+              <Icon name="Check" size="lg" />
+            </Button>
+            <SheetTitle>요청이 완료되었습니다</SheetTitle>
+            <VisuallyHidden>
+              <SheetDescription>요청이 완료되었음을 알려주는 시트입니다</SheetDescription>
+            </VisuallyHidden>
+          </SheetHeader>
+          <SheetFooter>
+            <SheetClose asChild>
+              <Button className="w-full">확인</Button>
+            </SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}
+
+export default MutationStatusSheet;

--- a/packages/ui/src/components/PhoneVerification/PhoneVerificationGuide.tsx
+++ b/packages/ui/src/components/PhoneVerification/PhoneVerificationGuide.tsx
@@ -12,7 +12,10 @@ export default function PhoneVerificationGuide() {
         </p>
       </div>
 
-      <p>③ 인증 메시지를 그대로 보내주세요.</p>
+      <p>
+        ③ 인증 메시지를 그대로{" "}
+        <span className="text-brand-primary-300">verification@fitlink.biz</span>로 보내주세요.
+      </p>
     </div>
   );
 }

--- a/packages/ui/src/components/PhoneVerification/PhoneVerificationGuide.tsx
+++ b/packages/ui/src/components/PhoneVerification/PhoneVerificationGuide.tsx
@@ -4,7 +4,14 @@ export default function PhoneVerificationGuide() {
   return (
     <div className="text-body-1 mt-[1.875rem] flex w-full flex-col gap-[1.875rem]  px-[1.875rem]">
       <p>① 하단 [인증 메시지 보내기] 눌러주세요.</p>
-      <p>② 메시지 작성 창에서 인증 메시지가 자동으로 입력되어 있어요.</p>
+      <div className="gap-1">
+        <p>② 메시지 작성 창에서 인증 메시지가 자동으로 입력되어 있어요.</p>
+        <p className="text-body-3 text-text-sub2">
+          * <span className="text-brand-primary-300">안드로이드 기기</span> 인 경우, 인증 메시지를{" "}
+          <span className="text-brand-primary-300">클립보드에 복사하여 메신저로 이동</span>합니다.
+        </p>
+      </div>
+
       <p>③ 인증 메시지를 그대로 보내주세요.</p>
     </div>
   );

--- a/packages/ui/src/components/PhoneVerification/PhoneVerificationImage.tsx
+++ b/packages/ui/src/components/PhoneVerification/PhoneVerificationImage.tsx
@@ -1,5 +1,15 @@
 import verifyPhone from "@ui/assets/verify-phone.avif";
 
 export default function PhoneVerificationImage() {
-  return <img className="mt-[2.5rem] px-[0.125rem]" src={verifyPhone.src} alt="verify-phone" />;
+  return (
+    <div className="flex items-center justify-center">
+      <img
+        className="mt-[2.5rem] px-[0.125rem]"
+        src={verifyPhone.src}
+        alt="verify-phone"
+        width="280px"
+        height="auto"
+      />
+    </div>
+  );
 }

--- a/packages/ui/src/components/PhoneVerification/PhoneVerificationNotice.tsx
+++ b/packages/ui/src/components/PhoneVerification/PhoneVerificationNotice.tsx
@@ -1,6 +1,6 @@
 export default function PhoneVerificationNotice() {
   return (
-    <div className="text-body-2 text-text-sub2 mt-[2.5rem] w-full text-center">
+    <div className="text-body-2 text-text-sub2 mt-4 w-full text-center">
       <p>이용 중인 통신 요금제에 따라 문자 메시지 발송 비용이</p>
       <p>청구될 수 있어요.</p>
     </div>

--- a/packages/ui/src/components/PhoneVerification/VerificationInfoDialog.tsx
+++ b/packages/ui/src/components/PhoneVerification/VerificationInfoDialog.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Check, Clipboard } from "lucide-react";
+import { useState } from "react";
+
+import { copyToClipboard } from "@ui/utils/copyToClipboard";
+
+import { Button } from "../Button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "../Dialog";
+
+const formatToHTML = (message: string) => {
+  const [header, content] = message.split("\n");
+
+  return (
+    <>
+      {header}
+      <br />
+      {content}
+    </>
+  );
+};
+
+const createClipboardClickHandler =
+  (content: string, setIsCopied: (copied: boolean) => void) => async () => {
+    const copySuccessful = await copyToClipboard(content);
+
+    if (copySuccessful) setIsCopied(true);
+  };
+
+type VerificationInfoDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  verificationMessage: string;
+};
+
+const ANIMATION_DURATION = 100;
+const VERIFICATION_EMAIL = "verification@fitlink.biz";
+
+function VerificationInfoDialog({
+  open,
+  onOpenChange,
+  verificationMessage,
+}: VerificationInfoDialogProps) {
+  const [isContactCopied, setIsContactCopied] = useState(false);
+  const [isContentCopied, setIsContentCopied] = useState(false);
+
+  const handleOpenChange = (open: boolean) => {
+    onOpenChange(open);
+    // Dialog 닫힘 animation이 끝날 때까지 상태변화를 미룹니다
+    setTimeout(() => setIsContactCopied(false), ANIMATION_DURATION);
+    setTimeout(() => setIsContentCopied(false), ANIMATION_DURATION);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>인증 메시지 확인</DialogTitle>
+          <DialogDescription className="text-center">
+            <span className="text-brand-primary-300">문자</span>로{" "}
+            <span className="text-brand-primary-300 ">{VERIFICATION_EMAIL}</span> 에게 인증 메시지를
+            전송해주세요
+          </DialogDescription>
+        </DialogHeader>
+        <label className="mt-4">
+          <span className="text-body-2">받는 사람</span>
+          <div className="bg-background-sub3 flex items-center justify-between rounded-lg p-2 pl-4">
+            <p>{VERIFICATION_EMAIL}</p>
+            <Button
+              variant={"outline"}
+              className="h-10 w-10"
+              onClick={createClipboardClickHandler(VERIFICATION_EMAIL, setIsContactCopied)}
+            >
+              {!isContactCopied ? <Clipboard /> : <Check />}
+            </Button>
+          </div>
+        </label>
+
+        <label className="mt-4">
+          <span className="text-body-2">인증 메시지</span>
+          <div className="bg-background-sub3 flex items-center justify-between rounded-lg p-2 pl-4">
+            <p>{formatToHTML(verificationMessage)}</p>
+            <Button
+              variant={"outline"}
+              className="h-10 w-10"
+              onClick={createClipboardClickHandler(verificationMessage, setIsContentCopied)}
+            >
+              {!isContentCopied ? <Clipboard /> : <Check />}
+            </Button>
+          </div>
+        </label>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default VerificationInfoDialog;

--- a/packages/ui/src/components/PhoneVerification/index.tsx
+++ b/packages/ui/src/components/PhoneVerification/index.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { DialogTitle } from "@mui/material";
-import { DialogDescription } from "@radix-ui/react-dialog";
-import { Check, Clipboard } from "lucide-react";
 import { useRef, useState } from "react";
+
+import { copyToClipboard } from "@ui/utils/copyToClipboard";
 
 import { Button } from "../Button";
 import PhoneVerificationGuide from "./PhoneVerificationGuide";
 import PhoneVerificationImage from "./PhoneVerificationImage";
 import PhoneVerificationNotice from "./PhoneVerificationNotice";
-import { Dialog, DialogContent, DialogHeader } from "../Dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "../Dialog";
 import QRCodeGenerator from "../QRCodeGenerator";
 import { Text } from "../Text";
+import VerificationInfoDialog from "./VerificationInfoDialog";
 
 type PhoneVerificationProps = {
   onClick: () => void;
@@ -41,36 +41,11 @@ const isAndroidCheck = () => {
 const generateSnsBody = (type: "link" | "clipboard", token?: string) => {
   return `[Fitlink]${type === "clipboard" ? "\n" : "%0A"}${token}`;
 };
-const formatToHTML = (message: string) => {
-  const [header, content] = message.split("\n");
-
-  return (
-    <>
-      {header}
-      <br />
-      {content}
-    </>
-  );
-};
-const copyToClipboard = async (text: string) => {
-  if (typeof navigator === "undefined") return false;
-
-  try {
-    await navigator.clipboard.writeText(text);
-
-    return true;
-  } catch {
-    alert("클립보드 복사에 실패했습니다. 수동으로 복사해주세요.");
-
-    return false;
-  }
-};
 
 function PhoneVerification({ onClick, verificationToken }: PhoneVerificationProps) {
   const linkRef = useRef<HTMLAnchorElement>(null);
   const [isQrCodeDialogOpen, setIsQrCodeDialogOpen] = useState(false);
-  const [isMessageDialogOpen, setIsMessageDialogOpen] = useState(false);
-  const [isCopied, setIsCopied] = useState(false);
+  const [isVerificationInfoDialogOpen, setIsVerificationInfoDialogOpen] = useState(false);
 
   const handleAndroidClick = async (token: string) => {
     const isCopied = await copyToClipboard(generateSnsBody("clipboard", token));
@@ -110,7 +85,7 @@ function PhoneVerification({ onClick, verificationToken }: PhoneVerificationProp
           iconLeft="CircleHelp"
           className="shink-0 min-h-[2.5rem]"
           onClick={() => {
-            setIsMessageDialogOpen(true);
+            setIsVerificationInfoDialogOpen(true);
           }}
         >
           인증 메시지 확인하기
@@ -159,42 +134,11 @@ function PhoneVerification({ onClick, verificationToken }: PhoneVerificationProp
           </div>
         </DialogContent>
       </Dialog>
-      <Dialog
-        open={isMessageDialogOpen}
-        onOpenChange={(open) => {
-          setIsMessageDialogOpen(open);
-          setIsCopied(false);
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>인증 메시지 확인</DialogTitle>
-            <DialogDescription className="text-center">
-              <span className="text-brand-primary-300">문자</span>로{" "}
-              <span className="text-brand-primary-300 ">verification@fitlink.biz</span> 에게 인증
-              메시지를 전송해주세요
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="bg-background-sub3 mt-8 flex items-center justify-between rounded-lg p-2 pl-4">
-            <p>{formatToHTML(generateSnsBody("clipboard", verificationToken))}</p>
-            <Button
-              variant={"outline"}
-              className="h-10 w-10"
-              onClick={async () => {
-                if (isCopied) return;
-                const copySuccessful = await copyToClipboard(
-                  generateSnsBody("clipboard", verificationToken),
-                );
-
-                if (copySuccessful) setIsCopied(true);
-              }}
-            >
-              {!isCopied ? <Clipboard /> : <Check />}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <VerificationInfoDialog
+        open={isVerificationInfoDialogOpen}
+        onOpenChange={setIsVerificationInfoDialogOpen}
+        verificationMessage={generateSnsBody("clipboard", verificationToken)}
+      />
     </main>
   );
 }

--- a/packages/ui/src/components/PhoneVerification/index.tsx
+++ b/packages/ui/src/components/PhoneVerification/index.tsx
@@ -1,12 +1,15 @@
 "use client";
 
+import { DialogTitle } from "@mui/material";
+import { DialogDescription } from "@radix-ui/react-dialog";
+import { Check, Clipboard } from "lucide-react";
 import { useRef, useState } from "react";
 
 import { Button } from "../Button";
 import PhoneVerificationGuide from "./PhoneVerificationGuide";
 import PhoneVerificationImage from "./PhoneVerificationImage";
 import PhoneVerificationNotice from "./PhoneVerificationNotice";
-import { Dialog, DialogContent } from "../Dialog";
+import { Dialog, DialogContent, DialogHeader } from "../Dialog";
 import QRCodeGenerator from "../QRCodeGenerator";
 import { Text } from "../Text";
 
@@ -15,12 +18,66 @@ type PhoneVerificationProps = {
   verificationToken?: string;
 };
 
-const generateSnsBody = (token?: string) => {
-  return `[Fitlink]%0A${token}`;
+/** TODO: Utils로 추후 분리 */
+const isDesktopCheck = () => {
+  if (typeof navigator !== "undefined") {
+    const userAgent = navigator.userAgent.toLowerCase();
+
+    const isMobile = /mobile|android|iphone|ipad|phone/i.test(userAgent);
+
+    return !isMobile;
+  }
 };
+const isAndroidCheck = () => {
+  if (typeof navigator !== "undefined") {
+    const userAgent = navigator.userAgent.toLowerCase();
+
+    const isAndroid = /android/i.test(userAgent);
+
+    return isAndroid;
+  }
+};
+
+const generateSnsBody = (type: "link" | "clipboard", token?: string) => {
+  return `[Fitlink]${type === "clipboard" ? "\n" : "%0A"}${token}`;
+};
+const formatToHTML = (message: string) => {
+  const [header, content] = message.split("\n");
+
+  return (
+    <>
+      {header}
+      <br />
+      {content}
+    </>
+  );
+};
+const copyToClipboard = async (text: string) => {
+  if (typeof navigator === "undefined") return false;
+
+  try {
+    await navigator.clipboard.writeText(text);
+
+    return true;
+  } catch {
+    alert("클립보드 복사에 실패했습니다. 수동으로 복사해주세요.");
+
+    return false;
+  }
+};
+
 function PhoneVerification({ onClick, verificationToken }: PhoneVerificationProps) {
   const linkRef = useRef<HTMLAnchorElement>(null);
   const [isQrCodeDialogOpen, setIsQrCodeDialogOpen] = useState(false);
+  const [isMessageDialogOpen, setIsMessageDialogOpen] = useState(false);
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleAndroidClick = async (token: string) => {
+    const isCopied = await copyToClipboard(generateSnsBody("clipboard", token));
+    if (!isCopied) return;
+
+    window.location.href = `sms:`;
+  };
 
   const handleButtonClick = () => {
     onClick();
@@ -31,56 +88,110 @@ function PhoneVerification({ onClick, verificationToken }: PhoneVerificationProp
       return;
     }
 
-    linkRef.current?.click();
-  };
-
-  /** TODO: Utils로 추후 분리 */
-  const isDesktopCheck = () => {
-    if (typeof navigator !== "undefined") {
-      const userAgent = navigator.userAgent.toLowerCase();
-
-      const isMobile = /mobile|android|iphone|ipad|phone/i.test(userAgent);
-
-      return !isMobile;
-    }
+    if (isAndroidCheck()) {
+      if (verificationToken) {
+        handleAndroidClick(verificationToken);
+      }
+    } else linkRef.current?.click();
   };
 
   return (
     <main className="flex h-full w-full flex-col items-center">
-      <section className="flex-1">
+      <section className="mb-4">
         <PhoneVerificationGuide />
         <PhoneVerificationImage />
         <PhoneVerificationNotice />
       </section>
-      <Button
-        size="xl"
-        className="text-headline shirink-0 min-h-[3.375rem] w-full"
-        onClick={handleButtonClick}
-        disabled={!verificationToken}
-      >
-        인증 메시지 보내기
-      </Button>
+      <div className="flex w-full flex-col items-center gap-4">
+        <Button
+          size="md"
+          corners={"pill"}
+          variant={"negative"}
+          iconLeft="CircleHelp"
+          className="shink-0 min-h-[2.5rem]"
+          onClick={() => {
+            setIsMessageDialogOpen(true);
+          }}
+        >
+          인증 메시지 확인하기
+        </Button>
+        <Button
+          size="xl"
+          className="text-headline shirink-0 min-h-[3.375rem] w-full"
+          onClick={handleButtonClick}
+          disabled={!verificationToken}
+        >
+          인증 메시지 보내기
+        </Button>
+      </div>
+
       <a
         ref={linkRef}
-        href={`sms:verification@fitlink.biz&body=${generateSnsBody(verificationToken)}`}
+        href={`sms:verification@fitlink.biz&body=${generateSnsBody("link", verificationToken)}`}
         className="hidden"
         aria-label="verification-link"
       />
       <Dialog open={isQrCodeDialogOpen} onOpenChange={setIsQrCodeDialogOpen}>
         <DialogContent className="p-10">
-          <div className="flex items-center justify-center gap-20">
-            <div className="flex flex-col items-center justify-center gap-4">
+          <DialogHeader>
+            <DialogTitle>인증 메세지 전송</DialogTitle>
+            <DialogDescription>
+              모바일 기기로 QR 코드를 스캔하여 인증 메세지를 전송해주세요
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-10 flex items-center justify-center gap-20">
+            <div className="bg-background-sub4 flex flex-col items-center justify-center gap-4 rounded-3xl  p-4 pt-1">
               <Text.Subhead1 className="font-bold">Android</Text.Subhead1>
-              <QRCodeGenerator
-                value={`sms:${encodeURIComponent("verification@fitlink.biz")}?body=${encodeURIComponent(generateSnsBody(verificationToken))}`}
-              />
+              <div className="rounded-lg bg-white p-4">
+                <QRCodeGenerator
+                  value={`sms:${encodeURIComponent("verification@fitlink.biz")}?body=${encodeURIComponent(generateSnsBody("link", verificationToken))}`}
+                />
+              </div>
             </div>
-            <div className="flex flex-col items-center justify-center gap-4">
+            <div className="bg-background-sub4 flex flex-col items-center justify-center gap-4 rounded-3xl  p-4 pt-1">
               <Text.Subhead1 className="font-bold">IOS</Text.Subhead1>
-              <QRCodeGenerator
-                value={`sms:verification@fitlink.biz&body=${generateSnsBody(verificationToken)}`}
-              />
+              <div className="rounded-lg bg-white p-4">
+                <QRCodeGenerator
+                  value={`sms:verification@fitlink.biz&body=${generateSnsBody("link", verificationToken)}`}
+                />
+              </div>
             </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={isMessageDialogOpen}
+        onOpenChange={(open) => {
+          setIsMessageDialogOpen(open);
+          setIsCopied(false);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>인증 메시지 확인</DialogTitle>
+            <DialogDescription className="text-center">
+              <span className="text-brand-primary-300">문자</span>로{" "}
+              <span className="text-brand-primary-300 ">verification@fitlink.biz</span> 에게 인증
+              메시지를 전송해주세요
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="bg-background-sub3 mt-8 flex items-center justify-between rounded-lg p-2 pl-4">
+            <p>{formatToHTML(generateSnsBody("clipboard", verificationToken))}</p>
+            <Button
+              variant={"outline"}
+              className="h-10 w-10"
+              onClick={async () => {
+                if (isCopied) return;
+                const copySuccessful = await copyToClipboard(
+                  generateSnsBody("clipboard", verificationToken),
+                );
+
+                if (copySuccessful) setIsCopied(true);
+              }}
+            >
+              {!isCopied ? <Clipboard /> : <Check />}
+            </Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/packages/ui/src/utils/copyToClipboard.ts
+++ b/packages/ui/src/utils/copyToClipboard.ts
@@ -1,0 +1,13 @@
+export const copyToClipboard = async (text: string) => {
+  if (typeof navigator === "undefined") return false;
+
+  try {
+    await navigator.clipboard.writeText(text);
+
+    return true;
+  } catch {
+    alert("클립보드 복사에 실패했습니다. 수동으로 복사해주세요.");
+
+    return false;
+  }
+};


### PR DESCRIPTION
# [FLIZ-368/ui] fix: 안드로이드 환경에서 휴대폰 인증 메시지 전송 지원

## 📝 작업 내용

안드로이드 환경에서 회원가입/휴대폰 인증 단계를 진행 할 때, 기기의 메신저 앱에 자동으로 주소 및 메시지 내용이 입력되는 기능이 지원되지 않는 버그가 존재했습니다.
해당 버그의 이유는 안드로이드 환경에서 sms:URI를 클릭하면 먼저 브라우저가 URL을 검증하기 때문입니다. 안드로이드 검증 기준이 IOS보다 엄격하며 주소로 전화번호만 허용합니다.

메일로 인증 메시지를 전달해야 하는 서비스 상황 상, 자동으로 메시지 주소 및 내용을 입력해주는 기능은 안드로이드에서 지원할 수 없으며, 대안으로 인증 메시지를 클립보드에 복사한 뒤, 메신저 앱을 실행하도록 구현했습니다

추가로 클립보드가 지원이 안 될 경우, 사용자가 수동으로 인증 메시지를 복사할 수 있도록 [인증 메시지 확인] 버튼을 만들었습니다. 해당 버튼 클릭 시, 인증 메시지 내용이 있는 Dialog가 나타납니다
### 📷 스크린샷 (선택)

<img width="488" alt="스크린샷 2025-06-19 오후 6 43 48" src="https://github.com/user-attachments/assets/ed638507-fd64-44a8-b24a-0cc10f5019df" />

<img width="488" alt="스크린샷 2025-06-20 오후 2 54 41" src="https://github.com/user-attachments/assets/24272249-b82a-4e46-8220-39279c1af024" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
