### PR TITLE
[FLIZ-389/root] fix: 알림 item bug fix

### DIFF
--- a/apps/trainer/app/notification/_components/NotificationItemContainer.tsx
+++ b/apps/trainer/app/notification/_components/NotificationItemContainer.tsx
@@ -30,6 +30,7 @@ function NotificationItemContainer({ notification, onClick }: NotificationItemCo
         createdAt={sendDate}
         isCompleted={isProcessed}
         message={message}
+        eventDate={eventDate}
       />
     );
 

--- a/apps/trainer/app/notification/_components/NotificationItemContainer.tsx
+++ b/apps/trainer/app/notification/_components/NotificationItemContainer.tsx
@@ -8,7 +8,7 @@ import { notificationQueries } from "@trainer/queries/notification";
 
 import NotificationItemError from "./NotificationItemError";
 import NotificationItemFallback from "./NotificationItemFallback";
-import { parseMessageFromContent } from "../_utils/parser";
+import { parseContent } from "../_utils/notificationParser";
 
 type NotificationItemContainerProps = {
   notification: NotificationInfo;
@@ -21,7 +21,7 @@ function NotificationItemContainer({ notification, onClick }: NotificationItemCo
   );
 
   const { content, type, sendDate, isProcessed, notificationId } = notification;
-  const message = parseMessageFromContent(content);
+  const { message, eventDate } = parseContent(content);
 
   if (isPending)
     return (
@@ -40,6 +40,7 @@ function NotificationItemContainer({ notification, onClick }: NotificationItemCo
   return (
     <NotificationItem
       message={message}
+      eventDate={eventDate}
       variant={type}
       createdAt={sendDate}
       image={

--- a/apps/trainer/app/notification/_components/NotificationItemFallback.tsx
+++ b/apps/trainer/app/notification/_components/NotificationItemFallback.tsx
@@ -7,8 +7,7 @@ import { cn } from "@ui/lib/utils";
 type NotificationItemFallbackProps = {
   isCompleted: boolean;
   message: string;
-  eventDate?: Date | string;
-  eventDetail?: Date | string;
+  eventDate?: string;
   createdAt: Date | string;
   variant: NotificationType;
 };
@@ -16,6 +15,7 @@ function NotificationItemFallback({
   isCompleted,
   createdAt,
   message,
+  eventDate,
   variant,
 }: NotificationItemFallbackProps) {
   const createdDateController = DateController(createdAt).validate();
@@ -34,6 +34,7 @@ function NotificationItemFallback({
         isCompleted={isCompleted}
         createdAt={createdDateController?.toRelative()}
         message={message}
+        eventDate={eventDate}
         variant={variant}
       />
     </li>

--- a/apps/trainer/app/notification/_components/NotificationSearch/MemberNotificationResult.tsx
+++ b/apps/trainer/app/notification/_components/NotificationSearch/MemberNotificationResult.tsx
@@ -12,7 +12,7 @@ import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
 import { NotificationStatus } from "../../_types";
 import createFilteredNotificationCount from "../../_utils/createFilteredNotificationCount";
 import handleNotificationFilter from "../../_utils/handleNotificationFilter";
-import { parseEventDateFromContent } from "../../_utils/parser";
+import { parseContent } from "../../_utils/notificationParser";
 import EmptyList from "../EmptyList";
 import NotificationItemContainer from "../NotificationItemContainer";
 import NotificationListFallback from "../NotificationListFallback";
@@ -102,6 +102,10 @@ function MemberNotificationResult({ memberId }: MemberNotificationResultProps) {
   const ActionSheet =
     selectedNotification && selectedNotification.type && SheetRenderer[selectedNotification.type];
 
+  const info = selectedNotification
+    ? parseContent(selectedNotification.content)
+    : { message: "", eventDate: "", other: "" };
+
   return (
     <>
       <div className="flex flex-col items-start gap-4">
@@ -156,7 +160,10 @@ function MemberNotificationResult({ memberId }: MemberNotificationResultProps) {
             open: isActionSheetOpen,
             onChangeOpen: setIsActionSheetOpen,
           },
-          parseEventDateFromContent(selectedNotification.content),
+          {
+            eventDate: info.eventDate,
+            cancelReason: info.other,
+          },
         )}
     </>
   );

--- a/apps/trainer/app/notification/_components/SheetRenderer/ReservationCancelSheet.tsx
+++ b/apps/trainer/app/notification/_components/SheetRenderer/ReservationCancelSheet.tsx
@@ -30,17 +30,20 @@ type ReservationCancelSheetProps = {
   open: boolean;
   onChangeOpen: (isOpen: boolean) => void;
   eventDateDescription: string;
+  cancelReason: string;
 };
 
 type ReservationCancelSheetContentProps = {
   notificationId: number;
   eventDateDescription: string;
+  cancelReason: string;
   handleDeclineClick: (reservationId: number, userId: number) => () => void;
   handleAcceptClick: (reservationId: number, userId: number) => () => void;
 };
 function ReservationCancelSheetContent({
   notificationId,
   eventDateDescription,
+  cancelReason,
   handleDeclineClick,
   handleAcceptClick,
 }: ReservationCancelSheetContentProps) {
@@ -70,6 +73,9 @@ function ReservationCancelSheetContent({
       >
         <Badge variant={"sub2"}>{formatSessionData(remainingCount, totalCount)}</Badge>
       </ProfileCard>
+      <div className="bg-background-sub1 mt-2 w-full rounded-[0.625rem] p-4 md:hover:bg-none">
+        {cancelReason}
+      </div>
       <SheetFooter>
         <div className="flex w-full justify-center gap-[0.625rem]">
           <SheetClose asChild>
@@ -103,6 +109,7 @@ function ReservationCancelSheet({
   open,
   onChangeOpen,
   eventDateDescription,
+  cancelReason,
 }: ReservationCancelSheetProps) {
   const queryClient = useQueryClient();
 
@@ -146,6 +153,7 @@ function ReservationCancelSheet({
               <ReservationCancelSheetContent
                 notificationId={notificationId}
                 eventDateDescription={eventDateDescription}
+                cancelReason={cancelReason}
                 handleDeclineClick={handleDeclineClick}
                 handleAcceptClick={handleAcceptClick}
               />

--- a/apps/trainer/app/notification/_components/SheetRenderer/index.tsx
+++ b/apps/trainer/app/notification/_components/SheetRenderer/index.tsx
@@ -13,15 +13,31 @@ const SheetRenderer = {
   "트레이너 연동": (commonProps: CommonSheetProps) => <ConnectTrainerSheet {...commonProps} />,
   "트레이너 연동 해제": () => null,
   "예약 요청": () => null,
-  "예약 변경": (commonProps: CommonSheetProps, eventDateDescription: string) => (
-    <ReservationChangeSheet {...commonProps} eventDateDescription={eventDateDescription} />
+  "예약 변경": (
+    commonProps: CommonSheetProps,
+    eventInfo: {
+      eventDate: string;
+    },
+  ) => <ReservationChangeSheet {...commonProps} eventDateDescription={eventInfo.eventDate} />,
+  "예약 취소": (
+    commonProps: CommonSheetProps,
+    eventInfo: {
+      eventDate: string;
+      cancelReason?: string;
+    },
+  ) => (
+    <ReservationCancelSheet
+      {...commonProps}
+      eventDateDescription={eventInfo.eventDate}
+      cancelReason={eventInfo.cancelReason || ""}
+    />
   ),
-  "예약 취소": (commonProps: CommonSheetProps, eventDateDescription: string) => (
-    <ReservationCancelSheet {...commonProps} eventDateDescription={eventDateDescription} />
-  ),
-  세션: (commonProps: CommonSheetProps, eventDateDescription: string) => (
-    <SessionCompleteSheet {...commonProps} eventDate={eventDateDescription} />
-  ),
+  세션: (
+    commonProps: CommonSheetProps,
+    eventInfo: {
+      eventDate: string;
+    },
+  ) => <SessionCompleteSheet {...commonProps} eventDate={eventInfo.eventDate} />,
 };
 
 export default SheetRenderer;

--- a/apps/trainer/app/notification/_utils/notificationParser.ts
+++ b/apps/trainer/app/notification/_utils/notificationParser.ts
@@ -1,0 +1,21 @@
+export const parseEventDateFromContent = (content: string) => {
+  return content.split("날짜: ")[1];
+};
+
+export const parseMessageFromContent = (content: string) => {
+  return content.split("날짜: ")[0];
+};
+
+export const parseContent = (content: string) => {
+  const [messageRaw, eventDateRaw, otherRaw] = content.split("\n");
+
+  const message = messageRaw ? messageRaw.trim() : messageRaw;
+  const eventDate = eventDateRaw ? eventDateRaw.trim().split("날짜: ")[1] : eventDateRaw;
+  const other = otherRaw ? otherRaw.trim() : otherRaw;
+
+  return {
+    message,
+    eventDate,
+    other,
+  };
+};

--- a/apps/trainer/app/notification/_utils/parseKoreanDateString.ts
+++ b/apps/trainer/app/notification/_utils/parseKoreanDateString.ts
@@ -1,0 +1,32 @@
+/* eslint-disable no-magic-numbers */
+export function parseKoreanDateString(dateStr: string) {
+  // 현재 연도 사용 (필요시 인자로 받게 변경 가능)
+  const currentYear = new Date().getFullYear();
+
+  // 월, 일 추출
+  const match = dateStr
+    .replace(/[()\s]/g, "") // 괄호와 공백 제거
+    .replace("오전", "AM")
+    .replace("오후", "PM")
+    .match(/(\d{2})\.(\d{2})[^\d]*(AM|PM)(\d{1,2})시/); // 정규식 매칭
+
+  if (!match) {
+    throw new Error("Invalid date string format");
+  }
+
+  const [monthStr, dayStr, meridiem, hourStr] = match.slice(1); // 첫 번째는 전체 match이므로 제외
+
+  // 숫자 변환
+  const month = parseInt(monthStr, 10) - 1; // JS는 0-based month
+  const day = parseInt(dayStr, 10);
+  let hour = parseInt(hourStr, 10);
+
+  if (meridiem === "PM" && hour !== 12) {
+    hour += 12;
+  } else if (meridiem === "AM" && hour === 12) {
+    hour = 0;
+  }
+
+  // Date 객체 생성
+  return new Date(currentYear, month, day, hour);
+}

--- a/apps/trainer/app/notification/_utils/parser.ts
+++ b/apps/trainer/app/notification/_utils/parser.ts
@@ -1,7 +1,0 @@
-export const parseEventDateFromContent = (content: string) => {
-  return content.split("날짜: ")[1];
-};
-
-export const parseMessageFromContent = (content: string) => {
-  return content.split("날짜: ")[0];
-};

--- a/apps/trainer/app/notification/reservation-cancel/page.tsx
+++ b/apps/trainer/app/notification/reservation-cancel/page.tsx
@@ -20,7 +20,7 @@ import ReservationCancelSheet from "../_components/SheetRenderer/ReservationCanc
 import { NotificationStatus } from "../_types";
 import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
 import handleNotificationFilter from "../_utils/handleNotificationFilter";
-import { parseEventDateFromContent } from "../_utils/parser";
+import { parseContent } from "../_utils/notificationParser";
 
 type ReservationCancelNotificationContentProps = {
   status: NotificationStatus;
@@ -98,6 +98,10 @@ function ReservationCancelNotificationPage() {
     setIsActionSheetOpen(true);
   };
 
+  const info = selectedNotification
+    ? parseContent(selectedNotification.content)
+    : { message: "", eventDate: "", other: "" };
+
   return (
     <div className="flex h-full flex-col">
       <Header className="mb-4">
@@ -134,7 +138,8 @@ function ReservationCancelNotificationPage() {
           notificationId={selectedNotification.notificationId}
           open={isActionSheetOpen}
           onChangeOpen={setIsActionSheetOpen}
-          eventDateDescription={parseEventDateFromContent(selectedNotification.content)}
+          eventDateDescription={info.eventDate}
+          cancelReason={info.other}
         />
       )}
     </div>

--- a/apps/trainer/app/notification/reservation-change/page.tsx
+++ b/apps/trainer/app/notification/reservation-change/page.tsx
@@ -20,7 +20,7 @@ import ReservationChangeSheet from "../_components/SheetRenderer/ReservationChan
 import { NotificationStatus } from "../_types";
 import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
 import handleNotificationFilter from "../_utils/handleNotificationFilter";
-import { parseEventDateFromContent } from "../_utils/parser";
+import { parseContent } from "../_utils/notificationParser";
 
 type ReservationChangeNotificationContentProps = {
   status: NotificationStatus;
@@ -98,6 +98,10 @@ function ReservationChangeNotificationPage() {
     setIsActionSheetOpen(true);
   };
 
+  const info = selectedNotification
+    ? parseContent(selectedNotification.content)
+    : { message: "", eventDate: "", other: "" };
+
   return (
     <div className="flex h-full flex-col">
       <Header className="mb-4">
@@ -134,7 +138,7 @@ function ReservationChangeNotificationPage() {
           notificationId={selectedNotification.notificationId}
           open={isActionSheetOpen}
           onChangeOpen={setIsActionSheetOpen}
-          eventDateDescription={parseEventDateFromContent(selectedNotification.content)}
+          eventDateDescription={info.eventDate}
         />
       )}
     </div>

--- a/apps/trainer/app/notification/session/page.tsx
+++ b/apps/trainer/app/notification/session/page.tsx
@@ -20,7 +20,7 @@ import SessionCompleteSheet from "../_components/SheetRenderer/SessionCompleteSh
 import { NotificationStatus } from "../_types";
 import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
 import handleNotificationFilter from "../_utils/handleNotificationFilter";
-import { parseEventDateFromContent } from "../_utils/parser";
+import { parseContent } from "../_utils/notificationParser";
 
 type SessionNotificationContentProps = {
   status: NotificationStatus;
@@ -98,6 +98,10 @@ function SessionNotificationPage() {
     setIsActionSheetOpen(true);
   };
 
+  const info = selectedNotification
+    ? parseContent(selectedNotification.content)
+    : { message: "", eventDate: "", other: "" };
+
   return (
     <div>
       <Header className="mb-4">
@@ -131,7 +135,7 @@ function SessionNotificationPage() {
           notificationId={selectedNotification.notificationId}
           open={isActionSheetOpen}
           onChangeOpen={setIsActionSheetOpen}
-          eventDate={parseEventDateFromContent(selectedNotification.content)}
+          eventDate={info.eventDate}
         />
       )}
     </div>

--- a/apps/user/app/notification/_components/NotificationContainer.tsx
+++ b/apps/user/app/notification/_components/NotificationContainer.tsx
@@ -2,7 +2,6 @@
 
 import { API_THROTTLE_LIMIT, throttle } from "@5unwan/core/utils/throttle";
 import { useMutation, useQueryClient, useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import NotificationItem from "@ui/components/NotificationItem/NotificationItem";
 import { Text } from "@ui/components/Text";
 import React, { Fragment, useRef } from "react";
 
@@ -13,6 +12,7 @@ import { readNotification } from "@user/services/notification";
 import useIntersectionObserver from "@user/hooks/useIntersectionObserver";
 
 import EmptyList from "./EmptyList";
+import NotificationItemContainer from "./NotificationItemContainer";
 
 function NotificationContainer() {
   const intersectionRef = useRef(null);
@@ -49,19 +49,18 @@ function NotificationContainer() {
         <ul className="flex flex-col items-center gap-4">
           {data.pages.map((group, index) => (
             <Fragment key={`notificationGroup-${index}`}>
-              {group.data.content.map(
-                ({ notificationId, content, sendDate, isProcessed, type }) => (
-                  <NotificationItem
-                    message={content}
-                    createdAt={sendDate}
+              {group.data.content.map((notification) => {
+                const { notificationId, isProcessed } = notification;
+
+                return (
+                  <NotificationItemContainer
+                    notification={notification}
                     isCompleted={isPending && notificationId === variables.id ? true : isProcessed}
-                    variant={type}
                     onClick={handleClick(notificationId)}
-                    className="w-full"
                     key={`notification-${notificationId}`}
                   />
-                ),
-              )}
+                );
+              })}
             </Fragment>
           ))}
           <div ref={intersectionRef} />

--- a/apps/user/app/notification/_components/NotificationItemContainer.tsx
+++ b/apps/user/app/notification/_components/NotificationItemContainer.tsx
@@ -1,0 +1,36 @@
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import NotificationItem from "@ui/components/NotificationItem/NotificationItem";
+import { MouseEventHandler } from "react";
+
+import { parseContent } from "../_utils/notificationParser";
+
+type NotificationItemContainerProps = {
+  notification: NotificationInfo;
+  isCompleted: boolean;
+  onClick: MouseEventHandler<HTMLLIElement>;
+};
+
+function NotificationItemContainer({
+  notification,
+  isCompleted,
+  onClick,
+}: NotificationItemContainerProps) {
+  const { content, type, sendDate, notificationId } = notification;
+
+  const { message, eventDate } = parseContent(content);
+
+  return (
+    <NotificationItem
+      message={message}
+      eventDate={eventDate}
+      createdAt={sendDate}
+      isCompleted={isCompleted}
+      variant={type}
+      onClick={onClick}
+      className="w-full"
+      key={`notification-${notificationId}`}
+    />
+  );
+}
+
+export default NotificationItemContainer;

--- a/apps/user/app/notification/_utils/notificationParser.ts
+++ b/apps/user/app/notification/_utils/notificationParser.ts
@@ -1,0 +1,20 @@
+export const parseEventDateFromContent = (content: string) => {
+  return content.split("날짜: ")[1];
+};
+
+export const parseMessageFromContent = (content: string) => {
+  return content.split("날짜: ")[0];
+};
+
+export const parseContent = (content: string) => {
+  const [messageRaw, eventDateRaw, otherRaw] = content.split("\n");
+  const message = messageRaw ? messageRaw.trim() : messageRaw;
+  const eventDate = eventDateRaw ? eventDateRaw.trim().split("날짜: ")[1] : eventDateRaw;
+  const other = otherRaw ? otherRaw.trim() : otherRaw;
+
+  return {
+    message,
+    eventDate,
+    other,
+  };
+};

--- a/packages/ui/src/components/NotificationItem/IconThumbnail.tsx
+++ b/packages/ui/src/components/NotificationItem/IconThumbnail.tsx
@@ -77,7 +77,7 @@ function IconThumbnail({
   return (
     <div
       className={cn(
-        "bg-brand-primary-500 flex h-[1.5rem] w-[1.5rem] items-center justify-center rounded-full transition-colors",
+        "bg-brand-primary-500 flex h-[1.5rem] w-[1.5rem] shrink-0 items-center justify-center rounded-full transition-colors",
         {
           "bg-background-sub2": isCompleted,
         },

--- a/packages/ui/src/components/NotificationItem/NotificationContent.tsx
+++ b/packages/ui/src/components/NotificationItem/NotificationContent.tsx
@@ -7,7 +7,6 @@ type NotificationContentProps = {
   message: string;
   eventDate?: string;
   createdAt?: string;
-  eventDetail?: string;
   variant: NotificationType;
 };
 function NotificationContent({
@@ -15,9 +14,29 @@ function NotificationContent({
   message,
   eventDate,
   createdAt,
-  eventDetail,
   variant,
 }: NotificationContentProps) {
+  const createEventDateJSX = (eventDate: string) => {
+    const [before, after] = eventDate.split(" -> ");
+
+    if (variant === "예약 변경")
+      return (
+        <span>
+          <span>{before}</span>
+          <span> → </span>
+          <span
+            className={cn("text-brand-primary-400", {
+              "text-brand-primary-700": isCompleted,
+            })}
+          >
+            {after}
+          </span>
+        </span>
+      );
+
+    return <span>{eventDate}</span>;
+  };
+
   return (
     <div
       className={cn(
@@ -29,27 +48,7 @@ function NotificationContent({
     >
       <span>{message}</span>
 
-      <p>
-        {eventDate && <span>{`${eventDate} ${variant === "예약 변경" ? "→ " : ""}`}</span>}
-        {eventDetail && (
-          <span
-            className={cn(
-              "text-brand-primary-500 transition-colors",
-              {
-                "text-brand-primary-700": variant !== "세션" && isCompleted,
-              },
-              {
-                "text-text-primary": variant === "세션" && !isCompleted,
-              },
-              {
-                "text-text-sub3": variant === "세션" && isCompleted,
-              },
-            )}
-          >
-            {eventDetail}
-          </span>
-        )}
-      </p>
+      <p>{eventDate && createEventDateJSX(eventDate)}</p>
 
       <span className="text-body-4 text-text-sub3">{createdAt}</span>
     </div>

--- a/packages/ui/src/components/NotificationItem/NotificationItem.tsx
+++ b/packages/ui/src/components/NotificationItem/NotificationItem.tsx
@@ -11,8 +11,7 @@ type Props = Omit<HTMLAttributes<HTMLLIElement>, "onClick"> & NotificationProps;
 type NotificationProps = {
   isCompleted: boolean;
   message: string;
-  eventDate?: Date | string;
-  eventDetail?: Date | string;
+  eventDate?: string;
   createdAt: Date | string;
   variant: NotificationType;
   onClick?: MouseEventHandler<HTMLLIElement>;
@@ -25,7 +24,6 @@ const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
     createdAt,
     message,
     eventDate,
-    eventDetail,
     variant,
     onClick,
     className,
@@ -39,9 +37,7 @@ const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
     onClick(e);
   };
 
-  const eventDateController = eventDate ? DateController(eventDate).validate() : undefined;
   const createdDateController = DateController(createdAt).validate();
-  const eventDetailController = eventDetail ? DateController(eventDetail).validate() : undefined;
 
   return (
     <li
@@ -61,13 +57,8 @@ const NotificationItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
         isCompleted={isCompleted}
         createdAt={createdDateController?.toRelative()}
         message={message}
-        eventDate={eventDateController?.toServiceFormat().untilMinutes}
+        eventDate={eventDate}
         variant={variant}
-        eventDetail={
-          eventDetailController
-            ? eventDetailController.toServiceFormat().untilMinutes
-            : (eventDetail as string)
-        }
       />
     </li>
   );


### PR DESCRIPTION
# [FLIZ-389/root] fix: 알림 item bug fix

## 📝 작업 내용

알림 Item ui 및 로직 버그를 해결했습니다

#### UI
- Icon 찌그러짐 버그
- 알림 메시지 내용 중 `날짜` 데이터 표시 안 되는 버그
- 서버에서 내려주는 알림 메시지 데이터 `\n` 기준 파싱 안 되는 버그
- 예약 취소 Sheet 취소 사유 UI 없는 버그
- NotificationItemFallback 내용과 실제 NotificationItem 내용 불일치 버그

#### 로직
- 트레이너 알림 중 예약 요청 알림 click하여  /pending-reservations로 redirect 시 Invalid Date 버그

### 스크린샷

<img width="488" alt="스크린샷 2025-06-23 오후 2 21 12" src="https://github.com/user-attachments/assets/00616005-a451-4184-bc65-88dc02ec8632" />
<img width="488" alt="스크린샷 2025-06-23 오후 2 21 27" src="https://github.com/user-attachments/assets/7399afd5-672b-490e-a04e-848307ec8b05" />

