### PR TITLE
[FLIZ-450/ui] fix: subHeader sticky position 유지를 위해 레이아웃 수정

### DIFF
--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -17,27 +17,25 @@ function HeaderRoot({ logo, subHeader, children, className }: HeaderRootProps) {
   const hasChildren = Array.isArray(children) ? children.some((child) => !!child) : children;
 
   return (
-    <section className="w-full py-2">
-      <header className={cn("bg-background-primary z-10 w-full")}>
-        {logo && (
-          <div
-            className={cn(
-              "border-background-sub2 flex h-[3rem] items-center justify-start transition-transform",
-            )}
-          >
-            {logo}
-          </div>
-        )}
-      </header>
+    <>
+      <section className="w-full">
+        <header className={cn("bg-background-primary z-10 w-full")}>
+          {logo && (
+            <div className={cn("flex h-[3rem] items-center justify-start transition-transform")}>
+              {logo}
+            </div>
+          )}
+        </header>
+      </section>
       {hasChildren && (
-        <div className="text-text-primary text-title-2 bg-background-primary sticky top-0 z-10 flex flex-col gap-2">
+        <section className="text-text-primary text-title-2 bg-background-primary sticky top-0 z-10 flex flex-col gap-2">
           <div className={cn("grid h-[2.1875rem] grid-cols-3 items-center", className)}>
             {children}
           </div>
           {subHeader && <div>{subHeader}</div>}
-        </div>
+        </section>
       )}
-    </section>
+    </>
   );
 }
 


### PR DESCRIPTION
# [FLIZ-450/ui] fix: subHeader sticky position 유지를 위해 레이아웃 수정

## 📝 작업 내용

Header의 subHeader가 의도와 다르게 viewport에 sticky하게 위치하지 않는 버그를 해결했습니다
### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
