### PR TITLE
[FLIZ-439/root] style: 인증 페이지 버튼 제외한 인증 안내 영역 전체 페이지 사이즈 할당

### DIFF
--- a/packages/ui/src/components/PhoneVerification/index.tsx
+++ b/packages/ui/src/components/PhoneVerification/index.tsx
@@ -65,7 +65,7 @@ function PhoneVerification({ onClick, verificationToken }: PhoneVerificationProp
 
   return (
     <>
-      <section className="mb-4">
+      <section className="mb-4 flex flex-1 flex-col">
         <PhoneVerificationGuide />
         <PhoneVerificationImage />
         <PhoneVerificationNotice />


### PR DESCRIPTION
## 📝 작업 내용
휴대폰 인증 페이지에서 버튼이 최하단에 위치하지 않던 스타일링 이슈를 해결 하였습니다
컨테이너 역할 div에 flex flex-1을 주어 버튼을 제외한 안내하는 영역은 자동으로 남은 부분을 사이즈로 가지도록 수정하였습니다.

<img width="481" height="1130" alt="스크린샷 2025-07-20 오후 4 49 41" src="https://github.com/user-attachments/assets/8bdaad9b-ab35-442f-a0e7-84e152ad5fe3" />

<img width="706" height="686" alt="스크린샷 2025-07-20 오후 4 49 55" src="https://github.com/user-attachments/assets/4706d006-96c5-45ab-a1bc-c964d2209d2a" />

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
