### PR TITLE
[FLIZ-406/user] feat: 트레이너 예약 현황 정보를 회원 도메인 예약 페이지의 timeSelector에 반영

### DIFF
--- a/apps/user/app/schedule-management/_utils/timeCellGenerator.ts
+++ b/apps/user/app/schedule-management/_utils/timeCellGenerator.ts
@@ -1,0 +1,77 @@
+import { DayOfWeek } from "@5unwan/core/api/types/common";
+import { TimeCell } from "@ui/utils/timeCellUtils";
+import { format } from "date-fns";
+
+import { TrainerAvailableTimesApiResponse } from "@user/services/types/myInformation.dto";
+import { ReservationStatusApiResponse } from "@user/services/types/reservations.dto";
+
+import { RequestReservationMode } from "@user/app/schedule-management/reservation/[mode]/types/requestReservation";
+
+import {
+  getInactiveTrainerReservationStatus,
+  isTimeReserved,
+  isUserHasReservation,
+  isWithinEditTimeLimit,
+  isOutsideSchedule,
+} from "./trainerReservationStatusConverter";
+
+export const generateIntegratedTimeCells = (
+  selectedDate: Date,
+  trainerAvailableTimes: TrainerAvailableTimesApiResponse["data"],
+  inactiveReservations: ReturnType<typeof getInactiveTrainerReservationStatus>,
+  userReservations: ReservationStatusApiResponse["data"],
+  mode: RequestReservationMode,
+): TimeCell[] => {
+  const dayOfWeek = format(selectedDate, "EEEE").toUpperCase() as DayOfWeek;
+
+  // dayOffs 배열에서 휴무일 체크 (O 대문자 주의)
+  const dayOffs: string[] = trainerAvailableTimes?.dayOffs ?? [];
+  const selectedDateString = format(selectedDate, "yyyy-MM-dd");
+  const isDayoff = dayOffs.includes(selectedDateString);
+
+  // 기본 스케줄 정보 찾기
+  const scheduleInfo = trainerAvailableTimes?.currentSchedules?.schedules?.find(
+    ({ dayOfWeek: scheduleDay }: { dayOfWeek: string }) => scheduleDay === dayOfWeek,
+  );
+
+  const isHoliday = scheduleInfo?.isHoliday || false;
+  const startTime = scheduleInfo?.startTime;
+  const endTime = scheduleInfo?.endTime;
+  const startHour = startTime ? parseInt(startTime.split(":")[0], 10) : undefined;
+  const endHour = endTime ? parseInt(endTime.split(":")[0], 10) : undefined;
+
+  const hasUserReservation = isUserHasReservation(selectedDate, userReservations);
+
+  const HOURS_IN_DAY = 24;
+  const PAD_LENGTH = 2;
+
+  return Array.from({ length: HOURS_IN_DAY }, (_, hour) => {
+    const time = `${hour.toString().padStart(PAD_LENGTH, "0")}:00`;
+
+    // 휴무일이면 무조건 disabled
+    if (isDayoff) {
+      return { dayOfWeek, time, disabled: true };
+    }
+
+    // 기본 스케줄 제약
+    const isDisabledBySchedule = isHoliday || isOutsideSchedule(hour, startHour, endHour);
+
+    // 예약된 시간인 경우
+    const isReserved = isTimeReserved(selectedDate, time, inactiveReservations);
+
+    // 사용자 기존 예약이 있는 경우
+    const isDisabledByUserReservation = hasUserReservation;
+
+    // 편집 모드 시간 제한
+    const isDisabledByEditLimit = isWithinEditTimeLimit(selectedDate, time, mode);
+
+    const disabled =
+      isDisabledBySchedule || isReserved || isDisabledByUserReservation || isDisabledByEditLimit;
+
+    return {
+      dayOfWeek,
+      time,
+      disabled,
+    };
+  });
+};

--- a/apps/user/app/schedule-management/_utils/trainerReservationStatusConverter.ts
+++ b/apps/user/app/schedule-management/_utils/trainerReservationStatusConverter.ts
@@ -1,0 +1,111 @@
+import { format } from "date-fns";
+
+import { TrainerReservationStatusApiResponse } from "@user/services/types/reservations.dto";
+
+export const getInactiveTrainerReservationStatus = (
+  trainerReservationStatus: TrainerReservationStatusApiResponse["data"],
+): { [month: string]: { [day: string]: [string, string] } } => {
+  const sortedTrainerReservationStatus = trainerReservationStatus.sort(
+    (a, b) => new Date(a.reservationDates[0]).getTime() - new Date(b.reservationDates[0]).getTime(),
+  );
+
+  const filteredTrainerReservationStatus = sortedTrainerReservationStatus.filter(
+    (reservationStatus) => {
+      switch (reservationStatus.status) {
+        case "예약 대기":
+        case "예약 취소":
+        case "예약 거절":
+        case "예약 종료":
+          return false;
+        default:
+          return true;
+      }
+    },
+  );
+
+  return filteredTrainerReservationStatus.reduce(
+    (acc, filteredReservationStatus) => {
+      const month = filteredReservationStatus.reservationDates[0].split("-")[1];
+      const day = filteredReservationStatus.reservationDates[0].split("-")[2].split("T")[0];
+      const time = filteredReservationStatus.reservationDates[0]
+        .split("-")[2]
+        .split("T")[1]
+        .split(":")[0];
+      const dayOfWeek = getDayOfWeek(filteredReservationStatus.reservationDates[0]);
+
+      if (!acc[month]) {
+        acc[month] = {};
+      }
+
+      acc[month][day] = [dayOfWeek, time];
+
+      return acc;
+    },
+    {} as { [month: string]: { [day: string]: [string, string] } },
+  );
+};
+
+const getDayOfWeek = (dateString: string): string => {
+  const date = new Date(dateString);
+  const days = ["SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY"];
+
+  return days[date.getDay()];
+};
+
+// 휴무일 체크 함수
+export const isDateInDayoff = (date: Date, dayoffDates: string[]): boolean => {
+  const dateString = format(date, "yyyy-MM-dd");
+
+  return dayoffDates.includes(dateString);
+};
+
+// 예약된 시간 체크 함수
+export const isTimeReserved = (
+  date: Date,
+  time: string,
+  inactiveReservations: ReturnType<typeof getInactiveTrainerReservationStatus>,
+): boolean => {
+  const month = format(date, "MM");
+  const day = format(date, "dd");
+  const hour = time.split(":")[0];
+
+  const monthData = inactiveReservations[month];
+  if (!monthData) return false;
+
+  const dayData = monthData[day];
+  if (!dayData) return false;
+
+  return dayData[1] === hour;
+};
+
+// 사용자 기존 예약 체크 함수
+export const isUserHasReservation = (
+  date: Date,
+  userReservations: Array<{ reservationDates: string[] }>,
+): boolean => {
+  const dateString = format(date, "yyyy-MM-dd");
+
+  return userReservations.some(
+    (reservation) => reservation.reservationDates[0].split("T")[0] === dateString,
+  );
+};
+
+// 편집 모드 시간 제한 체크 함수
+export const isWithinEditTimeLimit = (date: Date, time: string, mode: string): boolean => {
+  if (mode !== "edit") return false;
+
+  const currentDate = new Date();
+  const currentHour = currentDate.getHours();
+  const selectedHour = parseInt(time.split(":")[0], 10);
+  const MIN_HOURS_BEFORE_EDIT = 1;
+
+  return (
+    date.toDateString() === currentDate.toDateString() &&
+    selectedHour - currentHour <= MIN_HOURS_BEFORE_EDIT
+  );
+};
+
+// 기본 스케줄 제약 체크 함수
+export const isOutsideSchedule = (hour: number, startHour?: number, endHour?: number): boolean => {
+  return startHour === undefined || endHour === undefined || hour < startHour || hour > endHour;
+};

--- a/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/index.tsx
+++ b/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/index.tsx
@@ -1,7 +1,11 @@
+/* eslint-disable no-magic-numbers */
 "use client";
 
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { useState } from "react";
+
+import { reservationQueries } from "@user/queries/reservation";
 
 import { RequestReservationMode } from "@user/app/schedule-management/reservation/[mode]/types/requestReservation";
 
@@ -23,10 +27,16 @@ function ReservationContainer({
 }: ReservationContainerProps) {
   const searchParams = useSearchParams();
   const dateParam = searchParams.get("selectedDate");
+  const currentDate = new Date();
+  const today = `${currentDate.getFullYear()}-0${currentDate.getMonth() + 1}-${currentDate.getDate()}`;
 
   const [selectedDate, setSelectedDate] = useState<Date>(
     reservationDate ? new Date(reservationDate) : new Date(dateParam || Date.now()),
   );
+
+  const { data: trainerReservationStatus } = useSuspenseQuery({
+    ...reservationQueries.trainerReservationStatus(today),
+  });
 
   return (
     <section className="flex h-full w-full flex-col overflow-hidden">
@@ -36,6 +46,7 @@ function ReservationContainer({
         selectedDate={selectedDate}
         reservationDateTime={reservationDateTime}
         firstDayOfMonthKorea={firstDayOfMonthKorea}
+        trainerReservationStatus={trainerReservationStatus?.data}
       />
     </section>
   );

--- a/apps/user/app/schedule-management/reservation/[mode]/page.tsx
+++ b/apps/user/app/schedule-management/reservation/[mode]/page.tsx
@@ -2,9 +2,12 @@
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import { startOfMonth, addHours, format } from "date-fns";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 
 import { myInformationQueries } from "@user/queries/myInformation";
 import { reservationQueries } from "@user/queries/reservation";
+
+import LoadingFallback from "@user/components/Fallback/LoadingFallback";
 
 import Header from "./_components/Header";
 import ReservationContainer from "./_components/ReservationContainer";
@@ -47,12 +50,14 @@ async function Reservation({ params, searchParams }: ReservationParams) {
     <main className="flex h-full flex-col items-center overflow-hidden">
       <HydrationBoundary state={dehydrate(queryClient)}>
         <Header mode={mode} />
-        <ReservationContainer
-          mode={mode}
-          reservationDate={reservationDate}
-          reservationDateTime={reservationDateTime}
-          firstDayOfMonthKorea={firstDayOfMonthKorea}
-        />
+        <Suspense fallback={<LoadingFallback />}>
+          <ReservationContainer
+            mode={mode}
+            reservationDate={reservationDate}
+            reservationDateTime={reservationDateTime}
+            firstDayOfMonthKorea={firstDayOfMonthKorea}
+          />
+        </Suspense>
       </HydrationBoundary>
     </main>
   );

--- a/apps/user/queries/reservation.ts
+++ b/apps/user/queries/reservation.ts
@@ -1,11 +1,17 @@
 import { queryOptions } from "@tanstack/react-query";
 
-import { getReservationDetailStatus, getReservationStatus } from "@user/services/reservations";
+import {
+  getReservationDetailStatus,
+  getReservationStatus,
+  getTrainerReservationStatus,
+} from "@user/services/reservations";
 
 export const baseReservationKeys = {
   all: () => ["reservations"] as const,
   lists: () => [...baseReservationKeys.all(), "list"] as const,
   details: () => [...baseReservationKeys.all(), "detail"] as const,
+  trainerReservationStatus: () =>
+    [...baseReservationKeys.all(), "trainerReservationStatus"] as const,
 };
 
 export const reservationQueries = {
@@ -18,5 +24,10 @@ export const reservationQueries = {
     queryOptions({
       queryKey: [...baseReservationKeys.details(), reservationId],
       queryFn: () => getReservationDetailStatus({ reservationId }),
+    }),
+  trainerReservationStatus: (date: string) =>
+    queryOptions({
+      queryKey: [...baseReservationKeys.trainerReservationStatus(), date],
+      queryFn: () => getTrainerReservationStatus({ date }),
     }),
 };

--- a/apps/user/services/reservations.ts
+++ b/apps/user/services/reservations.ts
@@ -12,12 +12,20 @@ import {
   ReservationDetailStatusRequestPath,
   ReservationStatusApiResponse,
   ReservationStatusRequestQuery,
+  TrainerReservationStatusApiResponse,
+  TrainerReservationStatusPathParams,
 } from "./types/reservations.dto";
 
 const RESERVATION_BASE_URL = "reservations";
 
 export const getReservationStatus = ({ date }: ReservationStatusRequestQuery) =>
   http.get<ReservationStatusApiResponse>({ url: `/v1/${RESERVATION_BASE_URL}`, params: { date } });
+
+export const getTrainerReservationStatus = ({ date }: TrainerReservationStatusPathParams) =>
+  http.get<TrainerReservationStatusApiResponse>({
+    url: `/v1/${RESERVATION_BASE_URL}/trainers`,
+    params: { date },
+  });
 
 export const getReservationDetailStatus = ({ reservationId }: ReservationDetailStatusRequestPath) =>
   http.get<ReservationDetailStatusApiResponse>({

--- a/apps/user/services/types/myInformation.dto.ts
+++ b/apps/user/services/types/myInformation.dto.ts
@@ -97,5 +97,6 @@ type TrainerAvailableTimesResponse = {
     applyAt: string;
     schedules: AvailablePtTime[];
   };
+  dayOffs: string[];
 };
 export type TrainerAvailableTimesApiResponse = ResponseBase<TrainerAvailableTimesResponse>;

--- a/apps/user/services/types/reservations.dto.ts
+++ b/apps/user/services/types/reservations.dto.ts
@@ -7,11 +7,25 @@ import {
   ResponseBase,
 } from "@5unwan/core/api/types/common";
 
+type NullableMemberInfo = { [K in keyof BaseMemberInfo]: BaseMemberInfo[K] | null };
+
 export type ReservationStatusRequestQuery = {
   date?: string;
 };
 type ReservationStatusResponse = BaseReservationListItem[];
 export type ReservationStatusApiResponse = ResponseBase<ReservationStatusResponse>;
+
+export type TrainerReservationStatusPathParams = {
+  date: string;
+};
+type TrainerReservationStatusResponse = Omit<
+  BaseReservationListItem,
+  "sessionInfoId" | "memberInfo"
+> & {
+  sessionInfoId: number | null;
+  memberInfo: NullableMemberInfo;
+};
+export type TrainerReservationStatusApiResponse = ResponseBase<TrainerReservationStatusResponse>;
 
 export type ReservationDetailStatusRequestPath = ReservationPathParams;
 type ReservationDetailStatusResponse = BaseReservationDetail<

--- a/apps/user/services/types/reservations.dto.ts
+++ b/apps/user/services/types/reservations.dto.ts
@@ -18,13 +18,13 @@ export type ReservationStatusApiResponse = ResponseBase<ReservationStatusRespons
 export type TrainerReservationStatusPathParams = {
   date: string;
 };
-type TrainerReservationStatusResponse = Omit<
+type TrainerReservationStatusResponse = (Omit<
   BaseReservationListItem,
   "sessionInfoId" | "memberInfo"
 > & {
   sessionInfoId: number | null;
   memberInfo: NullableMemberInfo;
-};
+})[];
 export type TrainerReservationStatusApiResponse = ResponseBase<TrainerReservationStatusResponse>;
 
 export type ReservationDetailStatusRequestPath = ReservationPathParams;


### PR DESCRIPTION
## 📝 작업 내용

#### 트레이너 예약 현황 정보를 회원 도메인 예약 페이지의 timeSelector에 반영
- 트레이너의 예약 현황 정보를 불러오기 위한 인터페이스와 API 함수, 쿼리 작성
- 트레이너 예약 현황 정보를 view에 반영하기 위한 컨버터 작성
- 예약 페이지의 timeSelector에 비활/활성화된 시간을 반영하기 위한 generator 함수 작성

트레이너의 휴무일, 수업 가능시간, 이미 수업 확정된 시간이 반영되어 disabled, enabled 처리가 되었습니다.

주석은 테스트를 하루 앞둔 상황에서 이슈 발생시 빠르게 로직 수정을 하기 위해 일부러 남겨두었습니다.