### PR TITLE
[FLIZ-452/trainer] feat: 알림 도메인 API 업데이트 및 페이지 네트워크 최적화

### DIFF
--- a/apps/trainer/app/notification/_components/NotificationItemContainer.tsx
+++ b/apps/trainer/app/notification/_components/NotificationItemContainer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { NotificationInfo } from "@5unwan/core/api/types/common";
 import { useQuery } from "@tanstack/react-query";
 import NotificationItem from "@ui/components/NotificationItem/NotificationItem";
@@ -6,36 +8,48 @@ import { MouseEventHandler } from "react";
 
 import { notificationQueries } from "@trainer/queries/notification";
 
-import NotificationItemError from "./NotificationItemError";
 import NotificationItemFallback from "./NotificationItemFallback";
 import { parseContent } from "../_utils/notificationParser";
 
-type NotificationItemContainerProps = {
+type Props = {
   notification: NotificationInfo;
   onClick: MouseEventHandler<HTMLLIElement>;
 };
 
-function NotificationItemContainer({ notification, onClick }: NotificationItemContainerProps) {
-  const { data, isPending, isError } = useQuery({
-    ...notificationQueries.detail(notification.notificationId),
-  });
+function NotificationItemContainer({ notification, onClick }: Props) {
+  const { data, isLoading, isError } = useQuery(
+    notificationQueries.detail(notification.notificationId),
+  );
 
   const { content, type, sendDate, isProcessed, notificationId } = notification;
   const { message, eventDate } = parseContent(content);
 
-  if (isPending)
+  if (isLoading || !data) {
     return (
       <NotificationItemFallback
+        message={message || ""}
+        eventDate={eventDate || ""}
         variant={type}
         createdAt={sendDate}
         isCompleted={isProcessed}
-        message={message || ""}
-        eventDate={eventDate || ""}
       />
     );
+  }
 
-  if (isError) return <NotificationItemError />;
-
+  if (isError) {
+    return (
+      <NotificationItem
+        message={message || ""}
+        eventDate={eventDate || ""}
+        variant={type}
+        createdAt={sendDate}
+        isCompleted={isProcessed}
+        key={`notification-${notificationId}`}
+        className="w-full"
+        onClick={onClick}
+      />
+    );
+  }
   const { profilePictureUrl, name } = data.data.userDetail;
 
   return (

--- a/apps/trainer/app/notification/_components/NotificationPageClient.tsx
+++ b/apps/trainer/app/notification/_components/NotificationPageClient.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import DateController from "@ui/lib/DateController";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { notificationBaseKeys, notificationQueries } from "@trainer/queries/notification";
+
+import { readNotification } from "@trainer/services/notification";
+
+import RouteInstance from "@trainer/constants/route";
+
+import NotificationContainer from "./NotificationContainer";
+import SheetRenderer from "./SheetRenderer";
+import { parseContent } from "../_utils/notificationParser";
+import { parseKoreanDateString } from "../_utils/parseKoreanDateString";
+
+function NotificationPageClient() {
+  const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
+  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
+
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const readNotificationMutation = useMutation({
+    mutationFn: readNotification,
+    onMutate: async ({ id }) => {
+      queryClient.cancelQueries({ queryKey: notificationQueries.list({}).queryKey });
+
+      const previousNotifications = queryClient.getQueryData(notificationQueries.list({}).queryKey);
+
+      queryClient.setQueryData(notificationQueries.list({}).queryKey, (old) => {
+        if (!old) return old;
+        const newPages = old.pages.map((page) => {
+          const newData = {
+            ...page.data,
+            content: page.data.content.map((val) =>
+              val.notificationId === id ? { ...val, isProcessed: true } : val,
+            ),
+          };
+
+          return {
+            ...page,
+            data: newData,
+          };
+        });
+
+        return {
+          ...old,
+          pages: newPages,
+        };
+      });
+
+      return { previousNotifications };
+    },
+    onError: (_error, _variables, context) => {
+      queryClient.setQueryData(
+        notificationQueries.list({}).queryKey,
+        context?.previousNotifications,
+      );
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: notificationBaseKeys.lists() }),
+    onSuccess: () => {},
+  });
+
+  const handleNotificationClick = (notification: NotificationInfo) => () => {
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
+
+    const { eventDate } = parseContent(content);
+    const parsedDate = parseKoreanDateString(eventDate);
+
+    switch (type) {
+      case "트레이너 연동 해제":
+        if (isProcessed) return;
+        readNotificationMutation.mutate({ id: notificationId });
+        break;
+      case "예약 요청":
+        if (isProcessed) return;
+
+        readNotificationMutation.mutate({ id: notificationId });
+
+        if (parsedDate === null) {
+          toast.error("유효하지 않은 날짜의 일정입니다.");
+
+          return;
+        }
+
+        router.push(
+          RouteInstance["pending-reservations"]("", {
+            selectedDate: String(parsedDate),
+            formattedSelectedDate: DateController(parsedDate).toDateTimeWithDayFormat(),
+          }),
+        );
+        break;
+      case "세션":
+        if (isProcessed) return;
+
+        if (notificationType === "세션 곧 종료") {
+          router.push(RouteInstance["schedule-management"]());
+        } else if (notificationType === "세션 완료") {
+          readNotificationMutation.mutate({ id: notificationId });
+        }
+        break;
+      case "트레이너 연동":
+      case "예약 변경":
+      case "예약 취소":
+        if (notificationId !== selectedNotification?.notificationId) {
+          setSelectedNotification({
+            notificationId,
+            type,
+            notificationType,
+            content,
+            sendDate,
+            isProcessed,
+          });
+        }
+        setIsActionSheetOpen(true);
+        break;
+    }
+  };
+
+  // const handleNotificationClick = (notification: NotificationInfo) => () => {
+  //   setSelectedNotification(notification);
+  //   setIsActionSheetOpen(true);
+  // };
+
+  const ActionSheet =
+    selectedNotification && selectedNotification.type && SheetRenderer[selectedNotification.type];
+
+  const info = selectedNotification
+    ? parseContent(selectedNotification.content)
+    : { message: "", eventDate: "", other: "" };
+
+  return (
+    <>
+      <NotificationContainer onClick={handleNotificationClick} />
+      {ActionSheet &&
+        ActionSheet(
+          {
+            notificationId: selectedNotification.notificationId,
+            open: isActionSheetOpen,
+            onChangeOpen: setIsActionSheetOpen,
+          },
+          {
+            eventDate: info.eventDate || "",
+            cancelReason: info.other || "",
+          },
+        )}
+    </>
+  );
+}
+
+export default NotificationPageClient;

--- a/apps/trainer/app/notification/_components/NotificationSearch/MemberNotificationResult.tsx
+++ b/apps/trainer/app/notification/_components/NotificationSearch/MemberNotificationResult.tsx
@@ -86,7 +86,7 @@ function MemberNotificationResult({ memberId }: MemberNotificationResultProps) {
   const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
 
   const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed } = notification;
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
     if (notificationId !== selectedNotification?.notificationId) {
       setSelectedNotification({
         notificationId,
@@ -94,6 +94,7 @@ function MemberNotificationResult({ memberId }: MemberNotificationResultProps) {
         content,
         sendDate,
         isProcessed,
+        notificationType,
       });
     }
 

--- a/apps/trainer/app/notification/_components/NotificationsPerPage.tsx
+++ b/apps/trainer/app/notification/_components/NotificationsPerPage.tsx
@@ -1,0 +1,24 @@
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+
+import NotificationItemContainer from "./NotificationItemContainer";
+
+type NotificationPageProps = {
+  notifications: NotificationInfo[];
+  onClick: (notification: NotificationInfo) => () => void;
+};
+
+function NotificationPage({ notifications, onClick }: NotificationPageProps) {
+  return (
+    <>
+      {notifications.map((notification) => (
+        <NotificationItemContainer
+          key={notification.notificationId}
+          notification={notification}
+          onClick={onClick(notification)}
+        />
+      ))}
+    </>
+  );
+}
+
+export default NotificationPage;

--- a/apps/trainer/app/notification/_components/NotificationsPerPage.tsx
+++ b/apps/trainer/app/notification/_components/NotificationsPerPage.tsx
@@ -2,12 +2,12 @@ import { NotificationInfo } from "@5unwan/core/api/types/common";
 
 import NotificationItemContainer from "./NotificationItemContainer";
 
-type NotificationPageProps = {
+type NotificationsPerPageProps = {
   notifications: NotificationInfo[];
   onClick: (notification: NotificationInfo) => () => void;
 };
 
-function NotificationPage({ notifications, onClick }: NotificationPageProps) {
+function NotificationsPerPage({ notifications, onClick }: NotificationsPerPageProps) {
   return (
     <>
       {notifications.map((notification) => (
@@ -21,4 +21,4 @@ function NotificationPage({ notifications, onClick }: NotificationPageProps) {
   );
 }
 
-export default NotificationPage;
+export default NotificationsPerPage;

--- a/apps/trainer/app/notification/_components/NotificationsPerPageFallback.tsx
+++ b/apps/trainer/app/notification/_components/NotificationsPerPageFallback.tsx
@@ -1,0 +1,24 @@
+import NotificationItemFallback from "./NotificationItemFallback";
+
+type NotificationPerPageFallbackProps = {
+  pageIndex: number;
+};
+
+function NotificationsPerPageFallback({ pageIndex }: NotificationPerPageFallbackProps) {
+  return (
+    <>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <NotificationItemFallback
+          key={`notificationFallback-${pageIndex}-${i}`}
+          variant="세션"
+          createdAt={new Date().toISOString()}
+          isCompleted={false}
+          message="로딩 중"
+          eventDate=""
+        />
+      ))}
+    </>
+  );
+}
+
+export default NotificationsPerPageFallback;

--- a/apps/trainer/app/notification/_components/SheetRenderer/index.tsx
+++ b/apps/trainer/app/notification/_components/SheetRenderer/index.tsx
@@ -1,7 +1,6 @@
 import ConnectTrainerSheet from "./ConnectTrainerSheet";
 import ReservationCancelSheet from "./ReservationCancelSheet";
 import ReservationChangeSheet from "./ReservationChangeSheet";
-import SessionCompleteSheet from "./SessionCompleteSheet";
 
 type CommonSheetProps = {
   notificationId: number;
@@ -32,12 +31,15 @@ const SheetRenderer = {
       cancelReason={eventInfo.cancelReason || ""}
     />
   ),
-  세션: (
-    commonProps: CommonSheetProps,
-    eventInfo: {
-      eventDate: string;
-    },
-  ) => <SessionCompleteSheet {...commonProps} eventDate={eventInfo.eventDate} />,
+  세션: () => null,
+
+  // TODO: [2025.07.27] v1 API hotfix 대응하기 위해 '세션' Sheet 사용 보류
+  // 세션: (
+  //   commonProps: CommonSheetProps,
+  //   eventInfo: {
+  //     eventDate: string;
+  //   },
+  // ) => <SessionCompleteSheet {...commonProps} eventDate={eventInfo.eventDate} />,
 };
 
 export default SheetRenderer;

--- a/apps/trainer/app/notification/connect/_components/ConnectContainer.tsx
+++ b/apps/trainer/app/notification/connect/_components/ConnectContainer.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { Button } from "@ui/components/Button";
+import Header from "@ui/components/Header";
+import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
+import { Suspense, useEffect, useRef, useState } from "react";
+
+import { notificationQueries } from "@trainer/queries/notification";
+import { useNotificationStore } from "@trainer/store/notificationStore";
+
+import Logo from "@trainer/components/Logo";
+
+import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+
+import { commonLayoutContents } from "@trainer/constants/styles";
+
+import EmptyList from "../../_components/EmptyList";
+import NotificationSearch from "../../_components/NotificationSearch";
+import NotificationSideBar from "../../_components/NotificationSideBar";
+import NotificationsPerPage from "../../_components/NotificationsPerPage";
+import NotificationsPerPageFallback from "../../_components/NotificationsPerPageFallback";
+import { NotificationStatus } from "../../_types";
+import createFilteredNotificationCount from "../../_utils/createFilteredNotificationCount";
+import handleNotificationFilter from "../../_utils/handleNotificationFilter";
+import { NOTIFICATION_QUERY_TYPE, NOTIFICATION_TYPE } from "../_constants";
+
+type ConnectContainerProps = {
+  onNotificationClick: (notification: NotificationInfo) => () => void;
+};
+function ConnectContainer({ onNotificationClick }: ConnectContainerProps) {
+  const intersectionRef = useRef(null);
+  const [status, setStatus] = useState<NotificationStatus>("all");
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, refetch } =
+    useSuspenseInfiniteQuery(notificationQueries.list({ type: NOTIFICATION_QUERY_TYPE }));
+
+  const handleIntersect = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  useIntersectionObserver({
+    target: intersectionRef,
+    handleIntersect: handleIntersect,
+  });
+
+  const filteredNotificationCount = createFilteredNotificationCount(data, status);
+
+  const hasNewNotifications = useNotificationStore((state) =>
+    state.newNotificationTypes.has(NOTIFICATION_TYPE),
+  );
+  const setNewNotificationTypes = useNotificationStore((state) => state.setNewNotificationTypes);
+
+  useEffect(() => {
+    setNewNotificationTypes((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(NOTIFICATION_TYPE);
+
+      return newSet;
+    });
+  }, []);
+
+  return (
+    <>
+      <Header
+        logo={<Logo />}
+        subHeader={
+          <div className="bg-background-primary pb-2">
+            <ToggleGroup
+              type="single"
+              value={status}
+              onValueChange={setStatus as (value: string) => void}
+              className="w-full justify-start"
+            >
+              <ToggleGroupItem value="all">전체</ToggleGroupItem>
+              <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
+              <ToggleGroupItem value="complete">처리</ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+        }
+      >
+        <Header.Left>
+          <NotificationSideBar />
+        </Header.Left>
+        <Header.Title content={NOTIFICATION_TYPE} />
+        <Header.Right>
+          <NotificationSearch />
+        </Header.Right>
+      </Header>
+      <main className={commonLayoutContents}>
+        <div className="flex items-center justify-between pb-2">
+          <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
+          <span className="text-body-3">최신순</span>
+        </div>
+        {hasNewNotifications && (
+          <div className="mb-4 flex w-full items-center justify-center">
+            <Button
+              size="sm"
+              variant="negative"
+              corners="pill"
+              iconLeft="RotateCcw"
+              onClick={() => {
+                setNewNotificationTypes((prev) => {
+                  const newSet = new Set(prev);
+                  newSet.delete(NOTIFICATION_TYPE);
+
+                  return newSet;
+                });
+
+                refetch();
+              }}
+            >
+              새 알림 확인하기
+            </Button>
+          </div>
+        )}
+        {data.pages[0].data.totalElements ? (
+          <ul className="flex flex-col gap-4">
+            {data.pages.map((group, pageIndex) => {
+              const notifications = group.data.content.filter(handleNotificationFilter(status));
+
+              return (
+                <Suspense
+                  fallback={<NotificationsPerPageFallback pageIndex={pageIndex} />}
+                  key={pageIndex}
+                >
+                  <NotificationsPerPage
+                    key={`notificationsPage-${pageIndex}`}
+                    notifications={notifications}
+                    onClick={onNotificationClick}
+                  />
+                </Suspense>
+              );
+            })}
+            <div ref={intersectionRef} />
+          </ul>
+        ) : (
+          <EmptyList />
+        )}
+      </main>
+    </>
+  );
+}
+
+export default ConnectContainer;

--- a/apps/trainer/app/notification/connect/_components/NotificationPageClient.tsx
+++ b/apps/trainer/app/notification/connect/_components/NotificationPageClient.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useState } from "react";
+
+import ConnectContainer from "./ConnectContainer";
+import ConnectTrainerSheet from "../../_components/SheetRenderer/ConnectTrainerSheet";
+
+function ConnectNotificationPageClient() {
+  const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
+  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
+
+  const handleNotificationClick = (notification: NotificationInfo) => () => {
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
+    if (notificationId !== selectedNotification?.notificationId) {
+      setSelectedNotification({
+        notificationId,
+        type,
+        notificationType,
+        content,
+        sendDate,
+        isProcessed,
+      });
+    }
+
+    setIsActionSheetOpen(true);
+  };
+
+  return (
+    <>
+      <ConnectContainer onNotificationClick={handleNotificationClick} />
+      {selectedNotification && (
+        <ConnectTrainerSheet
+          open={isActionSheetOpen}
+          onChangeOpen={setIsActionSheetOpen}
+          notificationId={selectedNotification.notificationId}
+        />
+      )}
+    </>
+  );
+}
+
+export default ConnectNotificationPageClient;

--- a/apps/trainer/app/notification/connect/page.tsx
+++ b/apps/trainer/app/notification/connect/page.tsx
@@ -1,177 +1,27 @@
-"use client";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 
-import { NotificationInfo } from "@5unwan/core/api/types/common";
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { Button } from "@ui/components/Button";
-import Header from "@ui/components/Header";
-import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
-import { Fragment, Suspense, useEffect, useRef, useState } from "react";
-
-import NotificationSideBar from "@trainer/app/notification/_components/NotificationSideBar";
 import { notificationQueries } from "@trainer/queries/notification";
-import { useNotificationStore } from "@trainer/store/notificationStore";
 
-import Logo from "@trainer/components/Logo";
+import ConnectNotificationPageClient from "./_components/NotificationPageClient";
 
-import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+export default async function ConnectNotificationPage() {
+  const queryClient = new QueryClient();
 
-import { commonLayoutContents } from "@trainer/constants/styles";
-
-import { NOTIFICATION_QUERY_TYPE, NOTIFICATION_TYPE } from "./_constants";
-import EmptyList from "../_components/EmptyList";
-import NotificationItemContainer from "../_components/NotificationItemContainer";
-import NotificationListFallback from "../_components/NotificationListFallback";
-import NotificationSearch from "../_components/NotificationSearch";
-import ConnectTrainerSheet from "../_components/SheetRenderer/ConnectTrainerSheet";
-import { NotificationStatus } from "../_types";
-import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
-import handleNotificationFilter from "../_utils/handleNotificationFilter";
-
-type ConnectNotificationContentProps = {
-  onNotificationClick: (notification: NotificationInfo) => () => void;
-};
-function ConnectNotificationContent({ onNotificationClick }: ConnectNotificationContentProps) {
-  const intersectionRef = useRef(null);
-  const [status, setStatus] = useState<NotificationStatus>("all");
-
-  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, refetch } =
-    useSuspenseInfiniteQuery(notificationQueries.list({ type: NOTIFICATION_QUERY_TYPE }));
-
-  const handleIntersect = () => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  };
-
-  useIntersectionObserver({
-    target: intersectionRef,
-    handleIntersect: handleIntersect,
-  });
-
-  const filteredNotificationCount = createFilteredNotificationCount(data, status);
-
-  const hasNewNotifications = useNotificationStore((state) =>
-    state.newNotificationTypes.has(NOTIFICATION_TYPE),
+  const listQuery = await queryClient.fetchInfiniteQuery(
+    notificationQueries.list({ type: "CONNECT" }),
   );
-  const setNewNotificationTypes = useNotificationStore((state) => state.setNewNotificationTypes);
 
-  useEffect(() => {
-    setNewNotificationTypes((prev) => {
-      const newSet = new Set(prev);
-      newSet.delete(NOTIFICATION_TYPE);
+  const firstPageIds = listQuery.pages.flatMap((page) =>
+    page.data.content.map((n) => n.notificationId),
+  );
 
-      return newSet;
-    });
-  }, []);
+  await Promise.all(
+    firstPageIds.map((id) => queryClient.prefetchQuery(notificationQueries.detail(id))),
+  );
 
   return (
-    <>
-      <Header
-        logo={<Logo />}
-        subHeader={
-          <div className="bg-background-primary pb-2">
-            <ToggleGroup
-              type="single"
-              value={status}
-              onValueChange={setStatus as (value: string) => void}
-              className="w-full justify-start"
-            >
-              <ToggleGroupItem value="all">전체</ToggleGroupItem>
-              <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
-              <ToggleGroupItem value="complete">처리</ToggleGroupItem>
-            </ToggleGroup>
-          </div>
-        }
-      >
-        <Header.Left>
-          <NotificationSideBar />
-        </Header.Left>
-        <Header.Title content={NOTIFICATION_TYPE} />
-        <Header.Right>
-          <NotificationSearch />
-        </Header.Right>
-      </Header>
-      <main className={commonLayoutContents}>
-        <div className="flex items-center justify-between pb-2">
-          <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
-          <span className="text-body-3">최신순</span>
-        </div>
-        {hasNewNotifications && (
-          <div className="mb-4 flex w-full items-center justify-center">
-            <Button
-              size="sm"
-              variant="negative"
-              corners="pill"
-              iconLeft="RotateCcw"
-              onClick={() => {
-                setNewNotificationTypes((prev) => {
-                  const newSet = new Set(prev);
-                  newSet.delete(NOTIFICATION_TYPE);
-
-                  return newSet;
-                });
-
-                refetch();
-              }}
-            >
-              새 알림 확인하기
-            </Button>
-          </div>
-        )}
-        {data.pages[0].data.totalElements ? (
-          <ul className="flex flex-col gap-4">
-            {data.pages.map((group, index) => (
-              <Fragment key={`search-notificationGroup-${index}`}>
-                {group.data.content.filter(handleNotificationFilter(status)).map((notification) => (
-                  <NotificationItemContainer
-                    notification={notification}
-                    onClick={onNotificationClick(notification)}
-                    key={`search-notification-${notification.notificationId}`}
-                  />
-                ))}
-              </Fragment>
-            ))}
-            <div ref={intersectionRef} />
-          </ul>
-        ) : (
-          <EmptyList />
-        )}
-      </main>
-    </>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ConnectNotificationPageClient />
+    </HydrationBoundary>
   );
 }
-
-function ConnectNotificationPage() {
-  const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
-  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
-
-  const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed } = notification;
-    if (notificationId !== selectedNotification?.notificationId) {
-      setSelectedNotification({
-        notificationId,
-        type,
-        content,
-        sendDate,
-        isProcessed,
-      });
-    }
-
-    setIsActionSheetOpen(true);
-  };
-
-  return (
-    <>
-      <Suspense fallback={<NotificationListFallback />}>
-        <ConnectNotificationContent onNotificationClick={handleNotificationClick} />
-      </Suspense>
-      {selectedNotification && (
-        <ConnectTrainerSheet
-          open={isActionSheetOpen}
-          onChangeOpen={setIsActionSheetOpen}
-          notificationId={selectedNotification.notificationId}
-        />
-      )}
-    </>
-  );
-}
-
-export default ConnectNotificationPage;

--- a/apps/trainer/app/notification/disconnect/_components/DisconnectContainer.tsx
+++ b/apps/trainer/app/notification/disconnect/_components/DisconnectContainer.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { Button } from "@ui/components/Button";
+import Header from "@ui/components/Header";
+import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
+import { Suspense, useEffect, useRef, useState } from "react";
+
+import { notificationQueries } from "@trainer/queries/notification";
+import { useNotificationStore } from "@trainer/store/notificationStore";
+
+import Logo from "@trainer/components/Logo";
+
+import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+
+import { commonLayoutContents } from "@trainer/constants/styles";
+
+import EmptyList from "../../_components/EmptyList";
+import NotificationSearch from "../../_components/NotificationSearch";
+import NotificationSideBar from "../../_components/NotificationSideBar";
+import NotificationsPerPage from "../../_components/NotificationsPerPage";
+import NotificationsPerPageFallback from "../../_components/NotificationsPerPageFallback";
+import { NotificationStatus } from "../../_types";
+import createFilteredNotificationCount from "../../_utils/createFilteredNotificationCount";
+import handleNotificationFilter from "../../_utils/handleNotificationFilter";
+import { NOTIFICATION_QUERY_TYPE, NOTIFICATION_TYPE } from "../_constants";
+
+type DisconnectContainerProps = {
+  onNotificationClick: (notification: NotificationInfo) => () => void;
+};
+function DisconnectContainer({ onNotificationClick }: DisconnectContainerProps) {
+  const intersectionRef = useRef(null);
+  const [status, setStatus] = useState<NotificationStatus>("all");
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, refetch } =
+    useSuspenseInfiniteQuery(notificationQueries.list({ type: NOTIFICATION_QUERY_TYPE }));
+
+  const handleIntersect = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  useIntersectionObserver({
+    target: intersectionRef,
+    handleIntersect: handleIntersect,
+  });
+
+  const filteredNotificationCount = createFilteredNotificationCount(data, status);
+
+  const hasNewNotifications = useNotificationStore((state) =>
+    state.newNotificationTypes.has(NOTIFICATION_TYPE),
+  );
+  const setNewNotificationTypes = useNotificationStore((state) => state.setNewNotificationTypes);
+
+  useEffect(() => {
+    setNewNotificationTypes((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(NOTIFICATION_TYPE);
+
+      return newSet;
+    });
+  }, []);
+
+  return (
+    <>
+      <Header
+        logo={<Logo />}
+        subHeader={
+          <div className="bg-background-primary pb-2">
+            <ToggleGroup
+              type="single"
+              value={status}
+              onValueChange={setStatus as (value: string) => void}
+              className="w-full justify-start"
+            >
+              <ToggleGroupItem value="all">전체</ToggleGroupItem>
+              <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
+              <ToggleGroupItem value="complete">처리</ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+        }
+      >
+        <Header.Left>
+          <NotificationSideBar />
+        </Header.Left>
+        <Header.Title content={NOTIFICATION_TYPE} />
+        <Header.Right>
+          <NotificationSearch />
+        </Header.Right>
+      </Header>
+      <main className={commonLayoutContents}>
+        <div className="flex items-center justify-between pb-2">
+          <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
+          <span className="text-body-3">최신순</span>
+        </div>
+        {hasNewNotifications && (
+          <div className="mb-4 flex w-full items-center justify-center">
+            <Button
+              size="sm"
+              variant="negative"
+              corners="pill"
+              iconLeft="RotateCcw"
+              onClick={() => {
+                setNewNotificationTypes((prev) => {
+                  const newSet = new Set(prev);
+                  newSet.delete(NOTIFICATION_TYPE);
+
+                  return newSet;
+                });
+
+                refetch();
+              }}
+            >
+              새 알림 확인하기
+            </Button>
+          </div>
+        )}
+        {data.pages[0].data.totalElements ? (
+          <ul className="flex flex-col gap-4">
+            {data.pages.map((group, pageIndex) => {
+              const notifications = group.data.content.filter(handleNotificationFilter(status));
+
+              return (
+                <Suspense
+                  fallback={<NotificationsPerPageFallback pageIndex={pageIndex} />}
+                  key={pageIndex}
+                >
+                  <NotificationsPerPage
+                    key={`notificationsPage-${pageIndex}`}
+                    notifications={notifications}
+                    onClick={onNotificationClick}
+                  />
+                </Suspense>
+              );
+            })}
+            <div ref={intersectionRef} />
+          </ul>
+        ) : (
+          <EmptyList />
+        )}
+      </main>
+    </>
+  );
+}
+
+export default DisconnectContainer;

--- a/apps/trainer/app/notification/disconnect/_components/NotificationPageClient.tsx
+++ b/apps/trainer/app/notification/disconnect/_components/NotificationPageClient.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useState } from "react";
+
+import DisconnectContainer from "./DisconnectContainer";
+
+function DisconnectNotificationPageClient() {
+  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
+
+  const handleNotificationClick = (notification: NotificationInfo) => () => {
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
+    if (notificationId !== selectedNotification?.notificationId) {
+      setSelectedNotification({
+        notificationId,
+        type,
+        content,
+        sendDate,
+        isProcessed,
+        notificationType,
+      });
+    }
+  };
+
+  return <DisconnectContainer onNotificationClick={handleNotificationClick} />;
+}
+
+export default DisconnectNotificationPageClient;

--- a/apps/trainer/app/notification/disconnect/page.tsx
+++ b/apps/trainer/app/notification/disconnect/page.tsx
@@ -1,167 +1,27 @@
-"use client";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 
-import { NotificationInfo } from "@5unwan/core/api/types/common";
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { Button } from "@ui/components/Button";
-import Header from "@ui/components/Header";
-import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
-import { Fragment, Suspense, useEffect, useRef, useState } from "react";
-
-import NotificationSideBar from "@trainer/app/notification/_components/NotificationSideBar";
 import { notificationQueries } from "@trainer/queries/notification";
-import { useNotificationStore } from "@trainer/store/notificationStore";
 
-import Logo from "@trainer/components/Logo";
+import DisconnectNotificationPageClient from "./_components/NotificationPageClient";
 
-import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+export default async function DisconnectNotificationPage() {
+  const queryClient = new QueryClient();
 
-import { commonLayoutContents } from "@trainer/constants/styles";
-
-import EmptyList from "../_components/EmptyList";
-import NotificationItemContainer from "../_components/NotificationItemContainer";
-import NotificationSearch from "../_components/NotificationSearch";
-import { NotificationStatus } from "../_types";
-import { NOTIFICATION_QUERY_TYPE, NOTIFICATION_TYPE } from "./_constants";
-import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
-import handleNotificationFilter from "../_utils/handleNotificationFilter";
-
-type DisconnectNotificationContentProps = {
-  onNotificationClick: (notification: NotificationInfo) => () => void;
-};
-function DisconnectNotificationContent({
-  onNotificationClick,
-}: DisconnectNotificationContentProps) {
-  const intersectionRef = useRef(null);
-  const [status, setStatus] = useState<NotificationStatus>("all");
-
-  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, refetch } =
-    useSuspenseInfiniteQuery(notificationQueries.list({ type: NOTIFICATION_QUERY_TYPE }));
-
-  const handleIntersect = () => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  };
-
-  useIntersectionObserver({
-    target: intersectionRef,
-    handleIntersect: handleIntersect,
-  });
-
-  const filteredNotificationCount = createFilteredNotificationCount(data, status);
-
-  const hasNewNotifications = useNotificationStore((state) =>
-    state.newNotificationTypes.has(NOTIFICATION_TYPE),
+  const listQuery = await queryClient.fetchInfiniteQuery(
+    notificationQueries.list({ type: "DISCONNECT" }),
   );
-  const setNewNotificationTypes = useNotificationStore((state) => state.setNewNotificationTypes);
 
-  useEffect(() => {
-    setNewNotificationTypes((prev) => {
-      const newSet = new Set(prev);
-      newSet.delete(NOTIFICATION_TYPE);
+  const firstPageIds = listQuery.pages.flatMap((page) =>
+    page.data.content.map((n) => n.notificationId),
+  );
 
-      return newSet;
-    });
-  }, []);
+  await Promise.all(
+    firstPageIds.map((id) => queryClient.prefetchQuery(notificationQueries.detail(id))),
+  );
 
   return (
-    <>
-      <Header
-        logo={<Logo />}
-        subHeader={
-          <div className="bg-background-primary pb-2">
-            <ToggleGroup
-              type="single"
-              value={status}
-              onValueChange={setStatus as (value: string) => void}
-              className="w-full justify-start"
-            >
-              <ToggleGroupItem value="all">전체</ToggleGroupItem>
-              <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
-              <ToggleGroupItem value="complete">처리</ToggleGroupItem>
-            </ToggleGroup>
-          </div>
-        }
-      >
-        <Header.Left>
-          <NotificationSideBar />
-        </Header.Left>
-        <Header.Title content={NOTIFICATION_TYPE} />
-        <Header.Right>
-          <NotificationSearch />
-        </Header.Right>
-      </Header>
-      <main className={commonLayoutContents}>
-        <div className="flex items-center justify-between pb-2">
-          <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
-          <span className="text-body-3">최신순</span>
-        </div>
-        {hasNewNotifications && (
-          <div className="mb-4 flex w-full items-center justify-center">
-            <Button
-              size="sm"
-              variant="negative"
-              corners="pill"
-              iconLeft="RotateCcw"
-              onClick={() => {
-                setNewNotificationTypes((prev) => {
-                  const newSet = new Set(prev);
-                  newSet.delete(NOTIFICATION_TYPE);
-
-                  return newSet;
-                });
-
-                refetch();
-              }}
-            >
-              새 알림 확인하기
-            </Button>
-          </div>
-        )}
-        {data.pages[0].data.totalElements ? (
-          <ul className="flex flex-col gap-4">
-            {data.pages.map((group, index) => (
-              <Fragment key={`search-notificationGroup-${index}`}>
-                {group.data.content.filter(handleNotificationFilter(status)).map((notification) => (
-                  <NotificationItemContainer
-                    notification={notification}
-                    onClick={onNotificationClick(notification)}
-                    key={`search-notification-${notification.notificationId}`}
-                  />
-                ))}
-              </Fragment>
-            ))}
-            <div ref={intersectionRef} />
-          </ul>
-        ) : (
-          <EmptyList />
-        )}
-      </main>
-    </>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <DisconnectNotificationPageClient />
+    </HydrationBoundary>
   );
 }
-function DisconnectNotificationPage() {
-  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
-
-  const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
-    if (notificationId !== selectedNotification?.notificationId) {
-      setSelectedNotification({
-        notificationId,
-        type,
-        content,
-        sendDate,
-        isProcessed,
-        notificationType,
-      });
-    }
-  };
-
-  return (
-    <>
-      <Suspense>
-        <DisconnectNotificationContent onNotificationClick={handleNotificationClick} />
-      </Suspense>
-    </>
-  );
-}
-
-export default DisconnectNotificationPage;

--- a/apps/trainer/app/notification/disconnect/page.tsx
+++ b/apps/trainer/app/notification/disconnect/page.tsx
@@ -142,7 +142,7 @@ function DisconnectNotificationPage() {
   const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
 
   const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed } = notification;
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
     if (notificationId !== selectedNotification?.notificationId) {
       setSelectedNotification({
         notificationId,
@@ -150,6 +150,7 @@ function DisconnectNotificationPage() {
         content,
         sendDate,
         isProcessed,
+        notificationType,
       });
     }
   };

--- a/apps/trainer/app/notification/page.tsx
+++ b/apps/trainer/app/notification/page.tsx
@@ -1,146 +1,25 @@
-/* eslint-disable no-magic-numbers */
-"use client";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 
-import { NotificationInfo } from "@5unwan/core/api/types/common";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import DateController from "@ui/lib/DateController";
-import { useRouter } from "next/navigation";
-import { Suspense, useState } from "react";
-import { toast } from "sonner";
+import { notificationQueries } from "@trainer/queries/notification";
 
-import { notificationBaseKeys, notificationQueries } from "@trainer/queries/notification";
+import NotificationPageClient from "./_components/NotificationPageClient";
 
-import { readNotification } from "@trainer/services/notification";
+export default async function NotificationPage() {
+  const queryClient = new QueryClient();
 
-import RouteInstance from "@trainer/constants/route";
+  const listQuery = await queryClient.fetchInfiniteQuery(notificationQueries.list({}));
 
-import NotificationContainer from "./_components/NotificationContainer";
-import NotificationListFallback from "./_components/NotificationListFallback";
-import SheetRenderer from "./_components/SheetRenderer";
-import { parseContent } from "./_utils/notificationParser";
-import { parseKoreanDateString } from "./_utils/parseKoreanDateString";
+  const firstPageIds = listQuery.pages.flatMap((page) =>
+    page.data.content.map((n) => n.notificationId),
+  );
 
-function AllNotificationPage() {
-  const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
-  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
-
-  const queryClient = useQueryClient();
-  const router = useRouter();
-  const readNotificationMutation = useMutation({
-    mutationFn: readNotification,
-    onMutate: async ({ id }) => {
-      queryClient.cancelQueries({ queryKey: notificationQueries.list({}).queryKey });
-
-      const previousNotifications = queryClient.getQueryData(notificationQueries.list({}).queryKey);
-
-      queryClient.setQueryData(notificationQueries.list({}).queryKey, (old) => {
-        if (!old) return old;
-        const newPages = old.pages.map((page) => {
-          const newData = {
-            ...page.data,
-            content: page.data.content.map((val) =>
-              val.notificationId === id ? { ...val, isProcessed: true } : val,
-            ),
-          };
-
-          return {
-            ...page,
-            data: newData,
-          };
-        });
-
-        return {
-          ...old,
-          pages: newPages,
-        };
-      });
-
-      return { previousNotifications };
-    },
-    onError: (error, a, context) => {
-      queryClient.setQueryData(
-        notificationQueries.list({}).queryKey,
-        context?.previousNotifications,
-      );
-    },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: notificationBaseKeys.lists() }),
-    onSuccess: () => {},
-  });
-
-  const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed } = notification;
-
-    const { eventDate } = parseContent(content);
-    const parsedDate = parseKoreanDateString(eventDate);
-
-    switch (type) {
-      case "트레이너 연동 해제":
-        if (isProcessed) return;
-        readNotificationMutation.mutate({ id: notificationId });
-        break;
-      case "예약 요청":
-        if (isProcessed) return;
-
-        readNotificationMutation.mutate({ id: notificationId });
-
-        if (parsedDate === null) {
-          toast.error("유효하지 않은 날짜의 일정입니다.");
-
-          return;
-        }
-
-        router.push(
-          RouteInstance["pending-reservations"]("", {
-            selectedDate: String(parsedDate),
-            formattedSelectedDate: DateController(parsedDate).toDateTimeWithDayFormat(),
-          }),
-        );
-        break;
-      case "세션":
-      case "트레이너 연동":
-      case "예약 변경":
-      case "예약 취소":
-        if (notificationId !== selectedNotification?.notificationId) {
-          setSelectedNotification({
-            notificationId,
-            type,
-            content,
-            sendDate,
-            isProcessed,
-          });
-        }
-        setIsActionSheetOpen(true);
-        break;
-    }
-  };
-
-  const ActionSheet =
-    selectedNotification && selectedNotification.type && SheetRenderer[selectedNotification.type];
-
-  const info = selectedNotification
-    ? parseContent(selectedNotification.content)
-    : { message: "", eventDate: "", other: "" };
+  await Promise.all(
+    firstPageIds.map((id) => queryClient.prefetchQuery(notificationQueries.detail(id))),
+  );
 
   return (
-    <>
-      <Suspense fallback={<NotificationListFallback />}>
-        <NotificationContainer onClick={handleNotificationClick} />
-      </Suspense>
-
-      {ActionSheet &&
-        ActionSheet(
-          {
-            notificationId: selectedNotification.notificationId,
-            open: isActionSheetOpen,
-            onChangeOpen: setIsActionSheetOpen,
-          },
-          {
-            eventDate: info.eventDate || "",
-            cancelReason: info.other || "",
-          },
-        )}
-    </>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <NotificationPageClient />
+    </HydrationBoundary>
   );
 }
-
-export default AllNotificationPage;

--- a/apps/trainer/app/notification/reservation-cancel/_components/NotificationPageClient.tsx
+++ b/apps/trainer/app/notification/reservation-cancel/_components/NotificationPageClient.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useState } from "react";
+
+import ReservationCancelContainer from "./ReservationCancelContainer";
+import ReservationCancelSheet from "../../_components/SheetRenderer/ReservationCancelSheet";
+import { parseContent } from "../../_utils/notificationParser";
+
+function ReservationCancelNotificationPageClient() {
+  const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
+  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
+
+  const handleNotificationClick = (notification: NotificationInfo) => () => {
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
+    if (notificationId !== selectedNotification?.notificationId) {
+      setSelectedNotification({
+        notificationId,
+        type,
+        content,
+        sendDate,
+        isProcessed,
+        notificationType,
+      });
+    }
+
+    setIsActionSheetOpen(true);
+  };
+
+  const info = selectedNotification
+    ? parseContent(selectedNotification.content)
+    : { message: "", eventDate: "", other: "" };
+
+  return (
+    <>
+      <ReservationCancelContainer onNotificationClick={handleNotificationClick} />
+      {selectedNotification && (
+        <ReservationCancelSheet
+          notificationId={selectedNotification.notificationId}
+          open={isActionSheetOpen}
+          onChangeOpen={setIsActionSheetOpen}
+          eventDateDescription={info.eventDate || ""}
+          cancelReason={info.other || ""}
+        />
+      )}
+    </>
+  );
+}
+
+export default ReservationCancelNotificationPageClient;

--- a/apps/trainer/app/notification/reservation-cancel/_components/ReservationCancelContainer.tsx
+++ b/apps/trainer/app/notification/reservation-cancel/_components/ReservationCancelContainer.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { Button } from "@ui/components/Button";
+import Header from "@ui/components/Header";
+import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
+import { Suspense, useEffect, useRef, useState } from "react";
+
+import { notificationQueries } from "@trainer/queries/notification";
+import { useNotificationStore } from "@trainer/store/notificationStore";
+
+import Logo from "@trainer/components/Logo";
+
+import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+
+import { commonLayoutContents } from "@trainer/constants/styles";
+
+import EmptyList from "../../_components/EmptyList";
+import NotificationSearch from "../../_components/NotificationSearch";
+import NotificationSideBar from "../../_components/NotificationSideBar";
+import NotificationsPerPage from "../../_components/NotificationsPerPage";
+import NotificationsPerPageFallback from "../../_components/NotificationsPerPageFallback";
+import { NotificationStatus } from "../../_types";
+import createFilteredNotificationCount from "../../_utils/createFilteredNotificationCount";
+import handleNotificationFilter from "../../_utils/handleNotificationFilter";
+import { NOTIFICATION_QUERY_TYPE, NOTIFICATION_TYPE } from "../_constants";
+
+type ReservationCancelContainerProps = {
+  onNotificationClick: (notification: NotificationInfo) => () => void;
+};
+function ReservationCancelContainer({ onNotificationClick }: ReservationCancelContainerProps) {
+  const intersectionRef = useRef(null);
+  const [status, setStatus] = useState<NotificationStatus>("all");
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, refetch } =
+    useSuspenseInfiniteQuery(notificationQueries.list({ type: NOTIFICATION_QUERY_TYPE }));
+
+  const handleIntersect = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  useIntersectionObserver({
+    target: intersectionRef,
+    handleIntersect: handleIntersect,
+  });
+
+  const filteredNotificationCount = createFilteredNotificationCount(data, status);
+
+  const hasNewNotifications = useNotificationStore((state) =>
+    state.newNotificationTypes.has(NOTIFICATION_TYPE),
+  );
+  const setNewNotificationTypes = useNotificationStore((state) => state.setNewNotificationTypes);
+
+  useEffect(() => {
+    setNewNotificationTypes((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(NOTIFICATION_TYPE);
+
+      return newSet;
+    });
+  }, []);
+
+  return (
+    <>
+      <Header
+        logo={<Logo />}
+        subHeader={
+          <div className="bg-background-primary pb-2">
+            <ToggleGroup
+              type="single"
+              value={status}
+              onValueChange={setStatus as (value: string) => void}
+              className="w-full justify-start"
+            >
+              <ToggleGroupItem value="all">전체</ToggleGroupItem>
+              <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
+              <ToggleGroupItem value="complete">처리</ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+        }
+      >
+        <Header.Left>
+          <NotificationSideBar />
+        </Header.Left>
+        <Header.Title content={NOTIFICATION_TYPE} />
+        <Header.Right>
+          <NotificationSearch />
+        </Header.Right>
+      </Header>
+      <main className={commonLayoutContents}>
+        <div className="flex items-center justify-between pb-2">
+          <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
+          <span className="text-body-3">최신순</span>
+        </div>
+        {hasNewNotifications && (
+          <div className="mb-4 flex w-full items-center justify-center">
+            <Button
+              size="sm"
+              variant="negative"
+              corners="pill"
+              iconLeft="RotateCcw"
+              onClick={() => {
+                setNewNotificationTypes((prev) => {
+                  const newSet = new Set(prev);
+                  newSet.delete(NOTIFICATION_TYPE);
+
+                  return newSet;
+                });
+
+                refetch();
+              }}
+            >
+              새 알림 확인하기
+            </Button>
+          </div>
+        )}
+        {data.pages[0].data.totalElements ? (
+          <ul className="flex flex-col gap-4">
+            {data.pages.map((group, pageIndex) => {
+              const notifications = group.data.content.filter(handleNotificationFilter(status));
+
+              return (
+                <Suspense
+                  fallback={<NotificationsPerPageFallback pageIndex={pageIndex} />}
+                  key={pageIndex}
+                >
+                  <NotificationsPerPage
+                    key={`notificationsPage-${pageIndex}`}
+                    notifications={notifications}
+                    onClick={onNotificationClick}
+                  />
+                </Suspense>
+              );
+            })}
+            <div ref={intersectionRef} />
+          </ul>
+        ) : (
+          <EmptyList />
+        )}
+      </main>
+    </>
+  );
+}
+
+export default ReservationCancelContainer;

--- a/apps/trainer/app/notification/reservation-cancel/page.tsx
+++ b/apps/trainer/app/notification/reservation-cancel/page.tsx
@@ -1,186 +1,28 @@
-"use client";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 
-import { NotificationInfo } from "@5unwan/core/api/types/common";
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { Button } from "@ui/components/Button";
-import Header from "@ui/components/Header";
-import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
-import { Fragment, Suspense, useEffect, useRef, useState } from "react";
-
-import NotificationSideBar from "@trainer/app/notification/_components/NotificationSideBar";
 import { notificationQueries } from "@trainer/queries/notification";
-import { useNotificationStore } from "@trainer/store/notificationStore";
 
-import Logo from "@trainer/components/Logo";
+import ReservationCancelNotificationPageClient from "./_components/NotificationPageClient";
 
-import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+async function ReservationCancelNotificationPage() {
+  const queryClient = new QueryClient();
 
-import { commonLayoutContents } from "@trainer/constants/styles";
-
-import { NOTIFICATION_QUERY_TYPE, NOTIFICATION_TYPE } from "./_constants";
-import EmptyList from "../_components/EmptyList";
-import NotificationItemContainer from "../_components/NotificationItemContainer";
-import NotificationListFallback from "../_components/NotificationListFallback";
-import NotificationSearch from "../_components/NotificationSearch";
-import ReservationCancelSheet from "../_components/SheetRenderer/ReservationCancelSheet";
-import { NotificationStatus } from "../_types";
-import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
-import handleNotificationFilter from "../_utils/handleNotificationFilter";
-import { parseContent } from "../_utils/notificationParser";
-
-type ReservationCancelNotificationContentProps = {
-  onNotificationClick: (notification: NotificationInfo) => () => void;
-};
-function ReservationCancelNotificationContent({
-  onNotificationClick,
-}: ReservationCancelNotificationContentProps) {
-  const intersectionRef = useRef(null);
-  const [status, setStatus] = useState<NotificationStatus>("all");
-
-  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, refetch } =
-    useSuspenseInfiniteQuery(notificationQueries.list({ type: NOTIFICATION_QUERY_TYPE }));
-
-  const handleIntersect = () => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  };
-
-  useIntersectionObserver({
-    target: intersectionRef,
-    handleIntersect: handleIntersect,
-  });
-
-  const filteredNotificationCount = createFilteredNotificationCount(data, status);
-
-  const hasNewNotifications = useNotificationStore((state) =>
-    state.newNotificationTypes.has(NOTIFICATION_TYPE),
+  const listQuery = await queryClient.fetchInfiniteQuery(
+    notificationQueries.list({ type: "RESERVATION_CANCEL" }),
   );
-  const setNewNotificationTypes = useNotificationStore((state) => state.setNewNotificationTypes);
 
-  useEffect(() => {
-    setNewNotificationTypes((prev) => {
-      const newSet = new Set(prev);
-      newSet.delete(NOTIFICATION_TYPE);
+  const firstPageIds = listQuery.pages.flatMap((page) =>
+    page.data.content.map((n) => n.notificationId),
+  );
 
-      return newSet;
-    });
-  }, []);
+  await Promise.all(
+    firstPageIds.map((id) => queryClient.prefetchQuery(notificationQueries.detail(id))),
+  );
 
   return (
-    <>
-      <Header
-        logo={<Logo />}
-        subHeader={
-          <div className="bg-background-primary pb-2">
-            <ToggleGroup
-              type="single"
-              value={status}
-              onValueChange={setStatus as (value: string) => void}
-              className="w-full justify-start"
-            >
-              <ToggleGroupItem value="all">전체</ToggleGroupItem>
-              <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
-              <ToggleGroupItem value="complete">처리</ToggleGroupItem>
-            </ToggleGroup>
-          </div>
-        }
-      >
-        <Header.Left>
-          <NotificationSideBar />
-        </Header.Left>
-        <Header.Title content={NOTIFICATION_TYPE} />
-        <Header.Right>
-          <NotificationSearch />
-        </Header.Right>
-      </Header>
-      <main className={commonLayoutContents}>
-        <div className="flex items-center justify-between pb-2">
-          <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
-          <span className="text-body-3">최신순</span>
-        </div>
-        {hasNewNotifications && (
-          <div className="mb-4 flex w-full items-center justify-center">
-            <Button
-              size="sm"
-              variant="negative"
-              corners="pill"
-              iconLeft="RotateCcw"
-              onClick={() => {
-                setNewNotificationTypes((prev) => {
-                  const newSet = new Set(prev);
-                  newSet.delete(NOTIFICATION_TYPE);
-
-                  return newSet;
-                });
-
-                refetch();
-              }}
-            >
-              새 알림 확인하기
-            </Button>
-          </div>
-        )}
-        {data.pages[0].data.totalElements ? (
-          <ul className="flex flex-col gap-4">
-            {data.pages.map((group, index) => (
-              <Fragment key={`search-notificationGroup-${index}`}>
-                {group.data.content.filter(handleNotificationFilter(status)).map((notification) => (
-                  <NotificationItemContainer
-                    notification={notification}
-                    onClick={onNotificationClick(notification)}
-                    key={`search-notification-${notification.notificationId}`}
-                  />
-                ))}
-              </Fragment>
-            ))}
-            <div ref={intersectionRef} />
-          </ul>
-        ) : (
-          <EmptyList />
-        )}
-      </main>
-    </>
-  );
-}
-
-function ReservationCancelNotificationPage() {
-  const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
-  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
-
-  const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
-    if (notificationId !== selectedNotification?.notificationId) {
-      setSelectedNotification({
-        notificationId,
-        type,
-        content,
-        sendDate,
-        isProcessed,
-        notificationType,
-      });
-    }
-
-    setIsActionSheetOpen(true);
-  };
-
-  const info = selectedNotification
-    ? parseContent(selectedNotification.content)
-    : { message: "", eventDate: "", other: "" };
-
-  return (
-    <>
-      <Suspense fallback={<NotificationListFallback />}>
-        <ReservationCancelNotificationContent onNotificationClick={handleNotificationClick} />
-      </Suspense>
-      {selectedNotification && (
-        <ReservationCancelSheet
-          notificationId={selectedNotification.notificationId}
-          open={isActionSheetOpen}
-          onChangeOpen={setIsActionSheetOpen}
-          eventDateDescription={info.eventDate || ""}
-          cancelReason={info.other || ""}
-        />
-      )}
-    </>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ReservationCancelNotificationPageClient />
+    </HydrationBoundary>
   );
 }
 

--- a/apps/trainer/app/notification/reservation-cancel/page.tsx
+++ b/apps/trainer/app/notification/reservation-cancel/page.tsx
@@ -147,7 +147,7 @@ function ReservationCancelNotificationPage() {
   const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
 
   const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed } = notification;
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
     if (notificationId !== selectedNotification?.notificationId) {
       setSelectedNotification({
         notificationId,
@@ -155,6 +155,7 @@ function ReservationCancelNotificationPage() {
         content,
         sendDate,
         isProcessed,
+        notificationType,
       });
     }
 

--- a/apps/trainer/app/notification/reservation-change/_components/NotificationPageClient.tsx
+++ b/apps/trainer/app/notification/reservation-change/_components/NotificationPageClient.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useState } from "react";
+
+import ReservationChangeContainer from "./ReservationChangeContainer";
+import ReservationChangeSheet from "../../_components/SheetRenderer/ReservationChangeSheet";
+import { parseContent } from "../../_utils/notificationParser";
+
+function ReservationChangeNotificationPageClient() {
+  const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
+  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
+
+  const handleNotificationClick = (notification: NotificationInfo) => () => {
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
+    if (notificationId !== selectedNotification?.notificationId) {
+      setSelectedNotification({
+        notificationId,
+        type,
+        content,
+        sendDate,
+        isProcessed,
+        notificationType,
+      });
+    }
+
+    setIsActionSheetOpen(true);
+  };
+
+  const info = selectedNotification
+    ? parseContent(selectedNotification.content)
+    : { message: "", eventDate: "", other: "" };
+
+  return (
+    <>
+      <ReservationChangeContainer onNotificationClick={handleNotificationClick} />
+      {selectedNotification && (
+        <ReservationChangeSheet
+          notificationId={selectedNotification.notificationId}
+          open={isActionSheetOpen}
+          onChangeOpen={setIsActionSheetOpen}
+          eventDateDescription={info.eventDate || ""}
+        />
+      )}
+    </>
+  );
+}
+
+export default ReservationChangeNotificationPageClient;

--- a/apps/trainer/app/notification/reservation-change/_components/ReservationChangeContainer.tsx
+++ b/apps/trainer/app/notification/reservation-change/_components/ReservationChangeContainer.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { Button } from "@ui/components/Button";
+import Header from "@ui/components/Header";
+import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
+import { Suspense, useEffect, useRef, useState } from "react";
+
+import { notificationQueries } from "@trainer/queries/notification";
+import { useNotificationStore } from "@trainer/store/notificationStore";
+
+import Logo from "@trainer/components/Logo";
+
+import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+
+import { commonLayoutContents } from "@trainer/constants/styles";
+
+import EmptyList from "../../_components/EmptyList";
+import NotificationSearch from "../../_components/NotificationSearch";
+import NotificationSideBar from "../../_components/NotificationSideBar";
+import NotificationsPerPage from "../../_components/NotificationsPerPage";
+import NotificationsPerPageFallback from "../../_components/NotificationsPerPageFallback";
+import { NotificationStatus } from "../../_types";
+import createFilteredNotificationCount from "../../_utils/createFilteredNotificationCount";
+import handleNotificationFilter from "../../_utils/handleNotificationFilter";
+import { NOTIFICATION_QUERY_TYPE, NOTIFICATION_TYPE } from "../_constants";
+
+type ReservationChangeContainerProps = {
+  onNotificationClick: (notification: NotificationInfo) => () => void;
+};
+function ReservationChangeContainer({ onNotificationClick }: ReservationChangeContainerProps) {
+  const intersectionRef = useRef(null);
+
+  const [status, setStatus] = useState<NotificationStatus>("all");
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, refetch } =
+    useSuspenseInfiniteQuery(notificationQueries.list({ type: NOTIFICATION_QUERY_TYPE }));
+
+  const handleIntersect = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  useIntersectionObserver({
+    target: intersectionRef,
+    handleIntersect: handleIntersect,
+  });
+
+  const filteredNotificationCount = createFilteredNotificationCount(data, status);
+
+  const hasNewNotifications = useNotificationStore((state) =>
+    state.newNotificationTypes.has(NOTIFICATION_TYPE),
+  );
+  const setNewNotificationTypes = useNotificationStore((state) => state.setNewNotificationTypes);
+
+  useEffect(() => {
+    setNewNotificationTypes((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(NOTIFICATION_TYPE);
+
+      return newSet;
+    });
+  }, []);
+
+  return (
+    <>
+      <Header
+        logo={<Logo />}
+        subHeader={
+          <div className="bg-background-primary pb-2">
+            <ToggleGroup
+              type="single"
+              value={status}
+              onValueChange={setStatus as (value: string) => void}
+              className="w-full justify-start"
+            >
+              <ToggleGroupItem value="all">전체</ToggleGroupItem>
+              <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
+              <ToggleGroupItem value="complete">처리</ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+        }
+      >
+        <Header.Left>
+          <NotificationSideBar />
+        </Header.Left>
+        <Header.Title content={NOTIFICATION_TYPE} />
+        <Header.Right>
+          <NotificationSearch />
+        </Header.Right>
+      </Header>
+      <main className={commonLayoutContents}>
+        <div className="flex items-center justify-between pb-2">
+          <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
+          <span className="text-body-3">최신순</span>
+        </div>
+        {hasNewNotifications && (
+          <div className="mb-4 flex w-full items-center justify-center">
+            <Button
+              size="sm"
+              variant="negative"
+              corners="pill"
+              iconLeft="RotateCcw"
+              onClick={() => {
+                setNewNotificationTypes((prev) => {
+                  const newSet = new Set(prev);
+                  newSet.delete(NOTIFICATION_TYPE);
+
+                  return newSet;
+                });
+
+                refetch();
+              }}
+            >
+              새 알림 확인하기
+            </Button>
+          </div>
+        )}
+        {data.pages[0].data.totalElements ? (
+          <ul className="flex flex-col gap-4">
+            {data.pages.map((group, pageIndex) => {
+              const notifications = group.data.content.filter(handleNotificationFilter(status));
+
+              return (
+                <Suspense
+                  fallback={<NotificationsPerPageFallback pageIndex={pageIndex} />}
+                  key={pageIndex}
+                >
+                  <NotificationsPerPage
+                    key={`notificationsPage-${pageIndex}`}
+                    notifications={notifications}
+                    onClick={onNotificationClick}
+                  />
+                </Suspense>
+              );
+            })}
+            <div ref={intersectionRef} />
+          </ul>
+        ) : (
+          <EmptyList />
+        )}
+      </main>
+    </>
+  );
+}
+
+export default ReservationChangeContainer;

--- a/apps/trainer/app/notification/reservation-change/page.tsx
+++ b/apps/trainer/app/notification/reservation-change/page.tsx
@@ -148,7 +148,7 @@ function ReservationChangeNotificationPage() {
   const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
 
   const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed } = notification;
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
     if (notificationId !== selectedNotification?.notificationId) {
       setSelectedNotification({
         notificationId,
@@ -156,6 +156,7 @@ function ReservationChangeNotificationPage() {
         content,
         sendDate,
         isProcessed,
+        notificationType,
       });
     }
 

--- a/apps/trainer/app/notification/reservation-change/page.tsx
+++ b/apps/trainer/app/notification/reservation-change/page.tsx
@@ -1,186 +1,28 @@
-"use client";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 
-import { NotificationInfo } from "@5unwan/core/api/types/common";
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { Button } from "@ui/components/Button";
-import Header from "@ui/components/Header";
-import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
-import { Fragment, Suspense, useEffect, useRef, useState } from "react";
-
-import NotificationSideBar from "@trainer/app/notification/_components/NotificationSideBar";
 import { notificationQueries } from "@trainer/queries/notification";
-import { useNotificationStore } from "@trainer/store/notificationStore";
 
-import Logo from "@trainer/components/Logo";
+import ReservationChangeNotificationPageClient from "./_components/NotificationPageClient";
 
-import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+async function ReservationChangeNotificationPage() {
+  const queryClient = new QueryClient();
 
-import { commonLayoutContents } from "@trainer/constants/styles";
-
-import { NOTIFICATION_QUERY_TYPE, NOTIFICATION_TYPE } from "./_constants";
-import EmptyList from "../_components/EmptyList";
-import NotificationItemContainer from "../_components/NotificationItemContainer";
-import NotificationListFallback from "../_components/NotificationListFallback";
-import NotificationSearch from "../_components/NotificationSearch";
-import ReservationChangeSheet from "../_components/SheetRenderer/ReservationChangeSheet";
-import { NotificationStatus } from "../_types";
-import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
-import handleNotificationFilter from "../_utils/handleNotificationFilter";
-import { parseContent } from "../_utils/notificationParser";
-
-type ReservationChangeNotificationContentProps = {
-  onNotificationClick: (notification: NotificationInfo) => () => void;
-};
-function ReservationChangeNotificationContent({
-  onNotificationClick,
-}: ReservationChangeNotificationContentProps) {
-  const intersectionRef = useRef(null);
-
-  const [status, setStatus] = useState<NotificationStatus>("all");
-
-  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, refetch } =
-    useSuspenseInfiniteQuery(notificationQueries.list({ type: NOTIFICATION_QUERY_TYPE }));
-
-  const handleIntersect = () => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  };
-
-  useIntersectionObserver({
-    target: intersectionRef,
-    handleIntersect: handleIntersect,
-  });
-
-  const filteredNotificationCount = createFilteredNotificationCount(data, status);
-
-  const hasNewNotifications = useNotificationStore((state) =>
-    state.newNotificationTypes.has(NOTIFICATION_TYPE),
+  const listQuery = await queryClient.fetchInfiniteQuery(
+    notificationQueries.list({ type: "RESERVATION_CHANGE" }),
   );
-  const setNewNotificationTypes = useNotificationStore((state) => state.setNewNotificationTypes);
 
-  useEffect(() => {
-    setNewNotificationTypes((prev) => {
-      const newSet = new Set(prev);
-      newSet.delete(NOTIFICATION_TYPE);
+  const firstPageIds = listQuery.pages.flatMap((page) =>
+    page.data.content.map((n) => n.notificationId),
+  );
 
-      return newSet;
-    });
-  }, []);
+  await Promise.all(
+    firstPageIds.map((id) => queryClient.prefetchQuery(notificationQueries.detail(id))),
+  );
 
   return (
-    <>
-      <Header
-        logo={<Logo />}
-        subHeader={
-          <div className="bg-background-primary pb-2">
-            <ToggleGroup
-              type="single"
-              value={status}
-              onValueChange={setStatus as (value: string) => void}
-              className="w-full justify-start"
-            >
-              <ToggleGroupItem value="all">전체</ToggleGroupItem>
-              <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
-              <ToggleGroupItem value="complete">처리</ToggleGroupItem>
-            </ToggleGroup>
-          </div>
-        }
-      >
-        <Header.Left>
-          <NotificationSideBar />
-        </Header.Left>
-        <Header.Title content={NOTIFICATION_TYPE} />
-        <Header.Right>
-          <NotificationSearch />
-        </Header.Right>
-      </Header>
-      <main className={commonLayoutContents}>
-        <div className="flex items-center justify-between pb-2">
-          <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
-          <span className="text-body-3">최신순</span>
-        </div>
-        {hasNewNotifications && (
-          <div className="mb-4 flex w-full items-center justify-center">
-            <Button
-              size="sm"
-              variant="negative"
-              corners="pill"
-              iconLeft="RotateCcw"
-              onClick={() => {
-                setNewNotificationTypes((prev) => {
-                  const newSet = new Set(prev);
-                  newSet.delete(NOTIFICATION_TYPE);
-
-                  return newSet;
-                });
-
-                refetch();
-              }}
-            >
-              새 알림 확인하기
-            </Button>
-          </div>
-        )}
-        {data.pages[0].data.totalElements ? (
-          <ul className="flex flex-col gap-4">
-            {data.pages.map((group, index) => (
-              <Fragment key={`search-notificationGroup-${index}`}>
-                {group.data.content.filter(handleNotificationFilter(status)).map((notification) => (
-                  <NotificationItemContainer
-                    notification={notification}
-                    onClick={onNotificationClick(notification)}
-                    key={`search-notification-${notification.notificationId}`}
-                  />
-                ))}
-              </Fragment>
-            ))}
-            <div ref={intersectionRef} />
-          </ul>
-        ) : (
-          <EmptyList />
-        )}
-      </main>
-    </>
-  );
-}
-
-function ReservationChangeNotificationPage() {
-  const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
-  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
-
-  const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
-    if (notificationId !== selectedNotification?.notificationId) {
-      setSelectedNotification({
-        notificationId,
-        type,
-        content,
-        sendDate,
-        isProcessed,
-        notificationType,
-      });
-    }
-
-    setIsActionSheetOpen(true);
-  };
-
-  const info = selectedNotification
-    ? parseContent(selectedNotification.content)
-    : { message: "", eventDate: "", other: "" };
-
-  return (
-    <>
-      <Suspense fallback={<NotificationListFallback />}>
-        <ReservationChangeNotificationContent onNotificationClick={handleNotificationClick} />
-      </Suspense>
-      {selectedNotification && (
-        <ReservationChangeSheet
-          notificationId={selectedNotification.notificationId}
-          open={isActionSheetOpen}
-          onChangeOpen={setIsActionSheetOpen}
-          eventDateDescription={info.eventDate || ""}
-        />
-      )}
-    </>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ReservationChangeNotificationPageClient />
+    </HydrationBoundary>
   );
 }
 

--- a/apps/trainer/app/notification/reservation/_components/NotificationPageClient.tsx
+++ b/apps/trainer/app/notification/reservation/_components/NotificationPageClient.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable no-magic-numbers */
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import RouteInstance from "@trainer/constants/route";
+
+import ReservationContainer from "./ReservationContainer";
+
+function parseKoreanDateString(dateStr: string) {
+  // 현재 연도 사용 (필요시 인자로 받게 변경 가능)
+  const currentYear = new Date().getFullYear();
+
+  // 월, 일 추출
+  const match = dateStr
+    .replace(/[()\s]/g, "") // 괄호와 공백 제거
+    .replace("오전", "AM")
+    .replace("오후", "PM")
+    .match(/(\d{2})\.(\d{2})[^\d]*(AM|PM)(\d{1,2})시/); // 정규식 매칭
+
+  if (!match) {
+    throw new Error("Invalid date string format");
+  }
+
+  const [monthStr, dayStr, meridiem, hourStr] = match.slice(1); // 첫 번째는 전체 match이므로 제외
+
+  // 숫자 변환
+  const month = parseInt(monthStr, 10) - 1; // JS는 0-based month
+  const day = parseInt(dayStr, 10);
+  let hour = parseInt(hourStr, 10);
+
+  if (meridiem === "PM" && hour !== 12) {
+    hour += 12;
+  } else if (meridiem === "AM" && hour === 12) {
+    hour = 0;
+  }
+
+  // Date 객체 생성
+  return new Date(currentYear, month, day, hour);
+}
+
+function ReservationNotificationPageClient() {
+  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
+
+  const router = useRouter();
+
+  const handleNotificationClick = (notification: NotificationInfo) => () => {
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
+    if (notificationId !== selectedNotification?.notificationId) {
+      setSelectedNotification({
+        notificationId,
+        type,
+        notificationType,
+        content,
+        sendDate,
+        isProcessed,
+      });
+    }
+
+    const dateString = content.split("\n")[1].split("날짜: ")[1];
+
+    router.push(
+      RouteInstance["pending-reservations"]("", {
+        selectedDate: String(parseKoreanDateString(dateString)),
+        formattedSelectedDate: dateString,
+      }),
+    );
+  };
+
+  return <ReservationContainer onNotificationClick={handleNotificationClick} />;
+}
+
+export default ReservationNotificationPageClient;

--- a/apps/trainer/app/notification/reservation/_components/ReservationContainer.tsx
+++ b/apps/trainer/app/notification/reservation/_components/ReservationContainer.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { Button } from "@ui/components/Button";
+import Header from "@ui/components/Header";
+import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
+import { Suspense, useEffect, useRef, useState } from "react";
+
+import { notificationQueries } from "@trainer/queries/notification";
+import { useNotificationStore } from "@trainer/store/notificationStore";
+
+import Logo from "@trainer/components/Logo";
+
+import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+
+import { commonLayoutContents } from "@trainer/constants/styles";
+
+import EmptyList from "../../_components/EmptyList";
+import NotificationSearch from "../../_components/NotificationSearch";
+import NotificationSideBar from "../../_components/NotificationSideBar";
+import NotificationsPerPage from "../../_components/NotificationsPerPage";
+import NotificationsPerPageFallback from "../../_components/NotificationsPerPageFallback";
+import { NotificationStatus } from "../../_types";
+import createFilteredNotificationCount from "../../_utils/createFilteredNotificationCount";
+import handleNotificationFilter from "../../_utils/handleNotificationFilter";
+import { NOTIFICATION_QUERY_TYPE, NOTIFICATION_TYPE } from "../_constants";
+
+type ReservationContainerProps = {
+  onNotificationClick: (notification: NotificationInfo) => () => void;
+};
+function ReservationContainer({ onNotificationClick }: ReservationContainerProps) {
+  const intersectionRef = useRef(null);
+  const [status, setStatus] = useState<NotificationStatus>("all");
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, refetch } =
+    useSuspenseInfiniteQuery(notificationQueries.list({ type: NOTIFICATION_QUERY_TYPE }));
+  const handleIntersect = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  useIntersectionObserver({
+    target: intersectionRef,
+    handleIntersect: handleIntersect,
+  });
+
+  const filteredNotificationCount = createFilteredNotificationCount(data, status);
+
+  const hasNewNotifications = useNotificationStore((state) =>
+    state.newNotificationTypes.has(NOTIFICATION_TYPE),
+  );
+  const setNewNotificationTypes = useNotificationStore((state) => state.setNewNotificationTypes);
+
+  useEffect(() => {
+    setNewNotificationTypes((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(NOTIFICATION_TYPE);
+
+      return newSet;
+    });
+  }, []);
+
+  return (
+    <>
+      <Header
+        logo={<Logo />}
+        subHeader={
+          <div className="bg-background-primary pb-2">
+            <ToggleGroup
+              type="single"
+              value={status}
+              onValueChange={setStatus as (value: string) => void}
+              className="w-full justify-start"
+            >
+              <ToggleGroupItem value="all">전체</ToggleGroupItem>
+              <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
+              <ToggleGroupItem value="complete">처리</ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+        }
+      >
+        <Header.Left>
+          <NotificationSideBar />
+        </Header.Left>
+        <Header.Title content={NOTIFICATION_TYPE} />
+        <Header.Right>
+          <NotificationSearch />
+        </Header.Right>
+      </Header>
+      <main className={commonLayoutContents}>
+        <div className="flex items-center justify-between pb-2">
+          <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
+          <span className="text-body-3">최신순</span>
+        </div>
+        {hasNewNotifications && (
+          <div className="mb-4 flex w-full items-center justify-center">
+            <Button
+              size="sm"
+              variant="negative"
+              corners="pill"
+              iconLeft="RotateCcw"
+              onClick={() => {
+                setNewNotificationTypes((prev) => {
+                  const newSet = new Set(prev);
+                  newSet.delete(NOTIFICATION_TYPE);
+
+                  return newSet;
+                });
+
+                refetch();
+              }}
+            >
+              새 알림 확인하기
+            </Button>
+          </div>
+        )}
+        {data.pages[0].data.totalElements ? (
+          <ul className="flex flex-col gap-4">
+            {data.pages.map((group, pageIndex) => {
+              const notifications = group.data.content.filter(handleNotificationFilter(status));
+
+              return (
+                <Suspense
+                  fallback={<NotificationsPerPageFallback pageIndex={pageIndex} />}
+                  key={pageIndex}
+                >
+                  <NotificationsPerPage
+                    key={`notificationsPage-${pageIndex}`}
+                    notifications={notifications}
+                    onClick={onNotificationClick}
+                  />
+                </Suspense>
+              );
+            })}
+            <div ref={intersectionRef} />
+          </ul>
+        ) : (
+          <EmptyList />
+        )}
+      </main>
+    </>
+  );
+}
+
+export default ReservationContainer;

--- a/apps/trainer/app/notification/reservation/page.tsx
+++ b/apps/trainer/app/notification/reservation/page.tsx
@@ -179,11 +179,12 @@ function ReservationNotificationPage() {
   const router = useRouter();
 
   const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed } = notification;
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
     if (notificationId !== selectedNotification?.notificationId) {
       setSelectedNotification({
         notificationId,
         type,
+        notificationType,
         content,
         sendDate,
         isProcessed,

--- a/apps/trainer/app/notification/reservation/page.tsx
+++ b/apps/trainer/app/notification/reservation/page.tsx
@@ -1,212 +1,28 @@
-/* eslint-disable no-magic-numbers */
-"use client";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 
-import { NotificationInfo } from "@5unwan/core/api/types/common";
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { Button } from "@ui/components/Button";
-import Header from "@ui/components/Header";
-import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
-import { useRouter } from "next/navigation";
-import { Fragment, Suspense, useEffect, useRef, useState } from "react";
-
-import NotificationSideBar from "@trainer/app/notification/_components/NotificationSideBar";
 import { notificationQueries } from "@trainer/queries/notification";
-import { useNotificationStore } from "@trainer/store/notificationStore";
 
-import Logo from "@trainer/components/Logo";
+import ReservationNotificationPageClient from "./_components/NotificationPageClient";
 
-import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+async function ReservationNotificationPage() {
+  const queryClient = new QueryClient();
 
-import RouteInstance from "@trainer/constants/route";
-import { commonLayoutContents } from "@trainer/constants/styles";
-
-import EmptyList from "../_components/EmptyList";
-import NotificationItemContainer from "../_components/NotificationItemContainer";
-import { NotificationStatus } from "../_types";
-import { NOTIFICATION_QUERY_TYPE, NOTIFICATION_TYPE } from "./_constants";
-import NotificationSearch from "../_components/NotificationSearch";
-import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
-import handleNotificationFilter from "../_utils/handleNotificationFilter";
-
-function parseKoreanDateString(dateStr: string) {
-  // 현재 연도 사용 (필요시 인자로 받게 변경 가능)
-  const currentYear = new Date().getFullYear();
-
-  // 월, 일 추출
-  const match = dateStr
-    .replace(/[()\s]/g, "") // 괄호와 공백 제거
-    .replace("오전", "AM")
-    .replace("오후", "PM")
-    .match(/(\d{2})\.(\d{2})[^\d]*(AM|PM)(\d{1,2})시/); // 정규식 매칭
-
-  if (!match) {
-    throw new Error("Invalid date string format");
-  }
-
-  const [monthStr, dayStr, meridiem, hourStr] = match.slice(1); // 첫 번째는 전체 match이므로 제외
-
-  // 숫자 변환
-  const month = parseInt(monthStr, 10) - 1; // JS는 0-based month
-  const day = parseInt(dayStr, 10);
-  let hour = parseInt(hourStr, 10);
-
-  if (meridiem === "PM" && hour !== 12) {
-    hour += 12;
-  } else if (meridiem === "AM" && hour === 12) {
-    hour = 0;
-  }
-
-  // Date 객체 생성
-  return new Date(currentYear, month, day, hour);
-}
-
-type ReservationNotificationContentProps = {
-  onNotificationClick: (notification: NotificationInfo) => () => void;
-};
-function ReservationNotificationContent({
-  onNotificationClick,
-}: ReservationNotificationContentProps) {
-  const intersectionRef = useRef(null);
-  const [status, setStatus] = useState<NotificationStatus>("all");
-
-  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, refetch } =
-    useSuspenseInfiniteQuery(notificationQueries.list({ type: NOTIFICATION_QUERY_TYPE }));
-  const handleIntersect = () => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  };
-
-  useIntersectionObserver({
-    target: intersectionRef,
-    handleIntersect: handleIntersect,
-  });
-
-  const filteredNotificationCount = createFilteredNotificationCount(data, status);
-
-  const hasNewNotifications = useNotificationStore((state) =>
-    state.newNotificationTypes.has(NOTIFICATION_TYPE),
+  const listQuery = await queryClient.fetchInfiniteQuery(
+    notificationQueries.list({ type: "RESERVATION_REQUEST" }),
   );
-  const setNewNotificationTypes = useNotificationStore((state) => state.setNewNotificationTypes);
 
-  useEffect(() => {
-    setNewNotificationTypes((prev) => {
-      const newSet = new Set(prev);
-      newSet.delete(NOTIFICATION_TYPE);
+  const firstPageIds = listQuery.pages.flatMap((page) =>
+    page.data.content.map((n) => n.notificationId),
+  );
 
-      return newSet;
-    });
-  }, []);
+  await Promise.all(
+    firstPageIds.map((id) => queryClient.prefetchQuery(notificationQueries.detail(id))),
+  );
 
   return (
-    <>
-      <Header
-        logo={<Logo />}
-        subHeader={
-          <div className="bg-background-primary pb-2">
-            <ToggleGroup
-              type="single"
-              value={status}
-              onValueChange={setStatus as (value: string) => void}
-              className="w-full justify-start"
-            >
-              <ToggleGroupItem value="all">전체</ToggleGroupItem>
-              <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
-              <ToggleGroupItem value="complete">처리</ToggleGroupItem>
-            </ToggleGroup>
-          </div>
-        }
-      >
-        <Header.Left>
-          <NotificationSideBar />
-        </Header.Left>
-        <Header.Title content={NOTIFICATION_TYPE} />
-        <Header.Right>
-          <NotificationSearch />
-        </Header.Right>
-      </Header>
-      <main className={commonLayoutContents}>
-        <div className="flex items-center justify-between pb-2">
-          <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
-          <span className="text-body-3">최신순</span>
-        </div>
-        {hasNewNotifications && (
-          <div className="mb-4 flex w-full items-center justify-center">
-            <Button
-              size="sm"
-              variant="negative"
-              corners="pill"
-              iconLeft="RotateCcw"
-              onClick={() => {
-                setNewNotificationTypes((prev) => {
-                  const newSet = new Set(prev);
-                  newSet.delete(NOTIFICATION_TYPE);
-
-                  return newSet;
-                });
-
-                refetch();
-              }}
-            >
-              새 알림 확인하기
-            </Button>
-          </div>
-        )}
-        {data.pages[0].data.totalElements ? (
-          <ul className="flex flex-col gap-4">
-            {data.pages.map((group, index) => (
-              <Fragment key={`search-notificationGroup-${index}`}>
-                {group.data.content.filter(handleNotificationFilter(status)).map((notification) => (
-                  <NotificationItemContainer
-                    notification={notification}
-                    onClick={onNotificationClick(notification)}
-                    key={`search-notification-${notification.notificationId}`}
-                  />
-                ))}
-              </Fragment>
-            ))}
-            <div ref={intersectionRef} />
-          </ul>
-        ) : (
-          <EmptyList />
-        )}
-      </main>
-    </>
-  );
-}
-
-function ReservationNotificationPage() {
-  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
-
-  const router = useRouter();
-
-  const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
-    if (notificationId !== selectedNotification?.notificationId) {
-      setSelectedNotification({
-        notificationId,
-        type,
-        notificationType,
-        content,
-        sendDate,
-        isProcessed,
-      });
-    }
-
-    const dateString = content.split("\n")[1].split("날짜: ")[1];
-
-    router.push(
-      RouteInstance["pending-reservations"]("", {
-        selectedDate: String(parseKoreanDateString(dateString)),
-        formattedSelectedDate: dateString,
-      }),
-    );
-  };
-
-  return (
-    <>
-      <Suspense>
-        <ReservationNotificationContent onNotificationClick={handleNotificationClick} />
-      </Suspense>
-    </>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ReservationNotificationPageClient />
+    </HydrationBoundary>
   );
 }
 

--- a/apps/trainer/app/notification/session/_components/NotificationPageClient.tsx
+++ b/apps/trainer/app/notification/session/_components/NotificationPageClient.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useState } from "react";
+
+import SessionContainer from "./SessionContainer";
+import SessionCompleteSheet from "../../_components/SheetRenderer/SessionCompleteSheet";
+import { parseContent } from "../../_utils/notificationParser";
+
+function SessionNotificationPageClient() {
+  const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
+  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
+
+  const handleNotificationClick = (notification: NotificationInfo) => () => {
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
+    if (notificationId !== selectedNotification?.notificationId) {
+      setSelectedNotification({
+        notificationId,
+        type,
+        notificationType,
+        content,
+        sendDate,
+        isProcessed,
+      });
+    }
+
+    setIsActionSheetOpen(true);
+  };
+
+  const info = selectedNotification
+    ? parseContent(selectedNotification.content)
+    : { message: "", eventDate: "", other: "" };
+
+  return (
+    <>
+      <SessionContainer onNotificationClick={handleNotificationClick} />
+      {selectedNotification && (
+        <SessionCompleteSheet
+          notificationId={selectedNotification.notificationId}
+          open={isActionSheetOpen}
+          onChangeOpen={setIsActionSheetOpen}
+          eventDate={info.eventDate || ""}
+        />
+      )}
+    </>
+  );
+}
+
+export default SessionNotificationPageClient;

--- a/apps/trainer/app/notification/session/_components/SessionContainer.tsx
+++ b/apps/trainer/app/notification/session/_components/SessionContainer.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { NotificationInfo } from "@5unwan/core/api/types/common";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { Button } from "@ui/components/Button";
+import Header from "@ui/components/Header";
+import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
+import { Suspense, useEffect, useRef, useState } from "react";
+
+import { notificationQueries } from "@trainer/queries/notification";
+import { useNotificationStore } from "@trainer/store/notificationStore";
+
+import Logo from "@trainer/components/Logo";
+
+import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+
+import { commonLayoutContents } from "@trainer/constants/styles";
+
+import EmptyList from "../../_components/EmptyList";
+import NotificationSearch from "../../_components/NotificationSearch";
+import NotificationSideBar from "../../_components/NotificationSideBar";
+import NotificationsPerPage from "../../_components/NotificationsPerPage";
+import NotificationsPerPageFallback from "../../_components/NotificationsPerPageFallback";
+import { NotificationStatus } from "../../_types";
+import createFilteredNotificationCount from "../../_utils/createFilteredNotificationCount";
+import handleNotificationFilter from "../../_utils/handleNotificationFilter";
+import { NOTIFICATION_QUERY_TYPE, NOTIFICATION_TYPE } from "../_constants";
+
+type SessionContainerProps = {
+  onNotificationClick: (notification: NotificationInfo) => () => void;
+};
+function SessionContainer({ onNotificationClick }: SessionContainerProps) {
+  const intersectionRef = useRef(null);
+  const [status, setStatus] = useState<NotificationStatus>("all");
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, refetch } =
+    useSuspenseInfiniteQuery(notificationQueries.list({ type: NOTIFICATION_QUERY_TYPE }));
+
+  const handleIntersect = () => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  };
+
+  useIntersectionObserver({
+    target: intersectionRef,
+    handleIntersect: handleIntersect,
+  });
+
+  const filteredNotificationCount = createFilteredNotificationCount(data, status);
+
+  const hasNewNotifications = useNotificationStore((state) =>
+    state.newNotificationTypes.has(NOTIFICATION_TYPE),
+  );
+  const setNewNotificationTypes = useNotificationStore((state) => state.setNewNotificationTypes);
+
+  useEffect(() => {
+    setNewNotificationTypes((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(NOTIFICATION_TYPE);
+
+      return newSet;
+    });
+  }, []);
+
+  return (
+    <>
+      <Header
+        logo={<Logo />}
+        subHeader={
+          <div className="bg-background-primary pb-2">
+            <ToggleGroup
+              type="single"
+              value={status}
+              onValueChange={setStatus as (value: string) => void}
+              className="w-full justify-start"
+            >
+              <ToggleGroupItem value="all">전체</ToggleGroupItem>
+              <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
+              <ToggleGroupItem value="complete">처리</ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+        }
+      >
+        <Header.Left>
+          <NotificationSideBar />
+        </Header.Left>
+        <Header.Title content={NOTIFICATION_TYPE} />
+        <Header.Right>
+          <NotificationSearch />
+        </Header.Right>
+      </Header>
+      <main className={commonLayoutContents}>
+        <div className="flex items-center justify-between pb-2">
+          <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
+          <span className="text-body-3">최신순</span>
+        </div>
+        {hasNewNotifications && (
+          <div className="mb-4 flex w-full items-center justify-center">
+            <Button
+              size="sm"
+              variant="negative"
+              corners="pill"
+              iconLeft="RotateCcw"
+              onClick={() => {
+                setNewNotificationTypes((prev) => {
+                  const newSet = new Set(prev);
+                  newSet.delete(NOTIFICATION_TYPE);
+
+                  return newSet;
+                });
+
+                refetch();
+              }}
+            >
+              새 알림 확인하기
+            </Button>
+          </div>
+        )}
+        {data.pages[0].data.totalElements ? (
+          <ul className="flex flex-col gap-4">
+            {data.pages.map((group, pageIndex) => {
+              const notifications = group.data.content.filter(handleNotificationFilter(status));
+
+              return (
+                <Suspense
+                  fallback={<NotificationsPerPageFallback pageIndex={pageIndex} />}
+                  key={pageIndex}
+                >
+                  <NotificationsPerPage
+                    key={`notificationsPage-${pageIndex}`}
+                    notifications={notifications}
+                    onClick={onNotificationClick}
+                  />
+                </Suspense>
+              );
+            })}
+            <div ref={intersectionRef} />
+          </ul>
+        ) : (
+          <EmptyList />
+        )}
+      </main>
+    </>
+  );
+}
+
+export default SessionContainer;

--- a/apps/trainer/app/notification/session/page.tsx
+++ b/apps/trainer/app/notification/session/page.tsx
@@ -145,11 +145,12 @@ function SessionNotificationPage() {
   const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
 
   const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed } = notification;
+    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
     if (notificationId !== selectedNotification?.notificationId) {
       setSelectedNotification({
         notificationId,
         type,
+        notificationType,
         content,
         sendDate,
         isProcessed,

--- a/apps/trainer/app/notification/session/page.tsx
+++ b/apps/trainer/app/notification/session/page.tsx
@@ -1,183 +1,28 @@
-"use client";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 
-import { NotificationInfo } from "@5unwan/core/api/types/common";
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { Button } from "@ui/components/Button";
-import Header from "@ui/components/Header";
-import { ToggleGroup, ToggleGroupItem } from "@ui/components/ToggleGroup";
-import { useRef, useState, Fragment, Suspense, useEffect } from "react";
-
-import NotificationSideBar from "@trainer/app/notification/_components/NotificationSideBar";
 import { notificationQueries } from "@trainer/queries/notification";
-import { useNotificationStore } from "@trainer/store/notificationStore";
 
-import Logo from "@trainer/components/Logo";
+import SessionNotificationPageClient from "./_components/NotificationPageClient";
 
-import useIntersectionObserver from "@trainer/hooks/useIntersectionObserver";
+async function SessionNotificationPage() {
+  const queryClient = new QueryClient();
 
-import { commonLayoutContents } from "@trainer/constants/styles";
-
-import { NOTIFICATION_QUERY_TYPE, NOTIFICATION_TYPE } from "./_constants";
-import EmptyList from "../_components/EmptyList";
-import NotificationItemContainer from "../_components/NotificationItemContainer";
-import NotificationListFallback from "../_components/NotificationListFallback";
-import NotificationSearch from "../_components/NotificationSearch";
-import SessionCompleteSheet from "../_components/SheetRenderer/SessionCompleteSheet";
-import { NotificationStatus } from "../_types";
-import createFilteredNotificationCount from "../_utils/createFilteredNotificationCount";
-import handleNotificationFilter from "../_utils/handleNotificationFilter";
-import { parseContent } from "../_utils/notificationParser";
-
-type SessionNotificationContentProps = {
-  onNotificationClick: (notification: NotificationInfo) => () => void;
-};
-function SessionNotificationContent({ onNotificationClick }: SessionNotificationContentProps) {
-  const intersectionRef = useRef(null);
-  const [status, setStatus] = useState<NotificationStatus>("all");
-
-  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, refetch } =
-    useSuspenseInfiniteQuery(notificationQueries.list({ type: NOTIFICATION_QUERY_TYPE }));
-
-  const handleIntersect = () => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  };
-
-  useIntersectionObserver({
-    target: intersectionRef,
-    handleIntersect: handleIntersect,
-  });
-
-  const filteredNotificationCount = createFilteredNotificationCount(data, status);
-
-  const hasNewNotifications = useNotificationStore((state) =>
-    state.newNotificationTypes.has(NOTIFICATION_TYPE),
+  const listQuery = await queryClient.fetchInfiniteQuery(
+    notificationQueries.list({ type: "SESSION" }),
   );
-  const setNewNotificationTypes = useNotificationStore((state) => state.setNewNotificationTypes);
 
-  useEffect(() => {
-    setNewNotificationTypes((prev) => {
-      const newSet = new Set(prev);
-      newSet.delete(NOTIFICATION_TYPE);
+  const firstPageIds = listQuery.pages.flatMap((page) =>
+    page.data.content.map((n) => n.notificationId),
+  );
 
-      return newSet;
-    });
-  }, []);
+  await Promise.all(
+    firstPageIds.map((id) => queryClient.prefetchQuery(notificationQueries.detail(id))),
+  );
 
   return (
-    <>
-      <Header
-        logo={<Logo />}
-        subHeader={
-          <div className="bg-background-primary pb-2">
-            <ToggleGroup
-              type="single"
-              value={status}
-              onValueChange={setStatus as (value: string) => void}
-              className="w-full justify-start"
-            >
-              <ToggleGroupItem value="all">전체</ToggleGroupItem>
-              <ToggleGroupItem value="pending">미처리</ToggleGroupItem>
-              <ToggleGroupItem value="complete">처리</ToggleGroupItem>
-            </ToggleGroup>
-          </div>
-        }
-      >
-        <Header.Left>
-          <NotificationSideBar />
-        </Header.Left>
-        <Header.Title content={NOTIFICATION_TYPE} />
-        <Header.Right>
-          <NotificationSearch />
-        </Header.Right>
-      </Header>
-      <main className={commonLayoutContents}>
-        <div className="flex items-center justify-between pb-2">
-          <span className="text-body-3">{`${filteredNotificationCount}개의 알림`}</span>
-          <span className="text-body-3">최신순</span>
-        </div>
-        {hasNewNotifications && (
-          <div className="mb-4 flex w-full items-center justify-center">
-            <Button
-              size="sm"
-              variant="negative"
-              corners="pill"
-              iconLeft="RotateCcw"
-              onClick={() => {
-                setNewNotificationTypes((prev) => {
-                  const newSet = new Set(prev);
-                  newSet.delete(NOTIFICATION_TYPE);
-
-                  return newSet;
-                });
-
-                refetch();
-              }}
-            >
-              새 알림 확인하기
-            </Button>
-          </div>
-        )}
-        {data.pages[0].data.totalElements ? (
-          <ul className="flex flex-col gap-4">
-            {data.pages.map((group, index) => (
-              <Fragment key={`search-notificationGroup-${index}`}>
-                {group.data.content.filter(handleNotificationFilter(status)).map((notification) => (
-                  <NotificationItemContainer
-                    notification={notification}
-                    onClick={onNotificationClick(notification)}
-                    key={`search-notification-${notification.notificationId}`}
-                  />
-                ))}
-              </Fragment>
-            ))}
-            <div ref={intersectionRef} />
-          </ul>
-        ) : (
-          <EmptyList />
-        )}
-      </main>
-    </>
-  );
-}
-
-function SessionNotificationPage() {
-  const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
-  const [selectedNotification, setSelectedNotification] = useState<NotificationInfo>();
-
-  const handleNotificationClick = (notification: NotificationInfo) => () => {
-    const { notificationId, type, content, sendDate, isProcessed, notificationType } = notification;
-    if (notificationId !== selectedNotification?.notificationId) {
-      setSelectedNotification({
-        notificationId,
-        type,
-        notificationType,
-        content,
-        sendDate,
-        isProcessed,
-      });
-    }
-
-    setIsActionSheetOpen(true);
-  };
-
-  const info = selectedNotification
-    ? parseContent(selectedNotification.content)
-    : { message: "", eventDate: "", other: "" };
-
-  return (
-    <>
-      <Suspense fallback={<NotificationListFallback />}>
-        <SessionNotificationContent onNotificationClick={handleNotificationClick} />
-      </Suspense>
-      {selectedNotification && (
-        <SessionCompleteSheet
-          notificationId={selectedNotification.notificationId}
-          open={isActionSheetOpen}
-          onChangeOpen={setIsActionSheetOpen}
-          eventDate={info.eventDate || ""}
-        />
-      )}
-    </>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <SessionNotificationPageClient />
+    </HydrationBoundary>
   );
 }
 

--- a/packages/core/src/api/types/common.ts
+++ b/packages/core/src/api/types/common.ts
@@ -98,9 +98,11 @@ export type ReservationPathParams = {
   reservationId: number;
 };
 
+// TODO: [2025.07.27] notificationType 타입 정의
 export type NotificationInfo = {
   notificationId: number;
   type: NotificationType;
+  notificationType: string;
   content: string;
   sendDate: string;
   isProcessed: boolean;
@@ -110,6 +112,7 @@ export type NotificationDetailInfo = {
   notificationId: number;
   refId: number;
   type: NotificationType;
+  notificationType: string;
   content: string;
   sendDate: string;
   isProcessed: boolean;


### PR DESCRIPTION
# [FLIZ-452/trainer] feat: 알림 도메인 API 업데이트 및 페이지 네트워크 최적화

## 📝 작업 내용

- 트레이너 서비스에서 '세션' type 알림 종류가 '세션 곧 종료' / '세션 완료' 알림으로 분기되었습니다. 따라서 기존 '세션' 알림 클릭 시 UX를 '세션 곧 종료' + '세션 완료' 알림 으로 분리하는 작업을 진행했습니다. 
'세션 곧 종료' 알림 클릭 시 'schedule-management' 페이지로 redirect합니다
'세션 완료' 알림 클릭 시 별도의 UX 없이 알림 읽음 API만 호출합니다

*** 기존 '세션' 처리 BottomSheet는 사용하지 않습니다. 업데이트된 알림 API 구조상, 알림 정보에서 session 처리 API 호출에 필요한 데이터를 받아올 수 없게 되었습니다. 따라서 일단 schedule-management 페이지로 redirect 하고, 사용자가 직업 time cell을 클릭해서 처리하는 UX로 수정했습니다.

- 알림 페이지 및 하위 페이지 네트워크 waterfall을 최적화하였습니다
tanstack query의 prefetchQuery를 활용하여 notification detail API를 미리 호출하도록 수정했습니다. 또한 상위 Suspense로 인해 notification detail API가 serial 하게 fetch되던 문제를 해결하기 위해 일부 Suspense를 제거하고 RSC를 활용했습니다.

기존 워터폴의 diagram입니다
```
page.tsx (client)
│
├── NotificationContainer (client)
│   └── Suspense (page suspends here)
│       ├── useSuspenseInfiniteQuery → 🔄 GET /notifications?page=0
│       └── for each notification:
│            ├── Suspense
│            │   └── useSuspenseQuery → 🔄 GET /notification/:id   ← waits
│            ├── Suspense
│            │   └── useSuspenseQuery → 🔄 GET /notification/:id   ← waits
│            └── ...

```
다음은 수정된 버전의 워터폴 diagram입니다
```
page.tsx (server)
│
├── fetchInfiniteQuery → 🔄 GET /notifications?page=0 ✅
├── for each notificationId on page 0:
│   └── prefetchQuery → 🔄 GET /notification/:id ✅
│
└── <HydrationBoundary>
     └── NotificationPageClient (client)
         └── NotificationContainer (client)
             └── useSuspenseInfiniteQuery → (uses dehydrated state) ✅
             └── render list immediately
                 ├── NotificationItemContainer 1 (no fetch – already cached)
                 ├── NotificationItemContainer 2 (no fetch – already cached)
                 └── ...

// RUNTIME
User scrolls to next page
└── useSuspenseInfiniteQuery → 🔄 GET /notifications?page=1 ✅
├── For each notificationId on page:
│   ├── 🔄 GET /notification/:id
│   ├── 🔄 GET /notification/:id
│   └── ...
```
```
// Legend

🔄 = API fetch

✅ = happens once / controlled fetch

(no fetch) = cache hit (from server-side prefetch)
```
### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
