### PR TITLE
[FLIZ-453/root] refactor: 페이지 router 특징에 따른 라우팅 함수 (push, replace) 적용

### DIFF
--- a/apps/trainer/app/my-page/_components/LogoutButton.tsx
+++ b/apps/trainer/app/my-page/_components/LogoutButton.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Badge } from "@ui/components/Badge";
 import { Button } from "@ui/components/Button";
 import {
@@ -20,6 +20,7 @@ import RouteInstance from "@trainer/constants/route";
 
 export default function LogoutButton() {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const { mutate: logoutMutate } = useMutation({
     mutationFn: clearToken,
@@ -28,6 +29,7 @@ export default function LogoutButton() {
   const handleClickLogout = () => {
     logoutMutate(undefined, {
       onSuccess: () => {
+        queryClient.clear();
         router.push(RouteInstance.login());
       },
     });

--- a/apps/trainer/app/my-page/_components/MyPageHeader.tsx
+++ b/apps/trainer/app/my-page/_components/MyPageHeader.tsx
@@ -13,27 +13,25 @@ type MyPageHeaderProps = {
   name: string;
   imageSrc: string;
 };
-function MyPageHeader({ name, imageSrc }: MyPageHeaderProps) {
+
+export default function MyPageHeader({ name, imageSrc }: MyPageHeaderProps) {
   const router = useRouter();
 
-  const handleClickLogout = (page: string) => {
-    router.push(page);
+  const handleClickRoutingMyInformation = () => {
+    router.push(RouteInstance["my-information"]());
   };
 
   return (
     <section className="flex w-full justify-between">
       <ProfileHeader>
-        <ProfileHeader.Section onClick={() => handleClickLogout(RouteInstance["my-information"]())}>
+        <ProfileHeader.Section onClick={handleClickRoutingMyInformation}>
           <ProfileHeader.Avatar>
             <Image width={50} height={50} src={imageSrc || ""} alt={`${name} 프로필`} />
           </ProfileHeader.Avatar>
           <ProfileHeader.Name name={name} />
         </ProfileHeader.Section>
       </ProfileHeader>
-
       <LogoutButton />
     </section>
   );
 }
-
-export default MyPageHeader;

--- a/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleConfirmStep/ScheduleChangeResultSheet.tsx
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleConfirmStep/ScheduleChangeResultSheet.tsx
@@ -10,28 +10,21 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@ui/components/Sheet";
-import { useRouter } from "next/navigation";
 import React from "react";
-
-import { MYPAGE_ROUTES } from "@trainer/constants/mypageRoute";
 
 import { formatDateStringToKorean } from "@trainer/utils/avaliableScheduleUtils";
 
 interface ScheduleChangeResultSheetProps {
   children: React.ReactNode;
   scheduleApplyAt?: string;
+  onNext?: () => void;
 }
 
 export default function ScheduleChangeResultSheet({
   children,
   scheduleApplyAt,
+  onNext,
 }: ScheduleChangeResultSheetProps) {
-  const router = useRouter();
-
-  const handleClickConfirm = () => {
-    router.push(MYPAGE_ROUTES.MY_PAGE);
-  };
-
   return (
     <Sheet>
       <SheetTrigger>{children}</SheetTrigger>
@@ -49,7 +42,7 @@ export default function ScheduleChangeResultSheet({
         </SheetDescription>
         <SheetFooter>
           <SheetClose asChild>
-            <Button variant={"brand"} className="h-[2.5rem] w-full" onClick={handleClickConfirm}>
+            <Button variant={"brand"} className="h-[2.5rem] w-full" onClick={onNext}>
               확인
             </Button>
           </SheetClose>

--- a/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleConfirmStep/index.tsx
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleConfirmStep/index.tsx
@@ -17,12 +17,17 @@ import useDeleteScheduleMutation from "../../_hooks/useDeleteScheduleMutation";
 
 type EditScheduleConfirmStepProps = {
   onPrev: () => void;
+  onNext: () => void;
   context: {
     applyAt: string;
     availableTimes: Omit<AvailablePtTime, "availableTimeId">[];
   };
 };
-export default function EditScheduleConfirmStep({ onPrev, context }: EditScheduleConfirmStepProps) {
+export default function EditScheduleConfirmStep({
+  onPrev,
+  onNext,
+  context,
+}: EditScheduleConfirmStepProps) {
   const queryClient = useQueryClient();
   const { data: currentData } = useQuery(myInformationQueries.ptAvailableTime());
 
@@ -76,7 +81,7 @@ export default function EditScheduleConfirmStep({ onPrev, context }: EditSchedul
           </p>
         </div>
       </div>
-      <ScheduleChangeResultSheet scheduleApplyAt={applyAt}>
+      <ScheduleChangeResultSheet scheduleApplyAt={applyAt} onNext={onNext}>
         <Button className="w-full" size="lg" variant="brand" onClick={handleClickChangeSchedule}>
           변경
         </Button>

--- a/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleFunnel.tsx
+++ b/apps/trainer/app/my-page/edit-workout-schedule/_components/EditScheduleFunnel.tsx
@@ -4,6 +4,8 @@ import { AvailablePtTime } from "@5unwan/core/api/types/common";
 import { useFunnel } from "@use-funnel/browser";
 import dynamic from "next/dynamic";
 
+const BACK_FUNNEL_STEP_COUNT = -3;
+
 const EditScheduleStep = dynamic(() => import("./EditScheduleStep"), {
   ssr: false,
 });
@@ -35,7 +37,7 @@ export default function EditScheduleFunnel() {
         <EditScheduleStep
           onPrev={() => funnel.history.back()}
           onNext={(availableTimes) =>
-            funnel.history.replace("editScheduleApplyAt", {
+            funnel.history.push("editScheduleApplyAt", {
               availableTimes,
             })
           }
@@ -50,7 +52,13 @@ export default function EditScheduleFunnel() {
       );
     case "editScheduleConfirm":
       return (
-        <EditScheduleConfirmStep onPrev={() => funnel.history.back()} context={funnel.context} />
+        <EditScheduleConfirmStep
+          onPrev={() => funnel.history.back()}
+          context={funnel.context}
+          onNext={() => {
+            funnel.history.go(BACK_FUNNEL_STEP_COUNT);
+          }}
+        />
       );
   }
 }

--- a/apps/trainer/app/schedule-management/dayoff-management/_components/DayoffCalendarContainer/DayoffAdderButton.tsx
+++ b/apps/trainer/app/schedule-management/dayoff-management/_components/DayoffCalendarContainer/DayoffAdderButton.tsx
@@ -16,8 +16,6 @@ import { format } from "date-fns";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
-import RouteInstance from "@trainer/constants/route";
-
 import { useDayoffAddMutation } from "../../_hooks/mutations/useDayoffAddMutation";
 
 type DayoffAdderButtonProps = {
@@ -41,7 +39,7 @@ function DayoffAdderButton({ selectedDate }: DayoffAdderButtonProps) {
   };
 
   const handleClickCloseDayoffAdderSheet = () => {
-    router.push(RouteInstance["schedule-management"]());
+    router.back();
   };
 
   useEffect(() => {

--- a/apps/user/app/my-page/_components/LogoutButton.tsx
+++ b/apps/user/app/my-page/_components/LogoutButton.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Badge } from "@ui/components/Badge";
 import { Button } from "@ui/components/Button";
 import {
@@ -20,6 +20,7 @@ import RouteInstance from "@user/constants/routes";
 
 export default function LogoutButton() {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const { mutate } = useMutation({
     mutationFn: clearToken,
@@ -28,6 +29,7 @@ export default function LogoutButton() {
   const handleClickLogout = () => {
     mutate(undefined, {
       onSuccess: () => {
+        queryClient.clear();
         router.push(RouteInstance.login());
       },
     });

--- a/apps/user/app/my-page/_components/ProfileHeader.tsx
+++ b/apps/user/app/my-page/_components/ProfileHeader.tsx
@@ -17,18 +17,14 @@ interface HeaderProps {
 export default function ProfileHeader({ userName, profilePictureUrl }: HeaderProps) {
   const router = useRouter();
 
-  const handleClickRouting = (path: string) => {
-    router.push(path);
+  const handleClickRoutingMyInformation = () => {
+    router.push(RouteInstance["my-information"]());
   };
 
   return (
     <section className="flex items-center justify-between">
       <Profile>
-        <Profile.Section
-          onClick={() => {
-            handleClickRouting(RouteInstance["my-information"]());
-          }}
-        >
+        <Profile.Section onClick={handleClickRoutingMyInformation}>
           <Profile.Avatar>
             <Image
               width={50}

--- a/apps/user/app/my-page/connect-trainer/_components/InputOTP/index.tsx
+++ b/apps/user/app/my-page/connect-trainer/_components/InputOTP/index.tsx
@@ -47,7 +47,7 @@ export default function InputOTP() {
 
   useEffect(() => {
     if (isSuccess) {
-      router.push(RouteInstance["my-page"]());
+      router.replace(RouteInstance["my-page"]());
     }
     if (isError) {
       setStatus("error");

--- a/apps/user/app/my-page/edit-workout-schedules/_components/BottomSheet/SuccessEditPreferenceTimeBottomSheet.tsx
+++ b/apps/user/app/my-page/edit-workout-schedules/_components/BottomSheet/SuccessEditPreferenceTimeBottomSheet.tsx
@@ -15,8 +15,6 @@ import {
 import { useRouter } from "next/navigation";
 import React from "react";
 
-import RouteInstance from "@user/constants/routes";
-
 interface SuccessEditPreferenceTimeBottomSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -28,7 +26,7 @@ function SuccessEditPreferenceTimeBottomSheet({
   const router = useRouter();
 
   const handleClickClose = () => {
-    router.push(RouteInstance["my-page"]());
+    router.back();
   };
 
   return (

--- a/packages/core/src/api/core.ts
+++ b/packages/core/src/api/core.ts
@@ -33,6 +33,8 @@ export const initCoreApi = ({ baseUrl, tokenProvider }: CoreApiConfig) => {
 
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
+    } else {
+      window.location.href = "/login";
     }
 
     return config;


### PR DESCRIPTION
## 📝 작업 내용

* 각 페이지 특성에 맞는 라우팅 함수로 변경하였습니다.
앱에서 라우팅이 이루어질 때, 뒤로가기를 통해 다시 돌아갈 수 없어야 할 페이지에 대해 router의 `replace()`를 사용하여 이전 페이지에 접근을 방지하였습니다.

* `@toss/useFunnel`에 경우 funnel 작업에 대한 back() 기능 제공을 위하여 push로 history를 쌓아놓는 방식 이후, next router에는 몇 단계 돌리는 기능이 없어 onNext()를 추가하여 funnel.history 함수를 통하여 Trainer 희망 수업 시간 변경 funnel의 3단계(변경 -> 날짜선택 -> 확인) 만큼의 -3값을 `.go()` 를 사용하여 희망 시간 변경 페이지의 재진입을 방지하였습니다.

[@toss/useFunnel history 문서](https://use-funnel.slash.page/ko/docs/use-funnel#funnelhistory)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
