### PR TITLE
[FLIZ-457/root] feat: pretendard 폰트 적용

### DIFF
--- a/apps/trainer/app/layout.tsx
+++ b/apps/trainer/app/layout.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@ui/lib/utils";
 import { Viewport } from "next";
 import localFont from "next/font/local";
 
@@ -28,15 +27,12 @@ export default function RootLayout({
   return (
     <html
       lang="ko"
-      className={cn(
-        "bg-background-primary text-text-primary flex h-full flex-col",
-        pretendard.variable,
-      )}
+      className={`${pretendard.variable} bg-background-primary text-text-primary font-pretendard flex h-full flex-col`}
     >
       <head>
         <PWAManifestLinks />
       </head>
-      <body className={cn("m-0 flex-1", pretendard.className)}>
+      <body className={"font-pretendard m-0 flex-1"}>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/apps/user/app/layout.tsx
+++ b/apps/user/app/layout.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@ui/lib/utils";
 import { Viewport } from "next";
 import localFont from "next/font/local";
 
@@ -28,15 +27,12 @@ export default function RootLayout({
   return (
     <html
       lang="ko"
-      className={cn(
-        "bg-background-primary text-text-primary flex h-full flex-col",
-        pretendard.variable,
-      )}
+      className={`${pretendard.variable} bg-background-primary text-text-primary font-pretendard flex h-full flex-col`}
     >
       <head>
         <PWAManifestLinks />
       </head>
-      <body className={cn("m-0 flex-1", pretendard.className)}>
+      <body className={"font-pretendard m-0 flex-1"}>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/packages/config-tailwind/tailwind.config.ts
+++ b/packages/config-tailwind/tailwind.config.ts
@@ -7,6 +7,9 @@ import type { Config } from "tailwindcss";
 const config: Omit<Config, "content"> = {
   theme: {
     extend: {
+      fontFamily: {
+        pretendard: ["var(--font-pretendard)"],
+      },
       screens: {
         xs: "380px",
       },


### PR DESCRIPTION
# [FLIZ-457/root] feat: pretendard 폰트 적용

## 📝 작업 내용

기존에 내려받기만 했던 pretendard local font를 서비스에 적용하는 작업을 진행했습니다
이를 위해 tailwind config 파일에 pretendard font를 추가하고 각 app 별 root layout에 `font-pretendard` 를 추가했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
