### PR TITLE
[FLIZ-437/user] feat: 트레이너 연동상태 표시에 트레이너 이름 추가

### DIFF
--- a/apps/user/app/my-page/_components/PTInformation/ConnectedTrainerItem.tsx
+++ b/apps/user/app/my-page/_components/PTInformation/ConnectedTrainerItem.tsx
@@ -47,7 +47,7 @@ export default function ConnectedTrainerItem({
           ) : connectingStatus === "CONNECTED" ? (
             trainerName
           ) : (
-            <span className="text-brand-primary-500 font-bold">연동 요청 상태</span>
+            <span className="text-brand-primary-500 font-bold">{trainerName}에게 연동 요청 중</span>
           )}
           {connectingStatus !== "REQUESTED" && <Icon name="ChevronRight" size="lg" />}
         </div>


### PR DESCRIPTION
## 📝 작업 내용
주말에 나온 작업 리스트에 트레이너 연동 상태를 보여줄 시, 트레이너의 이름을 보여주면 좋을 거 같다는 의견에 트레이너 이름이 표시되도록 수정하였습니다.

<img width="503" height="453" alt="스크린샷 2025-07-20 오후 4 37 30" src="https://github.com/user-attachments/assets/6a749286-9eb0-451e-a101-dc1a1f65b6b7" />


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
