### PR TITLE
[FLIZ-419/user] fix: 트레이너 연동 페이지 Header 레이아웃 bugfix

### DIFF
--- a/apps/user/app/my-page/connect-trainer/_components/ConnectTrainerContainer.tsx
+++ b/apps/user/app/my-page/connect-trainer/_components/ConnectTrainerContainer.tsx
@@ -3,11 +3,5 @@ import React from "react";
 import InputOTP from "./InputOTP";
 
 export default function ConnectTrainerContainer() {
-  return (
-    <>
-      <p className="text-body-1 text-text-sub2"> 트레이너에게 받은 코드를 입력해주세요</p>
-
-      <InputOTP />
-    </>
-  );
+  return <InputOTP />;
 }

--- a/apps/user/app/my-page/connect-trainer/page.tsx
+++ b/apps/user/app/my-page/connect-trainer/page.tsx
@@ -6,9 +6,13 @@ import { commonLayoutContents } from "@user/constants/styles";
 
 import ConnectTrainerContainer from "./_components/ConnectTrainerContainer";
 
+const ConnectTrainerPageSubHeader = () => (
+  <p className="text-body-1 text-text-sub2 text-center">트레이너에게 받은 코드를 입력해주세요</p>
+);
+
 export default function Home() {
   return (
-    <HeaderProvider title="트레이너 연동" back>
+    <HeaderProvider title="트레이너 연동" back subHeader={<ConnectTrainerPageSubHeader />}>
       <main className={commonLayoutContents}>
         <ConnectTrainerContainer />
       </main>

--- a/apps/user/components/Providers/HeaderProvider.tsx
+++ b/apps/user/components/Providers/HeaderProvider.tsx
@@ -12,13 +12,21 @@ type HeaderProviderProps = {
   left?: ReactNode;
   right?: ReactNode;
   back?: boolean;
+  subHeader?: ReactNode;
 };
-function HeaderProvider({ children, title, left, right, back = false }: HeaderProviderProps) {
+function HeaderProvider({
+  children,
+  title,
+  left,
+  right,
+  subHeader,
+  back = false,
+}: HeaderProviderProps) {
   const router = useRouter();
 
   return (
     <>
-      <Header logo={<Logo />}>
+      <Header logo={<Logo />} subHeader={subHeader}>
         {back && <Header.Back onClick={router.back} />}
         {left && !back && <Header.Left>{left}</Header.Left>}
         {title && <Header.Title content={title} />}


### PR DESCRIPTION
# [FLIZ-419/user] fix: 트레이너 연동 페이지 Header 레이아웃 bugfix

## 📝 작업 내용

user 서비스 공통 레이아웃 적용 PR sideEffect로 발생한 트레이너 연동 페이지 스타일 버그를 해결했습니다

HeaderProvider에서 subHeader 렌더링 로직도 제어할 수 있도록 subHeader prop을 추가했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
