### PR TITLE
[FLIZ-413/root] feat: BottomNavigation 클릭 시, 즉시 반응하도록 구현

### DIFF
--- a/apps/trainer/components/BottomNavigation.tsx
+++ b/apps/trainer/components/BottomNavigation.tsx
@@ -1,38 +1,58 @@
 import { cn } from "@ui/lib/utils";
 import { Calendar, ContactRound, UserRound } from "lucide-react";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 import RouteInstance from "@trainer/constants/route";
 
 import { NotificationBell } from "./NotificationBell";
 
-export default function BottomNavigation() {
-  const navigationItems = Object.freeze([
-    { icon: Calendar, label: "캘린더", path: RouteInstance["schedule-management"]() },
-    { icon: ContactRound, label: "회원", path: RouteInstance["member-management"]() },
-    { icon: NotificationBell, label: "알림", path: RouteInstance.notification() },
-    { icon: UserRound, label: "마이페이지", path: RouteInstance["my-page"]() },
-  ]);
+const navigationItems = Object.freeze([
+  { icon: Calendar, label: "캘린더", path: RouteInstance["schedule-management"]() },
+  { icon: ContactRound, label: "회원", path: RouteInstance["member-management"]() },
+  { icon: NotificationBell, label: "알림", path: RouteInstance.notification() },
+  { icon: UserRound, label: "마이페이지", path: RouteInstance["my-page"]() },
+]);
 
+type BottomNavigationProps = {
+  isNavigating: boolean;
+  setIsNavigating: (isNavigating: boolean) => void;
+};
+
+export default function BottomNavigation({ isNavigating, setIsNavigating }: BottomNavigationProps) {
+  const router = useRouter();
   const pathname = usePathname();
+
+  useEffect(() => {
+    router.push(pathname);
+    setIsNavigating(false);
+  }, [pathname]);
+
+  const handleNavigation = (path: string) => {
+    if (path === pathname) return;
+
+    setIsNavigating(true);
+    router.push(path);
+  };
 
   return (
     <nav className="bg-background-primary border-background-sub2 md:max-w-mobile fixed bottom-0 z-10 flex h-[5.063rem] w-full justify-around border-t">
       {navigationItems.map(({ icon: Icon, label, path }, index) => (
         <div key={`${label}-${index}`} className="flex flex-1 items-center justify-center">
-          <Link
-            href={path}
+          <button
+            onClick={() => handleNavigation(path)}
+            disabled={isNavigating}
             className={cn(
               "text-background-sub4 md:hover:text-background-sub5 flex w-12 flex-col items-center justify-center gap-1 transition-colors",
               {
                 "text-text-primary": pathname.startsWith(path),
+                "opacity-50": isNavigating && !pathname.startsWith(path),
               },
             )}
           >
             <Icon />
             <span className="text-body-5">{label}</span>
-          </Link>
+          </button>
         </div>
       ))}
     </nav>

--- a/apps/trainer/components/Providers/FooterProvider.tsx
+++ b/apps/trainer/components/Providers/FooterProvider.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from "@ui/lib/utils";
 import { usePathname } from "next/navigation";
-import React from "react";
+import React, { useState } from "react";
 
 import RouteInstance from "@trainer/constants/route";
 
@@ -30,6 +30,8 @@ function FooterProvider({ children }: { children: React.ReactNode }) {
 
   const hasFooter = doesPathNeedFooter(pathName);
 
+  const [isNavigating, setIsNavigating] = useState(false);
+
   return (
     <>
       <div
@@ -41,8 +43,10 @@ function FooterProvider({ children }: { children: React.ReactNode }) {
           },
         )}
       >
-        {children}
-        {hasFooter && <BottomNavigation />}
+        {!isNavigating && children}
+        {hasFooter && (
+          <BottomNavigation isNavigating={isNavigating} setIsNavigating={setIsNavigating} />
+        )}
       </div>
     </>
   );

--- a/apps/user/components/BottomNavigation.tsx
+++ b/apps/user/components/BottomNavigation.tsx
@@ -2,39 +2,61 @@
 
 import { cn } from "@ui/lib/utils";
 import { Calendar, UserRound } from "lucide-react";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import React from "react";
+import { usePathname, useRouter } from "next/navigation";
+import React, { useState, useEffect } from "react";
 
 import RouteInstance from "@user/constants/routes";
 
 import { NotificationBell } from "./NotificationBell";
 
-export default function BottomNavigation() {
-  const navigationItems = Object.freeze([
-    { label: "캘린더", path: RouteInstance["schedule-management"](), icon: Calendar },
-    { label: "알림", path: RouteInstance.notification(), icon: NotificationBell },
-    { label: "마이페이지", path: RouteInstance["my-page"](), icon: UserRound },
-  ]);
+type BottomNavigationProps = {
+  isNavigating: boolean;
+  setIsNavigating: (isNavigating: boolean) => void;
+};
 
+const navigationItems = Object.freeze([
+  { label: "캘린더", path: RouteInstance["schedule-management"](), icon: Calendar },
+  { label: "알림", path: RouteInstance.notification(), icon: NotificationBell },
+  { label: "마이페이지", path: RouteInstance["my-page"](), icon: UserRound },
+]);
+
+export default function BottomNavigation({ isNavigating, setIsNavigating }: BottomNavigationProps) {
+  const router = useRouter();
   const pathname = usePathname();
+
+  const [activeTab, setActiveTab] = useState(pathname);
+
+  useEffect(() => {
+    setActiveTab(pathname);
+    setIsNavigating(false);
+  }, [pathname]);
+
+  const handleNavigation = (path: string) => {
+    if (path === pathname) return;
+
+    setActiveTab(path);
+    setIsNavigating(true);
+    router.push(path);
+  };
 
   return (
     <nav className="bg-background-primary border-background-sub2 md:max-w-mobile fixed bottom-0 z-10 flex h-[5.063rem] w-full justify-around border-t">
       {navigationItems.map(({ icon: Icon, label, path }, index) => (
         <div key={`${label}-${index}`} className="flex flex-1 items-center justify-center">
-          <Link
-            href={path}
+          <button
+            onClick={() => handleNavigation(path)}
+            disabled={isNavigating}
             className={cn(
               "text-background-sub4 md:hover:text-background-sub5 flex w-12 flex-col items-center justify-center gap-1 transition-colors",
               {
-                "text-text-primary": pathname === path,
+                "text-text-primary": activeTab === path,
+                "opacity-50": isNavigating && activeTab !== path,
               },
             )}
           >
             <Icon />
             <span className="text-body-5">{label}</span>
-          </Link>
+          </button>
         </div>
       ))}
     </nav>

--- a/apps/user/components/Providers/FooterProvider.tsx
+++ b/apps/user/components/Providers/FooterProvider.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from "@ui/lib/utils";
 import { usePathname } from "next/navigation";
-import React from "react";
+import React, { useState } from "react";
 
 import RouteInstance from "@user/constants/routes";
 
@@ -28,6 +28,8 @@ function FooterProvider({ children }: { children: React.ReactNode }) {
   const pathName = usePathname();
   const hasFooter = doesPathNeedFooter(pathName);
 
+  const [isNavigating, setIsNavigating] = useState(false);
+
   return (
     <>
       <div
@@ -36,9 +38,11 @@ function FooterProvider({ children }: { children: React.ReactNode }) {
           "pb-[2.125rem]": !hasFooter,
         })}
       >
-        {children}
+        {!isNavigating && children}
       </div>
-      {hasFooter && <BottomNavigation />}
+      {hasFooter && (
+        <BottomNavigation isNavigating={isNavigating} setIsNavigating={setIsNavigating} />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## 📝 작업 내용
기존 사용자가 바텀네비게이션을 통하여 탭을 이동할 때, 반응 없이 딜레이 되다가 페이지가 변경된 후 페이지 변경 및 바텀네비게이션 활성화된 탭 색상을 즉시 변경되도록 구현하였습니다.

구현은 state 사용하여 바텀시트와 페이지가 반응하도록 구현하였습니다.

1. 레퍼런스는 토스를 참고하였으며, 탭을 누르면 화면은 지워지고 탭은 이동합니다. (반응을 통하여 사용자 경험을 향상)
2. 빈 화면에서 페이지가 불러와지며 스켈레톤이 그려짐
3. 페이지 로딩

2번에서 로딩화면을 부탁하셨으나, 잠깐의 이동에서도 로딩되는 화면이 잠깐보여 오히려 사용자에게 좀 불쾌한 느낌을 주어 로딩페이지는 과감히 삭제하였습니다.

테스트가 필요하시다면

FooterProvider.tsx 파일에

```typescript
<div className="flex h-full w-full items-center justify-center">
     <Spinner />
</div>
```

위 코드를 삽입하여 바텀시트를 이동해보시면 확인 가능합니다.



> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
