### PR TITLE
[FLIZ-449/root] feat: background 푸시알림 클릭핸들러 추가

### DIFF
--- a/apps/trainer/public/firebase-messaging-sw.js
+++ b/apps/trainer/public/firebase-messaging-sw.js
@@ -24,3 +24,22 @@ messaging.onBackgroundMessage((payload) => {
 
   self.registration.showNotification(notificationTitle, notificationOptions);
 });
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+
+  const targetUrl = "/";
+
+  event.waitUntil(
+    clients.matchAll({ type: "window" }).then((clientList) => {
+      for (const client of clientList) {
+        if (client.url.includes(targetUrl) && "focus" in client) {
+          return client.focus();
+        }
+      }
+      if (clients.openWindow) {
+        return clients.openWindow("/notification");
+      }
+    }),
+  );
+});

--- a/apps/user/public/firebase-messaging-sw.js
+++ b/apps/user/public/firebase-messaging-sw.js
@@ -16,11 +16,30 @@ const messaging = firebase.messaging();
 messaging.onBackgroundMessage((payload) => {
   const { data } = payload;
   const { title, content } = data;
-  
+
   const notificationTitle = title || "Fitlink";
   const notificationOptions = {
     body: content,
   };
 
   self.registration.showNotification(notificationTitle, notificationOptions);
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+
+  const targetUrl = "/";
+
+  event.waitUntil(
+    clients.matchAll({ type: "window" }).then((clientList) => {
+      for (const client of clientList) {
+        if (client.url.includes(targetUrl) && "focus" in client) {
+          return client.focus();
+        }
+      }
+      if (clients.openWindow) {
+        return clients.openWindow("/notification");
+      }
+    }),
+  );
 });


### PR DESCRIPTION
# [FLIZ-449/root] feat: background 푸시알림 클릭핸들러 추가

## 📝 작업 내용

ServiceWorkerGlobalScope의 notificationclick 이벤트를 사용하여 푸시 알림 클릭 이벤트핸들러 로직을 추가했습니다
클릭시 알림이 지워지고, 1. 서비스가 열려있다면 focus, 2. 열려있는 핏링크 서비스가 없다면 /notification 경로로 엽니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
