### PR TITLE
[FLIZ-400/trainer] refactor: 트레이너 도메인 고정 예약 탐색 시점 수정, 수업 가능 시간 변경시 고정 예약 페이지에서 나타나는 에러 수정

### DIFF
--- a/apps/trainer/app/schedule-management/fixed-reservation/select-pt-times/_components/SelectPtTimesContainer/FixedReservationAdderButton.tsx
+++ b/apps/trainer/app/schedule-management/fixed-reservation/select-pt-times/_components/SelectPtTimesContainer/FixedReservationAdderButton.tsx
@@ -76,7 +76,7 @@ function FixedReservationAdderButton({
       currentDate,
       reservations,
       dayoff.data,
-      2,
+      1,
     );
 
     if (!fixedReservationDatesAndTimes) return;

--- a/apps/trainer/app/schedule-management/fixed-reservation/select-pt-times/_components/SelectPtTimesContainer/indext.tsx
+++ b/apps/trainer/app/schedule-management/fixed-reservation/select-pt-times/_components/SelectPtTimesContainer/indext.tsx
@@ -45,9 +45,13 @@ function SelectPtTimesContainer({ userInformation }: SelectPtTimesContainerProps
 
   const { data: ptAvailableTime } = useSuspenseQuery(myInformationQueries.ptAvailableTime());
 
-  const holidayDays = ptAvailableTime.data.currentSchedules.schedules
-    .filter((schedule) => schedule.isHoliday)
-    .map((schedule) => schedule.dayOfWeek);
+  const holidayDays = ptAvailableTime.data.currentSchedules
+    ? ptAvailableTime.data.currentSchedules.schedules
+        .filter((schedule) => schedule.isHoliday)
+        .map((schedule) => schedule.dayOfWeek)
+    : ptAvailableTime.data.scheduledChanges.schedules
+        .filter((schedule) => schedule.isHoliday)
+        .map((schedule) => schedule.dayOfWeek);
 
   selectedFixedSchedulesRef.current[dayRef.current] = selectedTimes;
 
@@ -62,10 +66,15 @@ function SelectPtTimesContainer({ userInformation }: SelectPtTimesContainerProps
   };
 
   const availableTimeMap = Object.fromEntries(
-    ptAvailableTime.data.currentSchedules.schedules.map((s) => [
-      s.dayOfWeek,
-      { start: s.startTime, end: s.endTime },
-    ]),
+    ptAvailableTime.data.currentSchedules
+      ? ptAvailableTime.data.currentSchedules.schedules.map((s) => [
+          s.dayOfWeek,
+          { start: s.startTime, end: s.endTime },
+        ])
+      : ptAvailableTime.data.scheduledChanges.schedules.map((s) => [
+          s.dayOfWeek,
+          { start: s.startTime, end: s.endTime },
+        ]),
   );
 
   const HOURS = Array.from({ length: 24 }, (_, i) => i.toString().padStart(2, "0") + ":00");


### PR DESCRIPTION
## 📝 작업 내용

#### 트레이너 도메인 고정 예약 탐색 시점 수정, 수업 가능 시간 변경시 고정 예약 페이지에서 나타나는 에러 수정
- 고정 예약 탐색 시점을 현재 시점 기준 2주 뒤에서 -> 1주 뒤로 변경
- 수업 시간 가능 시간 변경후 변경 적용 날짜가 되었음에도 currentSchedule의 응답으로 null이 넘어와 scheduleChanges를 나타나게 화면이 죽는 버그 수정(특정 시간이 되면 currentSchdule에 scheduleChanges의 데이터로 치환될 것으로 예상되어 미리 schedulechanges를 보여주는 방식)
