### PR TITLE
[FLIZ-425/root] feat: 회원가입 문자 인증 단계에서 문자 전송 시 interval 로직 추가

### DIFF
--- a/apps/user/app/sns-verification/page.tsx
+++ b/apps/user/app/sns-verification/page.tsx
@@ -3,19 +3,26 @@
 import { useQuery } from "@tanstack/react-query";
 import PhoneVerification from "@ui/components/PhoneVerification";
 import { useRouter } from "next/navigation";
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { authQueries } from "@user/queries/auth";
 
+import { UserVerificationStatus } from "@user/services/types/auth.dto";
+
 const REFETCH_INTERVAL = 5000;
+const BUTTON_AVAILABILITY_INTERVAL = 10000;
 
 function SnsVerificationPage() {
   const router = useRouter();
 
   const [hasClicked, setHasClicked] = useState(false);
+  const [isWaitingVerification, setIsWaitingVerification] = useState(false);
+
+  const userStatusRef = useRef<UserVerificationStatus | null>(null);
 
   const handleClick = () => {
     setHasClicked(true);
+    setIsWaitingVerification(true);
   };
 
   const { data: tokenData, status: tokenStatus } = useQuery(authQueries.snsToken());
@@ -40,8 +47,21 @@ function SnsVerificationPage() {
     if (status === "REQUIRED_REGISTER") router.push("/register");
   }
 
+  useEffect(() => {
+    if (!hasClicked) return;
+
+    const intervalId = setInterval(() => {
+      if (userStatusRef.current === "REQUIRED_SMS" && isWaitingVerification) {
+        setIsWaitingVerification(false);
+      }
+    }, BUTTON_AVAILABILITY_INTERVAL);
+
+    return () => clearInterval(intervalId);
+  }, [hasClicked]);
+
   return (
     <PhoneVerification
+      isWaitingVerification={isWaitingVerification}
       onClick={handleClick}
       verificationToken={
         tokenStatus === "success" && tokenData.success

--- a/packages/ui/src/components/PhoneVerification/index.tsx
+++ b/packages/ui/src/components/PhoneVerification/index.tsx
@@ -10,10 +10,12 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } f
 import QRCodeGenerator from "../QRCodeGenerator";
 import { Text } from "../Text";
 import VerificationInfoDialog from "./VerificationInfoDialog";
+import BrandSpinner from "../BrandSpinner";
 
 type PhoneVerificationProps = {
   onClick: () => void;
   verificationToken?: string;
+  isWaitingVerification: boolean;
 };
 
 /** TODO: Utils로 추후 분리 */
@@ -40,7 +42,11 @@ const generateSnsBody = (type: "link" | "clipboard", token?: string) => {
   return `[Fitlink]${type === "clipboard" ? "\n" : "%0A"}${token}`;
 };
 
-function PhoneVerification({ onClick, verificationToken }: PhoneVerificationProps) {
+function PhoneVerification({
+  onClick,
+  verificationToken,
+  isWaitingVerification,
+}: PhoneVerificationProps) {
   const linkRef = useRef<HTMLAnchorElement>(null);
   const [isQrCodeDialogOpen, setIsQrCodeDialogOpen] = useState(false);
   const [isVerificationInfoDialogOpen, setIsVerificationInfoDialogOpen] = useState(false);
@@ -87,9 +93,9 @@ function PhoneVerification({ onClick, verificationToken }: PhoneVerificationProp
           size="xl"
           className="text-headline shirink-0 min-h-[3.375rem] w-full"
           onClick={handleButtonClick}
-          disabled={!verificationToken}
+          disabled={!verificationToken || isWaitingVerification}
         >
-          인증 메시지 보내기
+          {isWaitingVerification ? <BrandSpinner /> : "인증 메시지 보내기"}
         </Button>
       </div>
 


### PR DESCRIPTION
# [FLIZ-425/root] feat: 회원가입 문자 인증 단계에서 문자 전송 시 interval 로직 추가

## 📝 작업 내용

인증문자 전송 버튼 클릭 후 대기 UI의 부재로 UX가 저하되는 문제를 보완하기 위한 작업입니다.

문자 전송 버튼을 누르더라도 실제 문자 전송 여부는 알 수 없기 때문에 버튼 클릭 시 영원히 버튼을 disabled 처리하는 것보다, 일정 시간(10초)마다 user verification status가 업데이트되지 않았다면 button disabled 처리와 대기 UI를 보여주고 해당 시간이 지난 후에는 다시 버튼을 활성화하여 재전송을 할 수 있도록 처리했습니다


### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
