### PR TITLE
[FLIZ-392/root] fix: 회원가입 완료 이후 로직 버그 fix

### DIFF
--- a/apps/trainer/app/register/_components/RegisterFunnel.tsx
+++ b/apps/trainer/app/register/_components/RegisterFunnel.tsx
@@ -36,7 +36,7 @@ const PushPermissionStep = dynamic(() => import("./PushPermissionStep"), {
 function RegisterFunnel() {
   const router = useRouter();
 
-  const { onSubmit, status } = useRegisterForm();
+  const { onSubmit, isPending: isRegisterPending } = useRegisterForm();
   const { uploadProfileImage } = useUploadProfileImage();
   const funnel = useFunnel<{
     basicInfo: BasicInfoStep;
@@ -93,7 +93,7 @@ function RegisterFunnel() {
           />
         )}
       />
-      <Sheet open={status === "pending"}>
+      <Sheet open={isRegisterPending}>
         <SheetContent side={"bottom"} className="md:w-mobile md:inset-x-[calc((100%-480px)/2)]">
           <SheetHeader>
             <SheetTitle>회원가입을 진행중입니다</SheetTitle>

--- a/apps/trainer/app/register/_hooks/useRegisterForm.ts
+++ b/apps/trainer/app/register/_hooks/useRegisterForm.ts
@@ -1,20 +1,34 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
 
 import { myInformationBaseKeys } from "@trainer/queries/myInformation";
 
-import { signup } from "@trainer/services/auth";
+import { saveTokens, signup } from "@trainer/services/auth";
+
+import RouteInstance from "@trainer/constants/route";
 
 export const useRegisterForm = () => {
+  const router = useRouter();
   const queryClient = useQueryClient();
-  const { mutateAsync, status } = useMutation({
+  const { mutate: saveUserTokens, isPending: saveUserTokensPending } = useMutation({
+    mutationFn: saveTokens,
+    onError: () => {
+      toast.error("예상하지 못한 오류가 발생했습니다. 회원가입/로그인을 다시 시대해주세요");
+      router.replace(RouteInstance.login());
+    },
+  });
+  const { mutateAsync: signupUser, isPending: signupUserPending } = useMutation({
     mutationFn: signup,
-    onSuccess: () => {
+    onSuccess: async ({ data }) => {
       queryClient.invalidateQueries({ queryKey: myInformationBaseKeys.all });
+
+      saveUserTokens(data);
     },
   });
 
   return {
-    onSubmit: mutateAsync,
-    status,
+    onSubmit: signupUser,
+    isPending: saveUserTokensPending || signupUserPending,
   };
 };

--- a/apps/user/app/register/_components/RegisterFunnel.tsx
+++ b/apps/user/app/register/_components/RegisterFunnel.tsx
@@ -37,7 +37,7 @@ const PushPermissionStep = dynamic(() => import("./PushPermissionStep"), {
 function RegisterFunnel() {
   const router = useRouter();
 
-  const { onSubmit, status } = useRegisterForm();
+  const { onSubmit, isPending: isRegisterPending } = useRegisterForm();
   const { uploadProfileImage } = useUploadProfileImage();
   const funnel = useFunnel<{
     basicInfo: BasicInfoStep;
@@ -75,17 +75,13 @@ function RegisterFunnel() {
           <WorkoutScheduleStep
             onPrev={() => history.back()}
             onSubmit={async (workoutSchedule) => {
-              try {
-                await onSubmit({
-                  ...context,
-                  workoutSchedule,
-                });
-                history.replace("result", {
-                  workoutSchedule,
-                });
-              } catch {
-                return;
-              }
+              await onSubmit({
+                ...context,
+                workoutSchedule,
+              });
+              history.replace("result", {
+                workoutSchedule,
+              });
             }}
           />
         )}
@@ -96,7 +92,7 @@ function RegisterFunnel() {
           />
         )}
       />
-      <Sheet open={status === "pending"}>
+      <Sheet open={isRegisterPending}>
         <SheetContent side={"bottom"} className="md:w-mobile md:inset-x-[calc((100%-480px)/2)]">
           <SheetHeader>
             <SheetTitle>회원가입을 진행중입니다</SheetTitle>

--- a/apps/user/app/register/_hooks/useRegisterForm.ts
+++ b/apps/user/app/register/_hooks/useRegisterForm.ts
@@ -1,20 +1,34 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
 
 import { myInformationBaseKeys } from "@user/queries/myInformation";
 
-import { signup } from "@user/services/auth";
+import { saveTokens, signup } from "@user/services/auth";
+
+import RouteInstance from "@user/constants/routes";
 
 export const useRegisterForm = () => {
+  const router = useRouter();
   const queryClient = useQueryClient();
-  const { mutateAsync, status } = useMutation({
+  const { mutate: saveUserTokens, isPending: saveUserTokensPending } = useMutation({
+    mutationFn: saveTokens,
+    onError: () => {
+      toast.error("예상하지 못한 오류가 발생했습니다. 회원가입/로그인을 다시 시대해주세요");
+      router.replace(RouteInstance.login());
+    },
+  });
+  const { mutateAsync: signupUser, isPending: signupUserPending } = useMutation({
     mutationFn: signup,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: myInformationBaseKeys.all() });
+    onSuccess: async ({ data }) => {
+      queryClient.invalidateQueries({ queryKey: myInformationBaseKeys.all });
+
+      saveUserTokens(data);
     },
   });
 
   return {
-    onSubmit: mutateAsync,
-    status,
+    onSubmit: signupUser,
+    isPending: saveUserTokensPending || signupUserPending,
   };
 };


### PR DESCRIPTION
# [FLIZ-392/root] fix: 회원가입 완료 이후 로직 버그 fix


## 📝 작업 내용

회원가입 후 API 호출에서 모두 사용자 token이 유효하지 않다는 버그가 발생했습니다. 해당 버그는 회원가입 API 성공 후 cookie에 토큰을 저장하는 로직이 빠져 발생했던 것으로 추정되어 해당 로직을 추가했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
