### PR TITLE
[FLIZ-408/trainer] style: 트레이너 캘린더 시간 및 타임 블록내 텍스트 스타일 수정

### DIFF
--- a/apps/trainer/app/schedule-management/_components/Calendar/DayColumn.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/DayColumn.tsx
@@ -19,7 +19,7 @@ export default function DayColumn({ children, isDayOff, ptAvailableTime, date }:
   return (
     <div
       className={cn(
-        "relative flex h-full w-full snap-start flex-col gap-[0.0625rem]",
+        "relative flex h-full w-full min-w-0 max-w-full snap-start flex-col gap-[0.0625rem]",
         (ptTimeInformation?.isHoliday || isDayOff) &&
           "bg-background-sub2 z-10 h-auto cursor-not-allowed items-center justify-center gap-0",
       )}

--- a/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
@@ -143,14 +143,18 @@ export default function TimeBlock({
           <div
             onClick={handleClickBlock}
             className={cn(
-              "bg-background-sub1 md:hover:bg-background-sub2 text-text-primary relative flex h-[3.9375rem] w-full cursor-pointer flex-col items-center justify-center gap-1 rounded-[0.125rem] p-1",
+              "bg-background-sub1 md:hover:bg-background-sub2 text-text-primary relative flex h-[3.9375rem] w-full min-w-0 max-w-full flex-shrink-0 cursor-pointer flex-col items-center justify-center gap-1 overflow-hidden rounded-[0.125rem] p-1",
               isToday(date) && "bg-background-sub3 md:hover:bg-background-sub4",
               reservationBlockStyle,
             )}
             {...props}
           >
-            <span className="text-body-2 whitespace-pre-line">{reservationBlockContent}</span>
-            <span className="text-body-5">{reservationBlockPtStatus}</span>
+            <span className="text-body-2 w-full overflow-hidden text-ellipsis whitespace-nowrap text-center">
+              {reservationBlockContent}
+            </span>
+            <span className="text-body-5 w-full overflow-hidden text-ellipsis whitespace-nowrap text-center">
+              {reservationBlockPtStatus}
+            </span>
             {isNotificationRead && (
               <span className="bg-notification absolute right-1 top-1 h-[4px] w-[4px] rounded-full" />
             )}
@@ -169,7 +173,7 @@ export default function TimeBlock({
       ) : (
         <div
           className={cn(
-            "bg-background-sub2 text-text-primary relative flex h-[3.9375rem] w-full cursor-not-allowed flex-col items-center justify-center gap-1 rounded-[0.125rem] p-1",
+            "bg-background-sub2 text-text-primary relative flex h-[3.9375rem] w-full min-w-0 max-w-full flex-shrink-0 cursor-not-allowed flex-col items-center justify-center gap-1 overflow-hidden rounded-[0.125rem] p-1",
             isToday(date) && "bg-background-sub3 md:hover:bg-background-sub4",
             reservationBlockStyle,
           )}

--- a/apps/trainer/app/schedule-management/_components/Calendar/TimeColumn.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/TimeColumn.tsx
@@ -8,13 +8,13 @@ export default function TimeColumn() {
 
     time.setHours(idx, ZERO_TIME, ZERO_TIME, ZERO_TIME);
 
-    return format(time, "HH:mm");
+    return format(time, "HH");
   });
 
   return (
-    <div className="text-body-4 bg-background-primary text-text-primary left-0 z-10 mr-2 flex h-max flex-col gap-[0.0625rem]">
+    <div className="text-body-4 bg-background-primary text-text-primary left-0 z-10 flex h-max flex-col gap-[0.0625rem]">
       {TimeCoulmns.map((time) => (
-        <div className=" flex h-[3.9375rem] w-[2.625rem] justify-end font-mono" key={time}>
+        <div className="flex h-[3.9375rem] justify-end font-mono" key={time}>
           {time}
         </div>
       ))}

--- a/apps/trainer/app/schedule-management/_components/Calendar/index.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/index.tsx
@@ -104,7 +104,7 @@ function Calendar() {
         <div className="flex h-full w-full">
           <div
             ref={timeColumnRef}
-            className="mr-2 h-full w-fit overflow-y-scroll [&::-webkit-scrollbar]:hidden"
+            className="mr-1.5 h-full w-fit overflow-y-scroll [&::-webkit-scrollbar]:hidden"
           >
             <TimeColumn />
           </div>


### PR DESCRIPTION
## 📝 작업 내용

#### 트레이너 캘린더 시간 및 타임 블록내 텍스트 스타일 수정
- 트레이너 캘린더 타임 블록내 텍스트가 길어지면 말줄임 표시(...)
- 트레이너 캘린더의 시간 텍스트 00:00 -> 00으로 변경

요런 느낌(IPhone SE 버전)

<img width="350" alt="image" src="https://github.com/user-attachments/assets/07b3b054-9997-4b18-a5f7-e79d9d006a03" />


