### PR TITLE
[FLIZ-399/root] feat: 푸시 알림 스위치에 FCM 연동 로직 추가

### DIFF
--- a/apps/trainer/app/my-page/my-information/_components/MyInformationContainer.tsx
+++ b/apps/trainer/app/my-page/my-information/_components/MyInformationContainer.tsx
@@ -2,11 +2,23 @@
 
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Avatar, AvatarFallback } from "@ui/components/Avatar";
+import BrandSpinner from "@ui/components/BrandSpinner";
 import { Button } from "@ui/components/Button";
 import { ProfileItem } from "@ui/components/ProfileItem";
 import PushPermissionSwitch from "@ui/components/PushPermissionSwitch";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@ui/components/Sheet";
+import { usePushPermissionSwitch } from "@ui/hooks/usePushPermissionSwitch";
+import { HelpCircle } from "lucide-react";
 import Image from "next/image";
+import { useState } from "react";
 
+import { useRegisterFcmToken } from "@trainer/app/register/_hooks/useRegisterFcmToken";
 import { myInformationQueries } from "@trainer/queries/myInformation";
 
 import { MemorizedProfileItem } from "./MemorizedProfileItem";
@@ -20,6 +32,18 @@ export default function MyInformationContainer() {
   if (!response) return;
 
   const myDetailInformation = response.data;
+
+  const { requestFcmPermission, isPending: isRegisterFcmTokenPending } = useRegisterFcmToken();
+
+  const [isReconnectPushDialogOpen, setIsReconnectPushDialogOpen] = useState(false);
+
+  const {
+    isHelpDialopOpen,
+    setIsHelpDialogOpen,
+    isNotificationGranted,
+    handleToggle,
+    helpDialogDescription,
+  } = usePushPermissionSwitch(requestFcmPermission);
 
   return (
     <section className="bg-background-primary text-text-primary flex h-screen w-full flex-col items-center">
@@ -55,14 +79,65 @@ export default function MyInformationContainer() {
       <MemorizedProfileItem
         variant="phone"
         value={getFormattedPhoneNumber(myDetailInformation.phoneNumber)}
-      >
-        {/* <section className="text-text-sub3 flex items-center" onClick={handleChangePhoneNumber}>
-          변경 <Icon name="ChevronRight" size="lg" />
-        </section> */}
-      </MemorizedProfileItem>
+      />
+
       <ProfileItem variant="pushAlarm" className="w-full">
-        <PushPermissionSwitch />
+        <PushPermissionSwitch
+          checked={isNotificationGranted}
+          onChecked={handleToggle}
+          isDialogOpen={isHelpDialopOpen}
+          setIsDialogOpen={setIsHelpDialogOpen}
+          dialogDescription={helpDialogDescription}
+        />
       </ProfileItem>
+      {isNotificationGranted && (
+        <>
+          <div className="flex w-full items-center justify-center">
+            <p
+              className="text-text-sub3 text-body-1 flex w-fit cursor-pointer items-center justify-center gap-2 md:hover:underline"
+              onClick={() => setIsReconnectPushDialogOpen(true)}
+            >
+              <HelpCircle className="h-4 w-4" />
+              <span>푸시 알림이 수신되지 않으시나요?</span>
+            </p>
+          </div>
+          <Sheet open={isReconnectPushDialogOpen} onOpenChange={setIsReconnectPushDialogOpen}>
+            <SheetContent side={"bottom"} className="md:w-mobile md:inset-x-[calc((100%-480px)/2)]">
+              <SheetHeader>
+                <SheetTitle>푸시 알림이 수신되지 않으세요?</SheetTitle>
+                <SheetDescription>
+                  <div className="flex items-center justify-center md:justify-start">
+                    <p className="text-left">
+                      ① 2개 이상의 기기에서 동일 계정을 공유하시거나
+                      <br />② 회원가입 진행 중 오류가 발생했을 경우
+                    </p>
+                  </div>
+                  <br />
+                  푸시 알림 연동에 실패했을 수 있습니다.
+                  <br /> 아래 버튼을 눌러 푸시 알림 연동을 진행해주세요
+                </SheetDescription>
+              </SheetHeader>
+              <div>
+                <Button
+                  disabled={isRegisterFcmTokenPending}
+                  size="lg"
+                  className="w-full"
+                  onClick={async () => {
+                    await requestFcmPermission();
+                    setIsReconnectPushDialogOpen(false);
+                  }}
+                >
+                  {isRegisterFcmTokenPending ? (
+                    <BrandSpinner className="h-8 w-8" />
+                  ) : (
+                    "푸시 알림 재연동하기"
+                  )}
+                </Button>
+              </div>
+            </SheetContent>
+          </Sheet>
+        </>
+      )}
     </section>
   );
 }

--- a/apps/trainer/app/register/_hooks/useRegisterFcmToken.ts
+++ b/apps/trainer/app/register/_hooks/useRegisterFcmToken.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { getDeviceToken, registerServiceWorker } from "@trainer/lib/firebaseMessaging";
 
@@ -11,7 +11,7 @@ export const useRegisterFcmToken = () => {
   });
 
   const [status, setStatus] = useState<"pending" | "success" | "error" | "idle">("idle");
-  async function requestFcmPermission() {
+  const requestFcmPermission = useCallback(async () => {
     if (typeof window === "undefined" || typeof navigator === "undefined") return "unSupported";
 
     setStatus("pending");
@@ -54,7 +54,7 @@ export const useRegisterFcmToken = () => {
 
       return permission;
     }
-  }
+  }, []);
 
   return {
     requestFcmPermission,

--- a/apps/user/app/my-page/my-information/_components/MyDetailInformations.tsx
+++ b/apps/user/app/my-page/my-information/_components/MyDetailInformations.tsx
@@ -1,10 +1,22 @@
 "use client";
 
 import { useSuspenseQuery } from "@tanstack/react-query";
+import BrandSpinner from "@ui/components/BrandSpinner";
+import { Button } from "@ui/components/Button";
 import { ProfileItem } from "@ui/components/ProfileItem";
 import PushPermissionSwitch from "@ui/components/PushPermissionSwitch";
-import React from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@ui/components/Sheet";
+import { usePushPermissionSwitch } from "@ui/hooks/usePushPermissionSwitch";
+import { HelpCircle } from "lucide-react";
+import React, { useState } from "react";
 
+import { useRegisterFcmToken } from "@user/app/register/_hooks/useRegisterFcmToken";
 import { myInformationQueries } from "@user/queries/myInformation";
 
 import { MemorizedChangePhoneLink } from "./MemorizedChangePhoneLink";
@@ -16,6 +28,18 @@ export default function MyDetailInformations() {
 
   const myDetailInformation = response?.data;
 
+  const { requestFcmPermission, isPending: isRegisterFcmTokenPending } = useRegisterFcmToken();
+
+  const [isReconnectPushDialogOpen, setIsReconnectPushDialogOpen] = useState(false);
+
+  const {
+    isHelpDialopOpen,
+    setIsHelpDialogOpen,
+    isNotificationGranted,
+    handleToggle,
+    helpDialogDescription,
+  } = usePushPermissionSwitch(requestFcmPermission);
+
   return (
     <section className="w-full flex-col">
       <MemorizedProfileItem type="name" value={myDetailInformation?.name ?? ""} />
@@ -24,8 +48,62 @@ export default function MyDetailInformations() {
         value={`${getFormattedPhoneNumber(myDetailInformation?.phoneNumber ?? "")}`}
       />
       <ProfileItem variant="pushAlarm" className="w-full">
-        <PushPermissionSwitch />
+        <PushPermissionSwitch
+          checked={isNotificationGranted}
+          onChecked={handleToggle}
+          isDialogOpen={isHelpDialopOpen}
+          setIsDialogOpen={setIsHelpDialogOpen}
+          dialogDescription={helpDialogDescription}
+        />
       </ProfileItem>
+      {isNotificationGranted && (
+        <>
+          <div className="flex w-full items-center justify-center">
+            <p
+              className="text-text-sub3 text-body-1 flex w-fit cursor-pointer items-center justify-center gap-2 md:hover:underline"
+              onClick={() => setIsReconnectPushDialogOpen(true)}
+            >
+              <HelpCircle className="h-4 w-4" />
+              <span>푸시 알림이 수신되지 않으시나요?</span>
+            </p>
+          </div>
+          <Sheet open={isReconnectPushDialogOpen} onOpenChange={setIsReconnectPushDialogOpen}>
+            <SheetContent side={"bottom"} className="md:w-mobile md:inset-x-[calc((100%-480px)/2)]">
+              <SheetHeader>
+                <SheetTitle>푸시 알림이 수신되지 않으세요?</SheetTitle>
+                <SheetDescription>
+                  <div className="flex items-center justify-center md:justify-start">
+                    <p className="text-left">
+                      ① 2개 이상의 기기에서 동일 계정을 공유하시거나
+                      <br />② 회원가입 진행 중 오류가 발생했을 경우
+                    </p>
+                  </div>
+                  <br />
+                  푸시 알림 연동에 실패했을 수 있습니다.
+                  <br /> 아래 버튼을 눌러 푸시 알림 연동을 진행해주세요
+                </SheetDescription>
+              </SheetHeader>
+              <div>
+                <Button
+                  disabled={isRegisterFcmTokenPending}
+                  size="lg"
+                  className="w-full"
+                  onClick={async () => {
+                    await requestFcmPermission();
+                    setIsReconnectPushDialogOpen(false);
+                  }}
+                >
+                  {isRegisterFcmTokenPending ? (
+                    <BrandSpinner className="h-8 w-8" />
+                  ) : (
+                    "푸시 알림 재연동하기"
+                  )}
+                </Button>
+              </div>
+            </SheetContent>
+          </Sheet>
+        </>
+      )}
     </section>
   );
 }

--- a/apps/user/app/register/_hooks/useRegisterFcmToken.ts
+++ b/apps/user/app/register/_hooks/useRegisterFcmToken.ts
@@ -1,6 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { isSupported } from "firebase/messaging";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { sendPushToken } from "@user/services/notification";
 
@@ -12,17 +11,11 @@ export const useRegisterFcmToken = () => {
   });
 
   const [status, setStatus] = useState<"pending" | "success" | "error" | "idle">("idle");
-  async function requestFcmPermission() {
+  const requestFcmPermission = useCallback(async () => {
     if (typeof window === "undefined" || typeof navigator === "undefined") return "unSupported";
 
     setStatus("pending");
 
-    const supported = await isSupported();
-    if (!supported) {
-      setStatus("error");
-
-      return "unSupported";
-    }
     const permission = await Notification.requestPermission();
     try {
       if (permission === "granted") {
@@ -61,7 +54,7 @@ export const useRegisterFcmToken = () => {
 
       return permission;
     }
-  }
+  }, []);
 
   return {
     requestFcmPermission,

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -5,18 +5,23 @@ import * as React from "react";
 import Icon, { IconNames } from "./Icon";
 import { cn } from "../lib/utils";
 
+// disabled:pointer-events-none disabled:bg-background-sub3 disabled:text-text-sub3
 const buttonVariants = cva(
-  "inline-flex items-center gap-1 px-4 justify-center whitespace-nowrap text-headline transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:bg-background-sub2 disabled:text-text-sub3 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "inline-flex items-center gap-1 px-4 justify-center whitespace-nowrap text-headline transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        brand: "bg-brand-primary-500 text-text-primary shadow md:hover:bg-brand-primary-500/90",
-        negative: "bg-background-sub5 text-text-sub5 shadow md:hover:bg-background-sub5/90",
-        secondary: "bg-background-sub1 text-text-primary shadow md:hover:bg-background-sub2",
+        brand:
+          "bg-brand-primary-500 text-text-primary shadow md:hover:bg-brand-primary-500/90 disabled:bg-brand-primary-500/40 disabled:text-text-sub3 md:disabled:hover:bg-brand-primary-500/40",
+        negative:
+          "bg-background-sub5 text-text-sub5 shadow md:hover:bg-background-sub5/90 disabled:bg-background-sub5/40 md:disabled:hover:bg-background-sub5/40",
+        secondary:
+          "bg-background-sub1 text-text-primary shadow md:hover:bg-background-sub2 disabled:bg-background-sub1/40 md:disabled:hover:bg-background-sub1/40",
         outline:
           "bg-transparent text-text-sub2 border border-solid border-background-sub4 md:hover:border-background-sub5 md:hover:bg-background-sub5 md:hover:text-text-sub5",
         ghost: "bg-transparent text-text-primary md:hover:bg-background-sub3",
-        destructive: "bg-notification text-text-primary shadow md:hover:bg-notification/90",
+        destructive:
+          "bg-notification text-text-primary shadow md:hover:bg-notification/90 disabled:bg-notification/20 md:disabled:hover:bg-notification/20",
       },
       size: {
         sm: "h-[2rem] text-body-3",

--- a/packages/ui/src/components/PushPermissionSwitch.tsx
+++ b/packages/ui/src/components/PushPermissionSwitch.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
-
-import { getEnvironment } from "@ui/utils/getEnvironment";
-
 import { Button } from "./Button";
 import {
   Dialog,
@@ -15,62 +11,32 @@ import {
 } from "./Dialog";
 import { Switch } from "./Switch";
 
-function PushPermissionSwitch() {
-  const [isNotificationGranted, setIsNotificationGranted] = useState(false);
-  const [isHelpDialopOpen, setIsHelpDialogOpen] = useState(false);
-
-  const environmentRef = useRef<ReturnType<typeof getEnvironment>>("desktop-web");
-
-  useEffect(() => {
-    if (typeof Notification !== "undefined") {
-      setIsNotificationGranted(Notification.permission === "granted");
-    }
-    if (typeof navigator !== "undefined") {
-      environmentRef.current = getEnvironment();
-    }
-  }, []);
-
-  useEffect(() => {
-    if (isNotificationGranted) {
-      Notification.requestPermission().then((permission) => {
-        if (permission === "granted") {
-          setIsNotificationGranted(true);
-        } else {
-          setIsNotificationGranted(false);
-        }
-      });
-    }
-  }, [isNotificationGranted]);
-
-  const isMobilePwa = environmentRef.current === "mobile-pwa";
-
-  const handleToggle = (isNotificationGranted: boolean) => {
-    if (Notification.permission !== "default") {
-      setIsHelpDialogOpen(true);
-
-      return;
-    }
-    if (!isNotificationGranted) {
-      setIsHelpDialogOpen(true);
-
-      return;
-    }
-    setIsNotificationGranted(isNotificationGranted);
-  };
-
-  const systemBasedDescription = `${isMobilePwa ? "앱 시스템 설정" : "브라우저 환경설정"}에서 [알림] 항목을 설정해주세요`;
-
+type PushPermissionSwitchProps = {
+  checked: boolean;
+  onChecked: (checked: boolean) => void;
+  isDialogOpen?: boolean;
+  setIsDialogOpen?: (open: boolean) => void;
+  dialogDescription?: string;
+};
+function PushPermissionSwitch({
+  checked,
+  onChecked,
+  isDialogOpen,
+  setIsDialogOpen,
+  dialogDescription,
+}: PushPermissionSwitchProps) {
   return (
     <>
-      <Switch checked={isNotificationGranted} onCheckedChange={handleToggle} />
-      <Dialog open={isHelpDialopOpen} onOpenChange={setIsHelpDialogOpen}>
+      <Switch checked={checked} onCheckedChange={onChecked} />
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>푸시 알림 재설정 안내</DialogTitle>
             <DialogDescription>
               푸시 알림을 다시 설정하려면
               <br />
-              {systemBasedDescription}
+              {dialogDescription}
             </DialogDescription>
           </DialogHeader>
           <DialogClose asChild>

--- a/packages/ui/src/hooks/usePushPermissionSwitch.ts
+++ b/packages/ui/src/hooks/usePushPermissionSwitch.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { getEnvironment } from "@ui/utils/getEnvironment";
+
+export function usePushPermissionSwitch(
+  requestPushPermission: () => Promise<NotificationPermission | "unSupported">,
+) {
+  const [isNotificationGranted, setIsNotificationGranted] = useState(false);
+  const [isHelpDialopOpen, setIsHelpDialogOpen] = useState(false);
+
+  const environmentRef = useRef<ReturnType<typeof getEnvironment>>("desktop-web");
+
+  useEffect(() => {
+    if (typeof Notification !== "undefined") {
+      setIsNotificationGranted(Notification.permission === "granted");
+    }
+    if (typeof navigator !== "undefined") {
+      environmentRef.current = getEnvironment();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isNotificationGranted) {
+      Notification.requestPermission().then((permission) => {
+        if (permission === "granted") {
+          setIsNotificationGranted(true);
+        } else {
+          setIsNotificationGranted(false);
+        }
+      });
+    }
+  }, [isNotificationGranted]);
+
+  const isMobilePwa = environmentRef.current === "mobile-pwa";
+
+  const handleToggle = (isNotificationGranted: boolean) => {
+    if (Notification.permission !== "default") {
+      setIsHelpDialogOpen(true);
+
+      return;
+    }
+    if (!isNotificationGranted) {
+      setIsHelpDialogOpen(true);
+
+      return;
+    }
+
+    setIsNotificationGranted(isNotificationGranted);
+    requestPushPermission();
+  };
+
+  const systemBasedDescription = `${isMobilePwa ? "앱 시스템 설정" : "브라우저 환경설정"}에서 [알림] 항목을 설정해주세요`;
+
+  return {
+    handleToggle,
+    isNotificationGranted,
+    isHelpDialopOpen,
+    setIsHelpDialogOpen,
+    helpDialogDescription: systemBasedDescription,
+  };
+}


### PR DESCRIPTION
# [FLIZ-399/root] feat: 푸시 알림 스위치에 FCM 연동 로직 추가

## 📝 작업 내용

기존에는 마이페이지>푸시 알림 스위치 활성화 시 브라우저 Notification 설정만 허용했습니다.
하지만 회원가입 과정에서 오류가 발생했거나, 여러 기기에서 계정을 공유하면 FCM 연동 API를 호출한 적이 없어 알림이 수신되지 않을 수도 있습니다. 
이를 해결하기 위해 스위치 활성화 시, 브라우저 Notification을 허용하고, FCM 연동 API를 호출하도록 수정했습니다. 
또한, Notification이 허용된 경우, 도움말 UI가 나타나며, 해당 UI를 클릭하면 Sheet가 열립니다. 
이 시트에서는 브라우저 알림을 허용한 사용자들에게 푸시 알림 연동 API를 재호출할 수 있는 방안을 제공합니다.

### 📷 스크린샷 (선택)

<img width="488" alt="스크린샷 2025-06-25 오후 1 35 10" src="https://github.com/user-attachments/assets/419488bb-6fac-4a35-8fcf-c6e1c6d0b393" />

<img width="488" alt="스크린샷 2025-06-25 오후 1 35 18" src="https://github.com/user-attachments/assets/894b6204-fd7a-4a80-a896-60669c2f5901" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
