### PR TITLE
[FLIZ-394/trainer] feat: 트레이너가 직접 예약시 같은 날짜에 같은 회원이 두 번 이상 수업 예약이 진행될 수 없다는 정책 반영

### DIFF
--- a/apps/trainer/app/schedule-management/reservation/page.tsx
+++ b/apps/trainer/app/schedule-management/reservation/page.tsx
@@ -1,6 +1,9 @@
+/* eslint-disable no-magic-numbers */
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { format, subHours } from "date-fns";
 import { Suspense } from "react";
 
+import { reservationQueries } from "@trainer/queries/reservation";
 import { userManagementQueries } from "@trainer/queries/userManagement";
 
 import MemberListContainer from "../_components/MemberListContainer";
@@ -8,10 +11,22 @@ import Header from "./_components/Header";
 import ReservationAdderButton from "./_components/ReservationAdderButton";
 import MemberContainerFallback from "../_components/Fallback/MemberContainerFallback";
 
-async function Reservation() {
+type ReservationProps = {
+  searchParams: { selectedDate: string | null; selectedFormatDate: string | null };
+};
+
+async function Reservation({ searchParams }: ReservationProps) {
+  const selectedDate = searchParams.selectedDate;
+
+  const koreanFormattedDate = format(subHours(new Date(selectedDate as string), 9), "yyyy-MM-dd");
+
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchInfiniteQuery(userManagementQueries.list());
+  await Promise.all([
+    await queryClient.prefetchInfiniteQuery(userManagementQueries.list()),
+    await queryClient.prefetchQuery(reservationQueries.list(koreanFormattedDate)),
+  ]);
+
   const dehydratedState = dehydrate(queryClient);
 
   return (

--- a/apps/trainer/components/Providers/index.tsx
+++ b/apps/trainer/components/Providers/index.tsx
@@ -17,8 +17,8 @@ function makeQueryClient() {
         refetchOnMount: true,
       },
       mutations: {
-        onError: () => {
-          toast.error("요청에 실패했습니다. 다시 시도해주세요!");
+        onError: (error) => {
+          toast.error(error.message);
         },
         onSuccess: () => {
           toast.success("요청이 완료되었습니다.");

--- a/apps/user/components/Providers/index.tsx
+++ b/apps/user/components/Providers/index.tsx
@@ -18,8 +18,8 @@ function makeQueryClient() {
       },
 
       mutations: {
-        onError: () => {
-          toast.error("요청에 실패했습니다. 다시 시도해주세요!");
+        onError: (error) => {
+          toast.error(error.message);
         },
         onSuccess: () => {
           toast.success("요청이 완료되었습니다.");


### PR DESCRIPTION
## 📝 작업 내용

#### 같은 날 같은 회원 두 번 이상 수업 진행 X 정책 반영
- 기존에는 방어 로직이 없어 같은 날에 같은 회원이 여러번 수업 예약을 할 수 있었습니다.
   - 현재는 방어 로직을 넣어 트레이너가 직접 예약 기능으로 같은 날짜에 같은 회원의 예약을 2번 이상 할 수 없도록 정책을 반영하였습니다.
   - 2번 이상 예약을 시도하게되면 토스트 에러메시지가 상단에 나타납니다.
#### 트레이너/회원 도메인 에러메시지 토스트 메시지에 반영
- 서버에서 내려주는 에러메시지를 토스트 메시지에 반영하였습니다.
- 용재님께서 토스트 라이브러리를 다른 라이브러리로 교체 작업을 진행중이신 걸로 알고있는데, 라이브러리 변경시 해당 코드가 머지되면 루트 provider에 설정된 토스트 메시지 말고도, 토스트 메시지가 작성된 부분들도 같이 수정해주시면 감사하겠습니다 :)