### PR TITLE
[FLIZ-447/root] fix: HOTFIX

### DIFF
--- a/apps/trainer/app/my-page/my-information/page.tsx
+++ b/apps/trainer/app/my-page/my-information/page.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@ui//lib/utils";
 import { Suspense } from "react";
 
 import HeaderProvider from "@trainer/components/Providers/BasicHeaderProvider";
@@ -10,7 +11,7 @@ import MyInformationSkeleton from "./_components/Skeleton";
 export default async function MyInformation() {
   return (
     <HeaderProvider title="내 정보" back>
-      <main className={commonLayoutContents}>
+      <main className={cn(commonLayoutContents, "px-4")}>
         <Suspense fallback={<MyInformationSkeleton />}>
           <MyInformationContainer />
         </Suspense>

--- a/apps/trainer/app/notification/_components/SheetRenderer/SessionCompleteSheet.tsx
+++ b/apps/trainer/app/notification/_components/SheetRenderer/SessionCompleteSheet.tsx
@@ -126,12 +126,24 @@ function SessionCompleteSheet({
   const [isAcceptSheetOpen, setIsAccepSheetOpen] = useState(false);
 
   const handleDeclineClick = (reservationId: number, userId: number) => () => {
-    sessionMutation.mutate({ memberId: userId, reservationId, isJoin: false });
-    setIsDeclineSheetOpen(true);
+    sessionMutation.mutate(
+      { memberId: userId, reservationId, isJoin: false },
+      {
+        onSuccess: () => {
+          setIsDeclineSheetOpen(true);
+        },
+      },
+    );
   };
   const handleAcceptClick = (reservationId: number, userId: number) => () => {
-    sessionMutation.mutate({ memberId: userId, reservationId, isJoin: true });
-    setIsAccepSheetOpen(true);
+    sessionMutation.mutate(
+      { memberId: userId, reservationId, isJoin: true },
+      {
+        onSuccess: () => {
+          setIsAccepSheetOpen(true);
+        },
+      },
+    );
   };
 
   return (

--- a/packages/ui/src/components/ProfileItem.tsx
+++ b/packages/ui/src/components/ProfileItem.tsx
@@ -56,7 +56,7 @@ export function ProfileItem({ className, variant, ...props }: ProfileItemProps) 
   return (
     <div
       className={cn(
-        `bg-background-primary relative flex min-h-[2.813rem] min-w-[22.375rem] items-center justify-between`,
+        `bg-background-primary relative flex min-h-[2.813rem] w-full items-center justify-between`,
         className,
       )}
       {...props}


### PR DESCRIPTION
# [FLIZ-447/root] fix: HOTFIX

## 📝 작업 내용

- ProfileItem 고정 width로 인한 모바일 환경에서 페이지 overflow bugfix
- 트레이너 세션 알림 PT완료/불참석 처리 mutation 성공 시에만 다음 Sheet 표시
- 트레이너 마이페이지 > 내 정보 페이지 padding 조정 
### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
