### PR TITLE
[FLIZ-404/user] fix: 알림 페이지 Header SSR bugfix

### DIFF
--- a/apps/user/app/notification/layout.tsx
+++ b/apps/user/app/notification/layout.tsx
@@ -1,5 +1,3 @@
-import Header from "@ui/components/Header";
-
 import { requireAuth } from "@user/utils/auth";
 
 import NotificationProvider from "./_components/NotificationProvdier";
@@ -12,9 +10,6 @@ async function NotificationLayout({ children }: NotificationLayoutProps) {
 
   return (
     <>
-      <Header>
-        <Header.Title content="알림" />
-      </Header>
       <NotificationProvider>{children}</NotificationProvider>
     </>
   );

--- a/apps/user/app/notification/page.tsx
+++ b/apps/user/app/notification/page.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import Header from "@ui/components/Header";
 import { Suspense } from "react";
 
 export const dynamic = "force-dynamic";
@@ -7,11 +10,16 @@ import NotificationContainer from "./_components/NotificationContainer";
 
 function NotificationPage() {
   return (
-    <main className="h-full w-full">
-      <Suspense fallback={<Fallback />}>
-        <NotificationContainer />
-      </Suspense>
-    </main>
+    <>
+      <Header>
+        <Header.Title content="알림" />
+      </Header>
+      <main className="h-full w-full">
+        <Suspense fallback={<Fallback />}>
+          <NotificationContainer />
+        </Suspense>
+      </main>
+    </>
   );
 }
 


### PR DESCRIPTION
# [FLIZ-404/user] fix: 알림 페이지 Header SSR bugfix

## 📝 작업 내용

@5unwan/user 앱 notification 페이지 진입 시 다음과 같은 에러가 발생했습니다
```
Uncaught Error: Could not find the module "/Users/yongjae/Documents/projects/5unwan-fe/packages/ui/src/components/Header.tsx#default#Title" in the React Client Manifest. This is probably a bug in the React Server Components bundler.
```

해당 에러 발생 이유는 다음과 같습니다.

RSC (notification/layout.tsx)에서 Client component (Header.tsx)를 import 하여 Client component의 internal component (Header.Title)를 사용하려고 했습니다.

**RSC가 Client Component를 import할 수 있는 조건은 다음과 같습니다**
 - Client Component의 default export를 import + render할 수 있습니다
 - Client Component의 내부 컴포넌트 (property), nested export, named export를 사용할 수 없습니다

> 참고
> 1. 빌드 시 번들러는 Server build / Client build를 분리해서 만듭니다
> 2. 그리고 빌드 중에 Next.js는 server / client manifest (모듈 이름 및 export를 명세하는 JSON 파일)를 만듭니다. 이때, server에서 접근하는 Client Component들은 default export만 명세됩니다)
> 3. Server runtime에 렌더링을 진행합니다. RSC의 경우 직접 실행하며, Client Component를 만날 경우, client manifest를 확인하고 reference만 설정합니다 (직접 호출 x)
> 4. 클라이언트에서 Hydration을 진행합니다

> 지금의 경우, server runtime에서 client manifest에 nested export인 Header.Title를 찾지 못하여 Header.tsx#default#Title 모듈을 찾지 못했다는 에러가 발생했습니다.


위 에러를 해결하기 위해 Header import 및 render 로직을 page.tsx(RSC)로 이전했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
