### PR TITLE
[FLIZ-436/root] fix: 트레이너 도메인 세션 수정 바텀시트 QA, 트레이너/회원 도메인 유저 role에 따른 리다이렉트 QA

### DIFF
--- a/apps/trainer/app/member-management/_components/MemberManagementContainer/PtRemainingCountEditSheet.tsx
+++ b/apps/trainer/app/member-management/_components/MemberManagementContainer/PtRemainingCountEditSheet.tsx
@@ -80,7 +80,7 @@ function PtRemainingCountEditSheet({
             <Icon name="Check" size="lg" />
           </Button>
           <SheetTitle className="whitespace-pre-line text-center">{`홍길동 회원의\n잔여 PT 횟수가 변경되었습니다`}</SheetTitle>
-          <SheetDescription>회원에게 잔여 PT {value}회 추가 알림이 전송돼요</SheetDescription>
+          <SheetDescription>회원에게 잔여 PT 횟수({value}회) 알림이 전송돼요</SheetDescription>
         </SheetHeader>
         <SheetFooter>
           <SheetClose asChild>

--- a/apps/trainer/app/member-management/_components/MemberManagementContainer/PtRemainingCountEditSheet.tsx
+++ b/apps/trainer/app/member-management/_components/MemberManagementContainer/PtRemainingCountEditSheet.tsx
@@ -12,7 +12,8 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@ui/components/Sheet";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 
 import { PtUser } from "@trainer/services/types/userManagement.dto";
 
@@ -31,12 +32,26 @@ function PtRemainingCountEditSheet({
 }: PtRemainingCountEditSheetProps) {
   const {
     memberId,
-    sessionInfo: { remainingCount, sessionInfoId },
+    sessionInfo: { remainingCount, totalCount, sessionInfoId },
   } = selectedMemberInformation;
+
+  const isSessionEditErrorFirstRender = useRef(false);
 
   const [successSheetOpen, setSuccessSheetOpen] = useState(false);
 
   const { mutate: updatePtRemainingCount, isSuccess } = useSessionCountEditMutation();
+
+  useEffect(() => {
+    if (value > totalCount) {
+      if (!isSessionEditErrorFirstRender.current) {
+        toast.error("잔여 PT 횟수는 등록 PT 횟수보다 많을 수 없습니다.");
+
+        isSessionEditErrorFirstRender.current = true;
+      }
+
+      return;
+    }
+  }, [value, totalCount]);
 
   const handleClick = () => {
     updatePtRemainingCount({
@@ -53,7 +68,7 @@ function PtRemainingCountEditSheet({
   };
 
   const checkDisabledButton = () => {
-    return value === remainingCount;
+    return value === remainingCount || value > totalCount;
   };
 
   useEffect(() => {

--- a/apps/trainer/app/member-management/_components/MemberManagementContainer/PtTotalCountEditSheet.tsx
+++ b/apps/trainer/app/member-management/_components/MemberManagementContainer/PtTotalCountEditSheet.tsx
@@ -12,7 +12,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@ui/components/Sheet";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { PtUser } from "@trainer/services/types/userManagement.dto";
@@ -35,13 +35,19 @@ function PtTotalCountEditSheet({
     sessionInfo: { totalCount, remainingCount, sessionInfoId },
   } = selectedMemberInformation;
 
+  const isSessionEditErrorFirstRender = useRef(false);
+
   const [successSheetOpen, setSuccessSheetOpen] = useState(false);
 
   const { mutate: updatePtTotalCount, isSuccess } = useSessionCountEditMutation();
 
   useEffect(() => {
     if (value < remainingCount) {
-      toast.error("등록 PT 횟수는 잔여 PT 횟수보다 작을 수 없습니다.");
+      if (!isSessionEditErrorFirstRender.current) {
+        toast.error("등록 PT 횟수는 잔여 PT 횟수보다 작을 수 없습니다.");
+
+        isSessionEditErrorFirstRender.current = true;
+      }
 
       return;
     }

--- a/apps/trainer/app/member-management/_components/MemberManagementContainer/PtTotalCountEditSheet.tsx
+++ b/apps/trainer/app/member-management/_components/MemberManagementContainer/PtTotalCountEditSheet.tsx
@@ -13,6 +13,7 @@ import {
   SheetTrigger,
 } from "@ui/components/Sheet";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 
 import { PtUser } from "@trainer/services/types/userManagement.dto";
 
@@ -31,12 +32,20 @@ function PtTotalCountEditSheet({
 }: PtTotalCountEditSheetProps) {
   const {
     memberId,
-    sessionInfo: { totalCount, sessionInfoId },
+    sessionInfo: { totalCount, remainingCount, sessionInfoId },
   } = selectedMemberInformation;
 
   const [successSheetOpen, setSuccessSheetOpen] = useState(false);
 
   const { mutate: updatePtTotalCount, isSuccess } = useSessionCountEditMutation();
+
+  useEffect(() => {
+    if (value < remainingCount) {
+      toast.error("등록 PT 횟수는 잔여 PT 횟수보다 작을 수 없습니다.");
+
+      return;
+    }
+  }, [value, remainingCount]);
 
   const handleClick = () => {
     updatePtTotalCount({
@@ -53,7 +62,7 @@ function PtTotalCountEditSheet({
   };
 
   const checkDisabledButton = () => {
-    return value === totalCount;
+    return value === totalCount || value < remainingCount;
   };
 
   useEffect(() => {
@@ -80,7 +89,7 @@ function PtTotalCountEditSheet({
             <Icon name="Check" size="lg" />
           </Button>
           <SheetTitle className="whitespace-pre-line text-center">{`홍길동 회원의\n등록 PT 횟수가 변경되었습니다`}</SheetTitle>
-          <SheetDescription>회원에게 등록 PT {value}회 추가 알림이 전송돼요</SheetDescription>
+          <SheetDescription>회원에게 등록 PT 횟수({value}회) 알림이 전송돼요</SheetDescription>
         </SheetHeader>
         <SheetFooter>
           <SheetClose asChild>

--- a/apps/trainer/components/Providers/index.tsx
+++ b/apps/trainer/components/Providers/index.tsx
@@ -3,10 +3,15 @@
 
 import { isServer, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import React from "react";
+import { useRouter } from "next/navigation";
+import React, { useEffect } from "react";
 import { Toaster, toast } from "sonner";
 
+import { authQueries } from "@trainer/queries/auth";
+
 import { useFcmListener } from "@trainer/hooks/useFcmListener";
+
+import { devTrainer, prodTrainer } from "@trainer/constants/pathname";
 
 import FooterProvider from "./FooterProvider";
 
@@ -48,6 +53,29 @@ type ProvidersProps = {
 
 function Providers({ children }: ProvidersProps) {
   const queryClient = getQueryClient();
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchUserStatus = async () => {
+      try {
+        const statusData = await queryClient.fetchQuery(authQueries.status());
+
+        if (statusData.data.userRole === "TRAINER") {
+          const urlObj = new URL(window.location.href).hostname;
+
+          if (urlObj.includes("dev.user")) {
+            router.replace(devTrainer);
+          } else if (urlObj.includes("user")) {
+            router.replace(prodTrainer);
+          }
+        }
+      } catch (error) {
+        console.error("사용자 Role 확인 실패:", error);
+      }
+    };
+
+    fetchUserStatus();
+  }, [router, queryClient]);
 
   useFcmListener();
 

--- a/apps/trainer/constants/pathname.ts
+++ b/apps/trainer/constants/pathname.ts
@@ -1,0 +1,6 @@
+const devUser = "https://dev.user.fitlink.biz/";
+const devTrainer = "https://dev.trainer.fitlink.biz/";
+const prodUser = "https://user.fitlink.biz/";
+const prodTrainer = "https://trainer.fitlink.biz/";
+
+export { devUser, devTrainer, prodUser, prodTrainer };

--- a/apps/trainer/hoc/WithBottomSheetStepper.tsx
+++ b/apps/trainer/hoc/WithBottomSheetStepper.tsx
@@ -58,6 +58,7 @@ export const WithBottomSheetStepper = (
     };
 
     const handleChangeValue = (value: number) => {
+      if (value < 0) return;
       setStep(value);
     };
 

--- a/apps/trainer/services/types/auth.dto.ts
+++ b/apps/trainer/services/types/auth.dto.ts
@@ -15,6 +15,7 @@ export type LogoutApiResponse = NoResponseData;
 
 export type GetUserVerificationStatusApiResponse = ResponseBase<{
   status: UserVerificationStatus;
+  userRole: "TRAINER" | "MEMBER";
   accessToken: string;
 }>;
 

--- a/apps/user/components/Providers/index.tsx
+++ b/apps/user/components/Providers/index.tsx
@@ -3,10 +3,15 @@
 
 import { isServer, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import React from "react";
+import { useRouter } from "next/navigation";
+import React, { useEffect } from "react";
 import { Toaster, toast } from "sonner";
 
+import { authQueries } from "@user/queries/auth";
+
 import { useFcmListener } from "@user/hooks/useFcmListener";
+
+import { devUser, prodUser } from "@user/constants/pathname";
 
 import FooterProvider from "./FooterProvider";
 
@@ -49,6 +54,29 @@ type ProvidersProps = {
 
 function Providers({ children }: ProvidersProps) {
   const queryClient = getQueryClient();
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchUserStatus = async () => {
+      try {
+        const statusData = await queryClient.fetchQuery(authQueries.status());
+
+        if (statusData.data.userRole === "MEMBER") {
+          const urlObj = new URL(window.location.href).hostname;
+
+          if (urlObj.includes("dev.trainer")) {
+            router.replace(devUser);
+          } else if (urlObj.includes("trainer")) {
+            router.replace(prodUser);
+          }
+        }
+      } catch (error) {
+        console.error("사용자 Role 확인 실패:", error);
+      }
+    };
+
+    fetchUserStatus();
+  }, [router, queryClient]);
 
   useFcmListener();
 

--- a/apps/user/constants/pathname.ts
+++ b/apps/user/constants/pathname.ts
@@ -1,0 +1,6 @@
+const devUser = "https://dev.user.fitlink.biz/";
+const devTrainer = "https://dev.trainer.fitlink.biz/";
+const prodUser = "https://user.fitlink.biz/";
+const prodTrainer = "https://trainer.fitlink.biz/";
+
+export { devUser, devTrainer, prodUser, prodTrainer };

--- a/apps/user/services/types/auth.dto.ts
+++ b/apps/user/services/types/auth.dto.ts
@@ -15,6 +15,7 @@ export type LogoutApiResponse = NoResponseData;
 
 export type GetUserVerificationStatusApiResponse = ResponseBase<{
   status: UserVerificationStatus;
+  userRole: "TRAINER" | "MEMBER";
   accessToken: string;
 }>;
 


### PR DESCRIPTION
## 📝 작업 내용

#### 트레이너 도메인 세션 수정 바텀시트 QA, 트레이너/회원 도메인 유저 role에 따른 리다이렉트 QA
- 트레이너 도메인의 회원 세션 수정 바텀시트의 Stepper 관련 QA를 적용하였습니다 -> 총 세션은 잔여 세션보다 적을 수 없다 / 잔여 세션은 총 세션보다 많을 수 없다 / 잔여세션 0 이하로 지정 X
- 양쪽 도메인 유저 role을 체크하여 url 확인 후 올바른 도메인으로 리다이렉팅