### PR TITLE
[FLIZ-421/root] fix: FCM 서비스 워커 정책 업데이트

### DIFF
--- a/apps/trainer/hooks/useFcmListener.ts
+++ b/apps/trainer/hooks/useFcmListener.ts
@@ -21,10 +21,10 @@ export const useFcmListener = () => {
         return;
       }
       unsubscribe = onMessage(messaging, (payload) => {
-        const { notification } = payload;
-        if (!notification) return;
+        const { data } = payload;
+        if (!data) return;
 
-        const { title, body } = notification;
+        const { title, body } = data;
 
         if (title) {
           setNewNotificationTypes((prev) => {

--- a/apps/trainer/public/firebase-messaging-sw.js
+++ b/apps/trainer/public/firebase-messaging-sw.js
@@ -1,5 +1,5 @@
-importScripts('https://www.gstatic.com/firebasejs/10.13.2/firebase-app-compat.js');
-importScripts('https://www.gstatic.com/firebasejs/10.13.2/firebase-messaging-compat.js');
+importScripts("https://www.gstatic.com/firebasejs/10.13.2/firebase-app-compat.js");
+importScripts("https://www.gstatic.com/firebasejs/10.13.2/firebase-messaging-compat.js");
 
 firebase.initializeApp({
   apiKey: "AIzaSyD_VI6GiPxFmTxPYMa9N-u9zuGBgWSOltc",
@@ -8,18 +8,18 @@ firebase.initializeApp({
   storageBucket: "fit-link-ffc73.firebasestorage.app",
   messagingSenderId: "85685256147",
   appId: "1:85685256147:web:321577a3626a52b28fb926",
-  measurementId: "G-082D1TQN3S"
+  measurementId: "G-082D1TQN3S",
 });
 
 const messaging = firebase.messaging();
 
 messaging.onBackgroundMessage((payload) => {
-  const {notification} = payload;
+  const { data } = payload;
+  const { title, body } = data;
 
-  const notificationTitle = notification.title || 'Fitlink';
+  const notificationTitle = title || "Fitlink";
   const notificationOptions = {
-    body: notification.body,
-    icon: 'http://localhost:3000/icon512_rounded.png',
+    body,
   };
 
   self.registration.showNotification(notificationTitle, notificationOptions);

--- a/apps/user/hooks/useFcmListener.ts
+++ b/apps/user/hooks/useFcmListener.ts
@@ -20,12 +20,12 @@ export const useFcmListener = () => {
         return;
       }
       unsubscribe = onMessage(messaging, (payload) => {
-        const { notification } = payload;
-        if (!notification) return;
+        const { data } = payload;
+        if (!data) return;
 
         setHasNewNotifications(true);
 
-        const { title, body } = notification;
+        const { title, body } = data;
 
         const parsedBody = body
           ? parseContent(body)

--- a/apps/user/public/firebase-messaging-sw.js
+++ b/apps/user/public/firebase-messaging-sw.js
@@ -1,5 +1,5 @@
-importScripts('https://www.gstatic.com/firebasejs/10.13.2/firebase-app-compat.js');
-importScripts('https://www.gstatic.com/firebasejs/10.13.2/firebase-messaging-compat.js');
+importScripts("https://www.gstatic.com/firebasejs/10.13.2/firebase-app-compat.js");
+importScripts("https://www.gstatic.com/firebasejs/10.13.2/firebase-messaging-compat.js");
 
 firebase.initializeApp({
   apiKey: "AIzaSyD_VI6GiPxFmTxPYMa9N-u9zuGBgWSOltc",
@@ -8,18 +8,18 @@ firebase.initializeApp({
   storageBucket: "fit-link-ffc73.firebasestorage.app",
   messagingSenderId: "85685256147",
   appId: "1:85685256147:web:321577a3626a52b28fb926",
-  measurementId: "G-082D1TQN3S"
+  measurementId: "G-082D1TQN3S",
 });
 
 const messaging = firebase.messaging();
 
 messaging.onBackgroundMessage((payload) => {
-  const {notification} = payload;
-
-  const notificationTitle = notification.title || 'Fitlink';
+  const { data } = payload;
+  const { title, body } = data;
+  
+  const notificationTitle = title || "Fitlink";
   const notificationOptions = {
-    body: notification.body,
-    icon: 'http://localhost:3000/icon512_rounded.png',
+    body,
   };
 
   self.registration.showNotification(notificationTitle, notificationOptions);


### PR DESCRIPTION
# [FLIZ-421/root] fix: FCM 서비스 워커 정책 업데이트

## 📝 작업 내용

트레이너, 회원 FCM foreground, background 수신 시 payload 파싱 정책을 업데이트했습니다. payload.notification에서 payload.data로 넘어오는 알림 정보를 읽도록 수정했습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
