### PR TITLE
[FLIZ-440/root] fix: 스타일링 이슈 수정 및 트레이너 코드 클립보드 복사 시도 성공 유무에 따른 토스트 메시지로 안내

### DIFF
--- a/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleApplyAtStep/index.tsx
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleApplyAtStep/index.tsx
@@ -61,12 +61,7 @@ export default function EditScheduleApplyAtStep({ onPrev, onNext }: EditSchedule
           onChangeSelectedDate={handleClickChangeApplyAtDate}
         />
 
-        <Button
-          className="mb-[2.125rem] w-full"
-          size="lg"
-          variant="brand"
-          onClick={handleClickNext}
-        >
+        <Button className="w-full" size="lg" variant="brand" onClick={handleClickNext}>
           다음
         </Button>
       </div>

--- a/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleConfirmStep/index.tsx
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleConfirmStep/index.tsx
@@ -68,7 +68,7 @@ export default function EditScheduleConfirmStep({ onPrev, context }: EditSchedul
           변경하고 싶은 시간이 맞는지 확인해주세요
         </p>
 
-        <div className="bg-background-sub2 mt-[3.25rem] min-h-[3rem] w-full rounded-lg py-[1.25rem]">
+        <div className="bg-background-sub2 mt-[3.25rem] min-h-[3rem] w-full rounded-lg py-[1.25rem] text-center">
           <p className="text-subhead-1 text-text-primary">
             {availableTimes?.map((time) => (
               <p key={time.dayOfWeek}>{formatAvailableScheduleConfirm(time)}</p>
@@ -77,12 +77,7 @@ export default function EditScheduleConfirmStep({ onPrev, context }: EditSchedul
         </div>
       </div>
       <ScheduleChangeResultSheet scheduleApplyAt={applyAt}>
-        <Button
-          className="mb-[2.125rem] w-full"
-          size="lg"
-          variant="brand"
-          onClick={handleClickChangeSchedule}
-        >
+        <Button className="w-full" size="lg" variant="brand" onClick={handleClickChangeSchedule}>
           변경
         </Button>
       </ScheduleChangeResultSheet>

--- a/apps/trainer/app/my-page/my-information/_components/MyInformationContainer.tsx
+++ b/apps/trainer/app/my-page/my-information/_components/MyInformationContainer.tsx
@@ -91,7 +91,7 @@ export default function MyInformationContainer() {
         <>
           <div className="flex w-full items-center justify-center">
             <p
-              className="text-text-sub3 text-body-1 flex w-fit cursor-pointer items-center justify-center gap-2 md:hover:underline"
+              className="text-text-sub3 text-body-1 mt-4 flex w-fit cursor-pointer items-center justify-center gap-2 md:hover:underline"
               onClick={() => setIsReconnectPushDialogOpen(true)}
             >
               <HelpCircle className="h-4 w-4" />

--- a/apps/trainer/app/my-page/trainer-code/_components/TrainerCodeContainer/InputWithCopy.tsx
+++ b/apps/trainer/app/my-page/trainer-code/_components/TrainerCodeContainer/InputWithCopy.tsx
@@ -2,7 +2,8 @@
 
 import Icon from "@ui/components/Icon";
 import { Input } from "@ui/components/Input";
-import React, { ComponentProps, useRef, useState } from "react";
+import React, { ComponentProps, useRef } from "react";
+import { toast } from "sonner";
 
 type CodeInputProps = ComponentProps<"input">;
 const TRAINER_CODE_MAX_LENGTH = 6;
@@ -10,12 +11,16 @@ const TRAINER_CODE_MAX_LENGTH = 6;
 export default function InputWithCopy({ ...props }: CodeInputProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const [copied, setCopied] = useState(false);
-
   const handleClickCopy = () => {
     if (inputRef.current) {
-      setCopied(true);
-      navigator.clipboard.writeText(inputRef.current.value);
+      navigator.clipboard
+        .writeText(inputRef.current.value)
+        .then(() => {
+          toast.success("클립보드에 복사되었습니다.");
+        })
+        .catch(() => {
+          toast.error("클립보드에 복사에 실패했습니다.");
+        });
     }
   };
 
@@ -37,9 +42,6 @@ export default function InputWithCopy({ ...props }: CodeInputProps) {
           className="text-text-sub2 absolute  -right-10 top-1/2 w-[1.563rem] -translate-y-1/2  cursor-pointer "
         />
       </div>
-      {copied && (
-        <p className="text-brand-primary-500 text-body-1 mt-[2rem]">클립보드에 복사되었습니다.</p>
-      )}
     </section>
   );
 }

--- a/apps/trainer/components/Providers/FooterProvider.tsx
+++ b/apps/trainer/components/Providers/FooterProvider.tsx
@@ -15,9 +15,15 @@ const PATHS = {
     RouteInstance.notification(),
     RouteInstance["my-page"](),
   ]),
+  WITH_FOOTER_PREFIX: [RouteInstance.notification()],
 };
 
-const doesPathNeedFooter = (pathName: string) => PATHS.WITH_FOOTER.has(pathName);
+const doesPathNeedFooter = (pathName: string) => {
+  if (PATHS.WITH_FOOTER_PREFIX.some((prefix) => pathName.startsWith(prefix))) return true;
+  if (PATHS.WITH_FOOTER.has(pathName)) return true;
+
+  return false;
+};
 
 function FooterProvider({ children }: { children: React.ReactNode }) {
   const pathName = usePathname();

--- a/apps/user/app/my-page/edit-workout-schedules/_components/EditPreferenceTimeContainer.tsx
+++ b/apps/user/app/my-page/edit-workout-schedules/_components/EditPreferenceTimeContainer.tsx
@@ -43,10 +43,10 @@ export default function EditPreferenceTimeContainer() {
   }, [isSuccess]);
 
   return (
-    <div className="flex flex-1 flex-col pb-[1.5625rem]">
+    <div className="flex flex-1 flex-col">
       <section className="mt-[0.625rem] text-center">
         <p className="text-body-1 text-text-sub2">PT 시간 : 50분</p>
-        <p className="text-body-1 text-text-sub2">PT 선택 시간은 시작 시간입니다.</p>
+        <p className="text-body-1 text-text-sub2 mb-[1.875rem]">PT 선택 시간은 시작 시간입니다.</p>
       </section>
       <WorkoutForm
         currentWorkout={prevScheudle}

--- a/apps/user/app/my-page/my-information/_components/MyDetailInformations.tsx
+++ b/apps/user/app/my-page/my-information/_components/MyDetailInformations.tsx
@@ -60,7 +60,7 @@ export default function MyDetailInformations() {
         <>
           <div className="flex w-full items-center justify-center">
             <p
-              className="text-text-sub3 text-body-1 flex w-fit cursor-pointer items-center justify-center gap-2 md:hover:underline"
+              className="text-text-sub3 text-body-1 mt-4 flex w-fit cursor-pointer items-center justify-center gap-2 md:hover:underline"
               onClick={() => setIsReconnectPushDialogOpen(true)}
             >
               <HelpCircle className="h-4 w-4" />

--- a/packages/ui/src/components/PhoneVerification/index.tsx
+++ b/packages/ui/src/components/PhoneVerification/index.tsx
@@ -71,24 +71,24 @@ function PhoneVerification({
 
   return (
     <>
-      <section className="mb-4 flex flex-1 flex-col">
+      <section className="mb-4 flex flex-1 flex-col items-center">
         <PhoneVerificationGuide />
         <PhoneVerificationImage />
         <PhoneVerificationNotice />
-      </section>
-      <div className="flex w-full flex-col items-center gap-4">
         <Button
           size="md"
           corners={"pill"}
           variant={"negative"}
           iconLeft="CircleHelp"
-          className="shink-0 min-h-[2.5rem]"
+          className="shink-0 min-h-[2.5rem3 mt-8 w-fit"
           onClick={() => {
             setIsVerificationInfoDialogOpen(true);
           }}
         >
           인증 메시지 확인하기
         </Button>
+      </section>
+      <div className="flex w-full flex-col items-center gap-4">
         <Button
           size="xl"
           className="text-headline shirink-0 min-h-[3.375rem] w-full"


### PR DESCRIPTION
## 📝 작업 내용
전체적으로 앱을 탐방하면서 스타일링 및 기능을 수정하였습니다.

### 🎨 Style
* 기존 바텀네비게션을 대응하기 위해 페이지 별 하단에 패딩값이 적용되어있던 Button의 패딩 값을 제거하였습니다.
* Trainer의 PT 수업 시간 변경 시, 변경 확인 페이지에서 변경 시간이 가운데 정렬이 되지 않던 이슈를 수정하였습니다.
* 마이페이지/내 정보 에서 푸시 알림이 오지 않는 안내 문구에 상단 알림 토글 컴포넌트와 마진을 추가하였습니다.
* SNS 인증 페이지 인증 메시지 확인용 버튼을 위에 안내 문구가 적힌 컴포넌트와 위치하도록 상단으로 조절하고 마진을 주었습니다.
* User PT 희망 시간 변경 페이지에  요일 선택과 안내 문구에 마진이 없는 스타일링에 마진을 추가하였습니다.


### 🔨 Feat
* 트레이너 알림 카테고리 변경 시, 알림(root)페이지를 제외하고 연동, 미연동, PT 내역 등의 알림 조회페이지에서도 바텀네비게이션이 보일 수 있도록 FooterProvider에 PREFIX 프로퍼티를 추가하여 pathname에 notification 접두사를 가질 경우에 바텀 네비게이션이 모두 표시 되도록 수정하였습니다.
* 트레이너 코드 클립보드 복사 시, 기존 하단에 복사되었다는 안내문구가 뜨는 방식에서 Toast를 통해 유저에게 알리도록 수정하였으며, clipboard 메서드의 성공 유무에 따른 알람이 표시되도록 수정하였습니다.


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
