### PR TITLE
[FLIZ-441/root] fix: 가입한 도메인에 맞지 않은 계정으로 로그인하거나, 인증에 실패할 경우 리다이렉트 로직 구현

### DIFF
--- a/apps/trainer/components/Providers/index.tsx
+++ b/apps/trainer/components/Providers/index.tsx
@@ -3,10 +3,15 @@
 
 import { isServer, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import React from "react";
+import { usePathname, useRouter } from "next/navigation";
+import React, { useEffect, useMemo } from "react";
 import { Toaster, toast } from "sonner";
 
+import { authQueries } from "@trainer/queries/auth";
+
 import { useFcmListener } from "@trainer/hooks/useFcmListener";
+
+import { devUser, prodUser } from "@trainer/constants/pathname";
 
 import FooterProvider from "./FooterProvider";
 
@@ -47,30 +52,34 @@ type ProvidersProps = {
 };
 
 function Providers({ children }: ProvidersProps) {
-  const queryClient = getQueryClient();
-  // const router = useRouter();
+  const queryClient = useMemo(() => getQueryClient(), []);
+  const router = useRouter();
+  const pathname = usePathname();
 
-  // useEffect(() => {
-  //   const fetchUserStatus = async () => {
-  //     try {
-  //       const statusData = await queryClient.fetchQuery(authQueries.status());
+  useEffect(() => {
+    const domainUrl = new URL(window.location.href).hostname;
 
-  //       if (statusData.data.userRole === "TRAINER") {
-  //         const urlObj = new URL(window.location.href).hostname;
+    (async () => {
+      try {
+        const userRole = await queryClient.fetchQuery(authQueries.status());
 
-  //         if (urlObj.includes("dev.user")) {
-  //           router.replace(devTrainer);
-  //         } else if (urlObj.includes("user")) {
-  //           router.replace(prodTrainer);
-  //         }
-  //       }
-  //     } catch (error) {
-  //       console.error("사용자 Role 확인 실패:", error);
-  //     }
-  //   };
-
-  //   fetchUserStatus();
-  // }, [router, queryClient]);
+        if (userRole.data.userRole === "MEMBER") {
+          if (domainUrl.includes("dev.user")) {
+            router.replace(devUser);
+          } else if (domainUrl.includes("user")) {
+            router.replace(prodUser);
+          }
+        }
+      } catch (error) {
+        if (error instanceof Error) {
+          if (pathname !== "login") {
+            router.replace("/login");
+          }
+        }
+        console.error("사용자 Role 확인 실패");
+      }
+    })();
+  }, [pathname, router]);
 
   useFcmListener();
 


### PR DESCRIPTION
## 📝 작업 내용

#### 가입한 도메인에 맞지 않은 계정으로 로그인하거나, 인증에 실패할 경우 리다이렉트 로직 구현
- 회원 도메인에서 가입 한 회원 유저가 회원 계정으로 트레이너 도메인에서 로그인 -> dev.trainer OR trainer(prod)로 리다이렉트
- 트레이너 도메인에서 가입한 트레이너 유저가 트레이너 계정으로 회원 도메인에서 로그인 ->  dev.user OR user(prod)로 리다이렉트
- 양 도메인 인증 정보 불러올 수 없을 시 로그인 페이지로 리다이렉트