### PR TITLE
[FLIZ-387/root] feat: toast 라이브러리 교체 및 토스트 styling

### DIFF
--- a/apps/trainer/app/my-page/_components/DeleteMyDayOffDialog/index.tsx
+++ b/apps/trainer/app/my-page/_components/DeleteMyDayOffDialog/index.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
 } from "@ui/components/Dialog";
 import React from "react";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 
 import { myInformationQueries } from "@trainer/queries/myInformation";
 

--- a/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleApplyAtStep/index.tsx
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleApplyAtStep/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@ui/components/Button";
 import { DayPicker } from "@ui/components/DayPicker";
 import React from "react";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 
 import Header from "../../../_components/Header";
 

--- a/apps/trainer/app/register/_hooks/useRegisterForm.ts
+++ b/apps/trainer/app/register/_hooks/useRegisterForm.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 
 import { myInformationBaseKeys } from "@trainer/queries/myInformation";
 

--- a/apps/trainer/app/schedule-management/reservation/_components/ReservationAdderButton.tsx
+++ b/apps/trainer/app/schedule-management/reservation/_components/ReservationAdderButton.tsx
@@ -18,7 +18,7 @@ import { VisuallyHidden } from "@ui/components/VisuallyHidden";
 import { format, subHours } from "date-fns";
 import { useRouter, useSearchParams } from "next/navigation";
 import React, { useEffect, useState } from "react";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 
 import { myInformationQueries } from "@trainer/queries/myInformation";
 import { reservationQueries } from "@trainer/queries/reservation";

--- a/apps/trainer/app/test/page.tsx
+++ b/apps/trainer/app/test/page.tsx
@@ -1,34 +1,75 @@
 "use client";
 
+import { Button } from "@ui/components/Button";
+import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
 import { cn } from "@ui/lib/utils";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
 
 import RouteInstance from "@trainer/constants/route";
 
 import { useRegisterFcmToken } from "../register/_hooks/useRegisterFcmToken";
 
-// TODO: FCM 등록이 안 되어 있는 기존 계정들을 위해 남겨놓겠습니다
+// TODO: v1 배포 시 테스트 페이지 제거
 
 function Page() {
   const router = useRouter();
-
+  const [toastType, setToastType] = useState("default");
   const { requestFcmPermission, isPending: isRegisterFcmTokenPending } = useRegisterFcmToken();
   const handleClick = async () => {
     const granted = await requestFcmPermission();
     if (granted) router.push(RouteInstance.root());
   };
 
+  const handleToastBtnClick = () => {
+    switch (toastType) {
+      case "default":
+        toast("default");
+        break;
+      case "success":
+        toast.success("success");
+        break;
+      case "error":
+        toast.error("요청에 실패했습니다", {
+          description: "error message",
+        });
+        break;
+      case "info":
+        toast.info("info", {
+          description: "sonner info toast",
+        });
+        break;
+      default:
+        toast("default");
+    }
+  };
+
   return (
-    <div>
-      <button
-        onClick={handleClick}
-        disabled={isRegisterFcmTokenPending}
-        className={cn("rounded-lg border p-3", {
-          "bg-green-200": isRegisterFcmTokenPending,
-        })}
-      >
-        FCM 등록
-      </button>
+    <div className="flex flex-col gap-6">
+      <label className="bg-background-sub3 text-body-1 flex items-center gap-4 rounded-xl p-2">
+        <span className="">토스트 종류</span>
+        <ToggleGroup type="single" value={toastType} onValueChange={setToastType} className="">
+          <ToggleGroupItem value="default">default</ToggleGroupItem>
+          <ToggleGroupItem value="success">success</ToggleGroupItem>
+          <ToggleGroupItem value="error">error</ToggleGroupItem>
+          <ToggleGroupItem value="info">info</ToggleGroupItem>
+        </ToggleGroup>
+      </label>
+
+      <div className="flex items-center gap-4">
+        <button
+          onClick={handleClick}
+          disabled={isRegisterFcmTokenPending}
+          className={cn("rounded-lg border p-3", {
+            "bg-green-200": isRegisterFcmTokenPending,
+          })}
+        >
+          FCM 등록
+        </button>
+
+        <Button onClick={handleToastBtnClick}>토스트 테스트</Button>
+      </div>
     </div>
   );
 }

--- a/apps/trainer/components/Providers/index.tsx
+++ b/apps/trainer/components/Providers/index.tsx
@@ -4,7 +4,7 @@
 import { isServer, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import React from "react";
-import { toast, ToastContainer, Bounce } from "react-toastify";
+import { Toaster, toast } from "sonner";
 
 import FooterProvider from "./FooterProvider";
 
@@ -18,7 +18,7 @@ function makeQueryClient() {
       },
       mutations: {
         onError: (error) => {
-          toast.error(error.message);
+          toast.error("요청에 실패했습니다", { description: error.message });
         },
         onSuccess: () => {
           toast.success("요청이 완료되었습니다.");
@@ -49,18 +49,11 @@ function Providers({ children }: ProvidersProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ToastContainer
+      <Toaster
         position="top-center"
-        autoClose={1500}
-        hideProgressBar={false}
-        newestOnTop={false}
-        closeOnClick
-        rtl={false}
-        pauseOnFocusLoss
-        draggable
-        pauseOnHover
-        theme="dark"
-        transition={Bounce}
+        swipeDirections={["top", "left", "right"]}
+        duration={3000}
+        richColors
       />
       <FooterProvider>{children}</FooterProvider>
       <ReactQueryDevtools initialIsOpen={false} />

--- a/apps/trainer/package.json
+++ b/apps/trainer/package.json
@@ -34,6 +34,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-toastify": "^11.0.5",
+    "sonner": "^2.0.5",
     "swiper": "^11.2.1",
     "zustand": "^5.0.2"
   },

--- a/apps/trainer/package.json
+++ b/apps/trainer/package.json
@@ -33,7 +33,6 @@
     "next-pwa": "^5.6.0",
     "react": "^18",
     "react-dom": "^18",
-    "react-toastify": "^11.0.5",
     "sonner": "^2.0.5",
     "swiper": "^11.2.1",
     "zustand": "^5.0.2"

--- a/apps/user/app/register/_hooks/useRegisterForm.ts
+++ b/apps/user/app/register/_hooks/useRegisterForm.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 
 import { myInformationBaseKeys } from "@user/queries/myInformation";
 

--- a/apps/user/app/schedule-management/_hooks/mutation/useReservationCancelMutation.ts
+++ b/apps/user/app/schedule-management/_hooks/mutation/useReservationCancelMutation.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 
 import { baseReservationKeys } from "@user/queries/reservation";
 

--- a/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/PtTimeSelector/index.tsx
+++ b/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/PtTimeSelector/index.tsx
@@ -16,7 +16,7 @@ import TimeCellToggleGroup from "@ui/components/TimeCellToggleGroup";
 import { TimeCell } from "@ui/utils/timeCellUtils";
 import { format, isSameDay } from "date-fns";
 import { useEffect, useLayoutEffect, useState } from "react";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 
 import { filterLatestReservationsByDate } from "@user/app/schedule-management/_utils/reservationMerger";
 import { myInformationQueries } from "@user/queries/myInformation";

--- a/apps/user/app/test/page.tsx
+++ b/apps/user/app/test/page.tsx
@@ -1,34 +1,74 @@
 "use client";
 
+import { Button } from "@ui/components/Button";
+import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
 import { cn } from "@ui/lib/utils";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
 
 import RouteInstance from "@user/constants/routes";
 
 import { useRegisterFcmToken } from "../register/_hooks/useRegisterFcmToken";
 
-// TODO: FCM 등록이 안 되어 있는 기존 계정들을 위해 남겨놓겠습니다
-
+// TODO: v1 배포 시 테스트 페이지 제거
 function Page() {
   const router = useRouter();
-
+  const [toastType, setToastType] = useState("default");
   const { requestFcmPermission, isPending: isRegisterFcmTokenPending } = useRegisterFcmToken();
   const handleClick = async () => {
     const granted = await requestFcmPermission();
     if (granted) router.push(RouteInstance.root());
   };
 
+  const handleToastBtnClick = () => {
+    switch (toastType) {
+      case "default":
+        toast("default");
+        break;
+      case "success":
+        toast.success("success");
+        break;
+      case "error":
+        toast.error("요청에 실패했습니다", {
+          description: "error message",
+        });
+        break;
+      case "info":
+        toast.info("info", {
+          description: "sonner info toast",
+        });
+        break;
+      default:
+        toast("default");
+    }
+  };
+
   return (
-    <div>
-      <button
-        onClick={handleClick}
-        disabled={isRegisterFcmTokenPending}
-        className={cn("rounded-lg border p-3", {
-          "bg-green-200": isRegisterFcmTokenPending,
-        })}
-      >
-        FCM 등록
-      </button>
+    <div className="flex flex-col gap-6">
+      <label className="bg-background-sub3 text-body-1 flex items-center gap-4 rounded-xl p-2">
+        <span className="">토스트 종류</span>
+        <ToggleGroup type="single" value={toastType} onValueChange={setToastType} className="">
+          <ToggleGroupItem value="default">default</ToggleGroupItem>
+          <ToggleGroupItem value="success">success</ToggleGroupItem>
+          <ToggleGroupItem value="error">error</ToggleGroupItem>
+          <ToggleGroupItem value="info">info</ToggleGroupItem>
+        </ToggleGroup>
+      </label>
+
+      <div className="flex items-center gap-4">
+        <button
+          onClick={handleClick}
+          disabled={isRegisterFcmTokenPending}
+          className={cn("rounded-lg border p-3", {
+            "bg-green-200": isRegisterFcmTokenPending,
+          })}
+        >
+          FCM 등록
+        </button>
+
+        <Button onClick={handleToastBtnClick}>토스트 테스트</Button>
+      </div>
     </div>
   );
 }

--- a/apps/user/components/Providers/index.tsx
+++ b/apps/user/components/Providers/index.tsx
@@ -4,7 +4,7 @@
 import { isServer, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import React from "react";
-import { toast, ToastContainer, Bounce } from "react-toastify";
+import { Toaster, toast } from "sonner";
 
 import FooterProvider from "./FooterProvider";
 
@@ -19,7 +19,7 @@ function makeQueryClient() {
 
       mutations: {
         onError: (error) => {
-          toast.error(error.message);
+          toast.error("요청에 실패했습니다", { description: error.message });
         },
         onSuccess: () => {
           toast.success("요청이 완료되었습니다.");
@@ -50,18 +50,11 @@ function Providers({ children }: ProvidersProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ToastContainer
+      <Toaster
         position="top-center"
-        autoClose={1500}
-        hideProgressBar={false}
-        newestOnTop={false}
-        closeOnClick
-        rtl={false}
-        pauseOnFocusLoss
-        draggable
-        pauseOnHover
-        theme="dark"
-        transition={Bounce}
+        swipeDirections={["top", "left", "right"]}
+        duration={3000}
+        richColors
       />
       <FooterProvider>{children}</FooterProvider>
       <ReactQueryDevtools />

--- a/apps/user/package.json
+++ b/apps/user/package.json
@@ -34,6 +34,7 @@
     "react-day-picker": "8.10.1",
     "react-dom": "^18",
     "react-toastify": "^11.0.5",
+    "sonner": "^2.0.5",
     "zustand": "^5.0.2"
   },
   "devDependencies": {

--- a/apps/user/package.json
+++ b/apps/user/package.json
@@ -33,7 +33,6 @@
     "react": "^18",
     "react-day-picker": "8.10.1",
     "react-dom": "^18",
-    "react-toastify": "^11.0.5",
     "sonner": "^2.0.5",
     "zustand": "^5.0.2"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -68,6 +68,7 @@
     "lucide-react": "^0.471.1",
     "qrcode.react": "^4.2.0",
     "react-day-picker": "8.10.1",
+    "sonner": "^2.0.5",
     "tailwind-merge": "^2.6.0",
     "vaul": "^1.1.2",
     "zod": "^3.24.2"

--- a/packages/ui/src/utils/copyToClipboard.ts
+++ b/packages/ui/src/utils/copyToClipboard.ts
@@ -1,3 +1,5 @@
+import { toast } from "sonner";
+
 export const copyToClipboard = async (text: string) => {
   if (typeof navigator === "undefined") return false;
 
@@ -6,7 +8,9 @@ export const copyToClipboard = async (text: string) => {
 
     return true;
   } catch {
-    alert("클립보드 복사에 실패했습니다. 수동으로 복사해주세요.");
+    toast.error("클립보드 복사에 실패했습니다", {
+      description: "수동으로 복사해주세요.",
+    });
 
     return false;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       react-toastify:
         specifier: ^11.0.5
         version: 11.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      sonner:
+        specifier: ^2.0.5
+        version: 2.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       swiper:
         specifier: ^11.2.1
         version: 11.2.1
@@ -213,6 +216,9 @@ importers:
       react-toastify:
         specifier: ^11.0.5
         version: 11.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      sonner:
+        specifier: ^2.0.5
+        version: 2.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zustand:
         specifier: ^5.0.2
         version: 5.0.2(@types/react@18.3.17)(react@18.3.1)
@@ -391,7 +397,7 @@ importers:
         version: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))
       eslint-plugin-jest:
         specifier: ^28.9.0
-        version: 28.9.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0))(typescript@5.5.4)
+        version: 28.9.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4)))(typescript@5.5.4)
       eslint-plugin-jest-dom:
         specifier: ^5.5.0
         version: 5.5.0(@testing-library/dom@10.4.0)(eslint@9.17.0(jiti@2.4.1))
@@ -531,6 +537,9 @@ importers:
       react-day-picker:
         specifier: 8.10.1
         version: 8.10.1(date-fns@4.1.0)(react@18.3.1)
+      sonner:
+        specifier: ^2.0.5
+        version: 2.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -6511,6 +6520,12 @@ packages:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
 
+  sonner@2.0.5:
+    resolution: {integrity: sha512-YwbHQO6cSso3HBXlbCkgrgzDNIhws14r4MO87Ofy+cV2X7ES4pOoAK3+veSmVTvqNx1BWUxlhPmZzP00Crk2aQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
   source-list-map@2.0.1:
     resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
 
@@ -9141,6 +9156,42 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.17.10
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.17.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   '@jest/environment@29.7.0':
     dependencies:
       '@jest/fake-timers': 29.7.0
@@ -10196,7 +10247,7 @@ snapshots:
 
   '@testing-library/dom@10.4.0':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/runtime': 7.26.0
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -11360,13 +11411,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0):
+  create-jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -11933,13 +11984,13 @@ snapshots:
     optionalDependencies:
       '@testing-library/dom': 10.4.0
 
-  eslint-plugin-jest@28.9.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0))(typescript@5.5.4):
+  eslint-plugin-jest@28.9.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4)))(typescript@5.5.4):
     dependencies:
       '@typescript-eslint/utils': 8.18.1(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4)
       eslint: 9.17.0(jiti@2.4.1)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4))(eslint@9.17.0(jiti@2.4.1))(typescript@5.5.4)
-      jest: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)
+      jest: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -13001,16 +13052,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0):
+  jest-cli@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)
+      create-jest: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -13052,7 +13103,39 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0):
+  jest-config@29.7.0(@types/node@20.17.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4)):
+    dependencies:
+      '@babel/core': 7.26.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.17.10
+      ts-node: 10.9.2(@types/node@22.13.5)(typescript@5.5.4)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    optional: true
+
+  jest-config@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.26.7
       '@jest/test-sequencer': 29.7.0
@@ -13078,6 +13161,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.13.5
+      ts-node: 10.9.2(@types/node@22.13.5)(typescript@5.5.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -13337,12 +13421,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0):
+  jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)
+      jest-cli: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -14492,6 +14576,11 @@ snapshots:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
 
+  sonner@2.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   source-list-map@2.0.1: {}
 
   source-map-js@1.2.1: {}
@@ -14901,6 +14990,25 @@ snapshots:
       typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@22.13.5)(typescript@5.5.4):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.13.5
+      acorn: 8.14.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.5.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   ts-node@10.9.2(@types/node@22.13.5)(typescript@5.6.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
-      react-toastify:
-        specifier: ^11.0.5
-        version: 11.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sonner:
         specifier: ^2.0.5
         version: 2.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -213,9 +210,6 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
-      react-toastify:
-        specifier: ^11.0.5
-        version: 11.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sonner:
         specifier: ^2.0.5
         version: 2.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6261,12 +6255,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  react-toastify@11.0.5:
-    resolution: {integrity: sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==}
-    peerDependencies:
-      react: ^18 || ^19
-      react-dom: ^18 || ^19
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -14260,12 +14248,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.17
-
-  react-toastify@11.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
# [FLIZ-387/root] feat: toast 라이브러리 교체 및 토스트 styling

## 📝 작업 내용

프로젝트 toast 라이브러리를 react-toastify에서 sonner로 migration 진행했습니다. 
migration 이유는
- 패키지 크기가 작습니다 (후보 중 가장 size가 작습니다)
- 모바일 친화적입니다 (swipe를 통한 dismiss 기능 지원)
- tailwindcss 커스텀 용이합니다

sonner 셋업만 다를 뿐 실제 toast를 호출하는 API는 기존과 동일합니다. 참고 부탁드립니다.
