### PR TITLE
[FLIZ-391/ui] fix: 안드로이드 환경 PhoneVerification 버그 fix

### DIFF
--- a/packages/ui/src/components/PhoneVerification/index.tsx
+++ b/packages/ui/src/components/PhoneVerification/index.tsx
@@ -2,8 +2,6 @@
 
 import { useRef, useState } from "react";
 
-import { copyToClipboard } from "@ui/utils/copyToClipboard";
-
 import { Button } from "../Button";
 import PhoneVerificationGuide from "./PhoneVerificationGuide";
 import PhoneVerificationImage from "./PhoneVerificationImage";
@@ -47,10 +45,7 @@ function PhoneVerification({ onClick, verificationToken }: PhoneVerificationProp
   const [isQrCodeDialogOpen, setIsQrCodeDialogOpen] = useState(false);
   const [isVerificationInfoDialogOpen, setIsVerificationInfoDialogOpen] = useState(false);
 
-  const handleAndroidClick = async (token: string) => {
-    const isCopied = await copyToClipboard(generateSnsBody("clipboard", token));
-    if (!isCopied) return;
-
+  const handleAndroidClick = async () => {
     window.location.href = `sms:`;
   };
 
@@ -64,9 +59,7 @@ function PhoneVerification({ onClick, verificationToken }: PhoneVerificationProp
     }
 
     if (isAndroidCheck()) {
-      if (verificationToken) {
-        handleAndroidClick(verificationToken);
-      }
+      handleAndroidClick();
     } else linkRef.current?.click();
   };
 


### PR DESCRIPTION
# [FLIZ-391/ui] fix: 안드로이드 환경 PhoneVerification 버그 fix

## 📝 작업 내용

안드로이드 환경에서 PhoneVerification 단계 action 버튼 클릭 시 메시지 content를 복사하고 메신저 앱으로 전환했었습니다. 연락처 및 인증 메시지 content 복사 기능이 action button click handler 때문에 클립보드 복사 내용이 overwrite되어서 click handler에서 클립 보드 복사 기능을 제거했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
