### PR TITLE
[FLIZ-422/user] feat: PT 희망시간 변경 페이지 접속 시 기존 PT 희망시간 data를 기본값으로 설정

### DIFF
--- a/apps/user/app/my-page/edit-workout-schedules/_components/EditPreferenceTimeContainer.tsx
+++ b/apps/user/app/my-page/edit-workout-schedules/_components/EditPreferenceTimeContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PreferredWorkout } from "@5unwan/core/api/types/common";
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import WorkoutForm from "@ui/components/WorkoutForm";
 import React, { useEffect, useState } from "react";
 
@@ -14,7 +14,7 @@ import useEditPreferenceTimeMutation from "../_hooks/useEditPreferenceTimeMutati
 export default function EditPreferenceTimeContainer() {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
 
-  const { data: myInformation } = useQuery(myInformationQueries.summary());
+  const { data: myInformation } = useSuspenseQuery(myInformationQueries.summary());
 
   const prevScheudle = myInformation?.data.workoutSchedules;
 
@@ -48,8 +48,10 @@ export default function EditPreferenceTimeContainer() {
         <p className="text-body-1 text-text-sub2">PT 시간 : 50분</p>
         <p className="text-body-1 text-text-sub2">PT 선택 시간은 시작 시간입니다.</p>
       </section>
-
-      <WorkoutForm onSubmit={(editedData) => handleClickOnSubmit(editedData)} />
+      <WorkoutForm
+        currentWorkout={prevScheudle}
+        onSubmit={(editedData) => handleClickOnSubmit(editedData)}
+      />
       <SuccessEditPreferenceTimeBottomSheet open={isSheetOpen} onOpenChange={setIsSheetOpen} />
       {isPending && <MyPagePending />}
     </div>

--- a/apps/user/app/my-page/edit-workout-schedules/page.tsx
+++ b/apps/user/app/my-page/edit-workout-schedules/page.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import BrandSpinner from "@ui/components/BrandSpinner";
+import React, { Suspense } from "react";
 
 import HeaderProvider from "@user/components/Providers/HeaderProvider";
 
@@ -10,7 +11,9 @@ export default async function EditWorkoutSchedules() {
   return (
     <HeaderProvider title="PT 희망 시간" back>
       <main className={commonLayoutContents}>
-        <EditPreferenceTimeContainer />
+        <Suspense fallback={<BrandSpinner />}>
+          <EditPreferenceTimeContainer />
+        </Suspense>
       </main>
     </HeaderProvider>
   );

--- a/packages/ui/src/components/WorkoutForm.tsx
+++ b/packages/ui/src/components/WorkoutForm.tsx
@@ -27,15 +27,23 @@ const generateTimeCells: (dayOfWeek: Days) => TimeCell[] = (dayOfWeek) => {
 
 type WorkoutFormProps = {
   onSubmit: (workoutSchedule: Omit<PreferredWorkout, "workoutScheduleId">[]) => void;
+  currentWorkout?: PreferredWorkout[];
 };
-function WorkoutForm({ onSubmit }: WorkoutFormProps) {
+function WorkoutForm({ onSubmit, currentWorkout }: WorkoutFormProps) {
   const [currentDay, setCurrentDay] = React.useState<Days>(Days.Monday);
-  const [workoutForm, setWorkoutForm] = React.useState([
-    ...Array.from({ length: 7 }, (_v, index) => ({
-      dayOfWeek: DAYS_OF_WEEK_MAP[index],
-      preferenceTimes: [] as string[],
-    })),
-  ]);
+  const [workoutForm, setWorkoutForm] = React.useState(() =>
+    currentWorkout
+      ? // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        currentWorkout.map(({ workoutScheduleId: _, ...dailyWorkout }) => {
+          return dailyWorkout;
+        })
+      : [
+          ...Array.from({ length: 7 }, (_v, index) => ({
+            dayOfWeek: DAYS_OF_WEEK_MAP[index],
+            preferenceTimes: [] as string[],
+          })),
+        ],
+  );
 
   const filledDays = workoutForm
     ? workoutForm.map((dayForm) => dayForm.preferenceTimes.length > EMPTY_DAY_FORM)


### PR DESCRIPTION
# [FLIZ-422/user] feat: PT 희망시간 변경 페이지 접속 시 기존 PT 희망시간 data를 기본값으로 설정

## 📝 작업 내용

개선된 UX를 위해 기존 PT희망 시간 정보를 불러와 PT 희망 시간 수정 폼에 기본값으로 설정하는 작업을 진행했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
