### PR TITLE
[FLIZ-410/trainer] feat: BottomSheet List업 관련 각 페이지 초기로만 설정

### DIFF
--- a/apps/trainer/.env
+++ b/apps/trainer/.env
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_DEV_API_BASE_URL=https://dev.api.fitlink.biz
+NEXT_PUBLIC_PROD_API_BASE_URL=https://dev.api.fitlink.biz
+NEXT_PUBLIC_FCM_VAPID_KEY=BPoeWkcB8llePaosmRm4Ep9LBEM_cywYLtq21z4a7_WzSHlwA07sPBlynS0IR0or9Ozkpn3xw3rbLGm7YzZNgw4
+NEXT_PUBLIC_BASE_URL=https://dev.trainer.fitlink.biz

--- a/apps/trainer/app/schedule-management/_components/Calendar/WeekRow.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/WeekRow.tsx
@@ -43,26 +43,6 @@ export default function WeekRow({
 
   if (!reservationInformation || isLoading) return null;
 
-  console.log(
-    "예약 데이터 체크:",
-    reservationInformation.data.sort((a, b) => {
-      const aDate = new Date(a.reservationDates[0]);
-      const bDate = new Date(b.reservationDates[0]);
-
-      return aDate.getTime() - bDate.getTime();
-    }),
-  );
-
-  console.log(
-    "컨버팅 된 예약 데이터 체크->",
-    filterLatestReservationsByDate(reservationInformation.data).sort((a, b) => {
-      const aDate = new Date(a.reservationDates[0]);
-      const bDate = new Date(b.reservationDates[0]);
-
-      return aDate.getTime() - bDate.getTime();
-    }),
-  );
-
   return (
     <div className="flex h-full gap-[0.125rem]">
       {week.map((date) => (

--- a/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/index.tsx
+++ b/apps/trainer/app/schedule-management/pending-reservations/_components/PendingReservationContainer/index.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { useQuery } from "@tanstack/react-query";
 import { addHours, format } from "date-fns";
 import { useState } from "react";
@@ -14,18 +15,15 @@ import MemberCardList from "./MemberCardList";
 type PendingReservationContainerProps = {
   formattedAdjustedDate: string;
   selectedDate: string;
-  emptyErrorCheckSelectedDate: Date;
+  emptyErrorCheckSelectedDate?: Date;
 };
 
 function PendingReservationContainer({
   formattedAdjustedDate,
   selectedDate,
-  emptyErrorCheckSelectedDate,
 }: PendingReservationContainerProps) {
   const [selectedMemberInformation, setSelectedMemberInformation] =
     useState<ReservationDetailPendingStatus | null>(null);
-
-  console.log("쿼리파람 SelectedDate 체크:", emptyErrorCheckSelectedDate);
 
   const NINE_HOURS = 9;
   const isProduction = process.env.NODE_ENV === "production";
@@ -37,8 +35,6 @@ function PendingReservationContainer({
   const { data: reservationPendingList, isLoading } = useQuery(
     reservationQueries.pendingDetail(formattedDate),
   );
-
-  console.log("예약 대기 리스트 확인용 콘솔:", reservationPendingList);
 
   return (
     <section className="flex h-full w-full flex-col overflow-hidden pt-[1.688rem]">

--- a/apps/trainer/app/schedule-management/pending-reservations/page.tsx
+++ b/apps/trainer/app/schedule-management/pending-reservations/page.tsx
@@ -24,7 +24,6 @@ async function PendingReservations({ searchParams }: PendingReservationsProps) {
     <main className="flex h-full flex-col">
       <Header />
       <PendingReservationContainer
-        emptyErrorCheckSelectedDate={selectedDate}
         formattedAdjustedDate={formattedAdjustedDate}
         selectedDate={koreanDateTimeFormat}
       />

--- a/apps/trainer/components/Providers/FooterProvider.tsx
+++ b/apps/trainer/components/Providers/FooterProvider.tsx
@@ -9,25 +9,18 @@ import RouteInstance from "@trainer/constants/route";
 import BottomNavigation from "../BottomNavigation";
 
 const PATHS = {
-  WITH_FOOTER: [
+  WITH_FOOTER: new Set([
     RouteInstance["schedule-management"](),
     RouteInstance["member-management"](),
     RouteInstance.notification(),
     RouteInstance["my-page"](),
-  ],
-  WITHOUT_FOOTER: [
-    RouteInstance.register(),
-    RouteInstance["sns-verification"](),
-    RouteInstance.login(),
-  ],
+  ]),
 };
 
-const doesPathNeedFooter = (pathName: string) =>
-  PATHS.WITH_FOOTER.some((route) => pathName.startsWith(route));
+const doesPathNeedFooter = (pathName: string) => PATHS.WITH_FOOTER.has(pathName);
 
 function FooterProvider({ children }: { children: React.ReactNode }) {
   const pathName = usePathname();
-
   const hasFooter = doesPathNeedFooter(pathName);
 
   return (

--- a/apps/trainer/lib/firebaseMessaging.ts
+++ b/apps/trainer/lib/firebaseMessaging.ts
@@ -34,8 +34,6 @@ export async function getDeviceToken() {
       vapidKey: process.env.NEXT_PUBLIC_FCM_VAPID_KEY,
     });
     if (token) {
-      console.log(token);
-
       return token;
     }
   } catch {

--- a/apps/user/.env
+++ b/apps/user/.env
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_DEV_API_BASE_URL=https://dev.api.fitlink.biz
+NEXT_PUBLIC_PROD_API_BASE_URL=https://dev.api.fitlink.biz
+NEXT_PUBLIC_FCM_VAPID_KEY=BPoeWkcB8llePaosmRm4Ep9LBEM_cywYLtq21z4a7_WzSHlwA07sPBlynS0IR0or9Ozkpn3xw3rbLGm7YzZNgw4
+NEXT_PUBLIC_BASE_URL=https://dev.user.fitlink.biz

--- a/apps/user/app/my-page/my-information/verify-phone/_components/VerificationPhoneContainer.tsx
+++ b/apps/user/app/my-page/my-information/verify-phone/_components/VerificationPhoneContainer.tsx
@@ -20,7 +20,6 @@ export default function VerificationPhoneContainer({
   const linkRef = useRef<HTMLAnchorElement>(null);
 
   const handleButtonClick = () => {
-    console.log("click");
     linkRef.current?.setAttribute(
       "href",
       `sms:verification@fitlink.biz?body=${generateSnsBody(verificationToken)}`,

--- a/apps/user/components/Providers/FooterProvider.tsx
+++ b/apps/user/components/Providers/FooterProvider.tsx
@@ -10,15 +10,9 @@ import BottomNavigation from "../BottomNavigation";
 
 const PATHS = {
   WITH_FOOTER: new Set([
-    // RouteInstance.root(),
     RouteInstance["schedule-management"](),
     RouteInstance.notification(),
     RouteInstance["my-page"](),
-  ]),
-  WITHOUT_FOOTER: new Set([
-    RouteInstance.register(),
-    RouteInstance.login(),
-    RouteInstance["sns-verification"](),
   ]),
 };
 


### PR DESCRIPTION
## 📝 작업 내용
바텀시트를 리스트업하는 작업을 수행하였습니다.

개발 진행은 다음과 같이 진행하였습니다.
바텀시트는 무조건 각 페이지마다 루트(login 관련 제외) 에만 가지고 있습니다 (토스, 카카오 등 모든 앱에서 통일)
따라서 굳이 하나 하나 모든 페이지의 라우트를 설정해줄 필요는 없는 것으로 보이며,
없는 컴포넌트보다는 있는 컴포넌트의 개수가 현저히 적어  바텀시트를 갖고있는 컴포넌트를 기준으로 작업하였으며,
트레이너의 기존 코드를 유저쪽과 통일시켜 Set을 확인하여 값이 있을 때만 적용되도록 하였습니다.

+ 불필요한 console.log() 를 제외하였습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
