### PR TITLE
[FLIZ-411/trainer] style: bottomNavigation 우측으로 패딩값 적용된 이슈 수정

### DIFF
--- a/apps/trainer/components/Providers/FooterProvider.tsx
+++ b/apps/trainer/components/Providers/FooterProvider.tsx
@@ -9,21 +9,15 @@ import RouteInstance from "@trainer/constants/route";
 import BottomNavigation from "../BottomNavigation";
 
 const PATHS = {
-  WITH_FOOTER: [
+  WITH_FOOTER: new Set([
     RouteInstance["schedule-management"](),
     RouteInstance["member-management"](),
     RouteInstance.notification(),
     RouteInstance["my-page"](),
-  ],
-  WITHOUT_FOOTER: [
-    RouteInstance.register(),
-    RouteInstance["sns-verification"](),
-    RouteInstance.login(),
-  ],
+  ]),
 };
 
-const doesPathNeedFooter = (pathName: string) =>
-  PATHS.WITH_FOOTER.some((route) => pathName.startsWith(route));
+const doesPathNeedFooter = (pathName: string) => PATHS.WITH_FOOTER.has(pathName);
 
 function FooterProvider({ children }: { children: React.ReactNode }) {
   const pathName = usePathname();
@@ -42,8 +36,8 @@ function FooterProvider({ children }: { children: React.ReactNode }) {
         )}
       >
         {children}
-        {hasFooter && <BottomNavigation />}
       </div>
+      {hasFooter && <BottomNavigation />}
     </>
   );
 }


### PR DESCRIPTION
## 📝 작업 내용
bottomNavigation이 컨텐츠의 패딩값도 먹고있어서 수정하였습니다.
depth를 한 단계 위로 올리어 컨텐츠의 패딩값이 영향을 받지 않게 하였습니다.
한 단계 위로 올림으로써 컨텐츠와도 구분이 되는 것으로 보입니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
