### PR TITLE
[FLIZ-415/trainer] style: 트레이너 도메인 캘린더 시간 컬럼 UI 깨짐 해결

### DIFF
--- a/apps/trainer/app/schedule-management/_components/Calendar/TimeColumn.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/TimeColumn.tsx
@@ -8,13 +8,13 @@ export default function TimeColumn() {
 
     time.setHours(idx, ZERO_TIME, ZERO_TIME, ZERO_TIME);
 
-    return format(time, "HH");
+    return format(time, "HH:mm");
   });
 
   return (
-    <div className="text-body-4 bg-background-primary text-text-primary left-0 z-10 flex h-max flex-col gap-[0.0625rem]">
+    <div className="text-body-4 bg-background-primary text-text-primary left-0 z-10 mr-2 flex h-max flex-col gap-[0.0625rem]">
       {TimeCoulmns.map((time) => (
-        <div className="flex h-[3.9375rem] justify-end font-mono" key={time}>
+        <div className="flex h-[3.9375rem] w-[2.625rem] justify-end font-mono" key={time}>
           {time}
         </div>
       ))}

--- a/apps/trainer/app/schedule-management/_components/Calendar/index.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/index.tsx
@@ -104,7 +104,7 @@ function Calendar() {
         <div className="flex h-full w-full">
           <div
             ref={timeColumnRef}
-            className="mr-1.5 h-full w-fit overflow-y-scroll [&::-webkit-scrollbar]:hidden"
+            className="mr-2 h-full w-fit overflow-y-scroll [&::-webkit-scrollbar]:hidden"
           >
             <TimeColumn />
           </div>


### PR DESCRIPTION

## 📝 작업 내용

- 트레이너 도메인 캘린더 시간 컬럼 UI 깨짐 해결

