### PR TITLE
[FLIZ-461/root] feat: 로고 우측에 사용자 가이드 페이지 링크 연결

### DIFF
--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { MouseEventHandler, ReactNode } from "react";
 
 import { cn } from "@ui/lib/utils";
 
+import Icon from "./Icon";
 import { Text } from "./Text";
 
 type HeaderRootProps = {
@@ -13,16 +14,38 @@ type HeaderRootProps = {
   subHeader?: ReactNode;
   className?: string;
 };
+
+const GUIDE_URL =
+  "https://www.notion.so/Fit-Link-245764b4d45580da9230e07a9e3b374e?source=copy_link";
+
 function HeaderRoot({ logo, subHeader, children, className }: HeaderRootProps) {
   const hasChildren = Array.isArray(children) ? children.some((child) => !!child) : children;
+
+  const handleClickOpenInformation = () => {
+    if (typeof window !== "undefined") {
+      if (window.matchMedia("(display-mode: standalone)").matches) {
+        window.open(GUIDE_URL, "_blank", "noopener,noreferrer");
+      } else {
+        window.open(GUIDE_URL, "_blank");
+      }
+    }
+  };
 
   return (
     <>
       <section className="w-full">
         <header className={cn("bg-background-primary z-10 w-full")}>
           {logo && (
-            <div className={cn("flex h-[3rem] items-center justify-start transition-transform")}>
-              {logo}
+            <div className="flex items-center justify-between">
+              <div className={cn("flex h-[3rem] items-center justify-start transition-transform")}>
+                {logo}
+              </div>
+              <Icon
+                name="Info"
+                size="lg"
+                className="cursor-pointer"
+                onClick={handleClickOpenInformation}
+              />
             </div>
           )}
         </header>


### PR DESCRIPTION
## 📝 작업 내용
기존 개인 워크스페이스에 있던 문서를 [새로운 워크스페이스](https://www.notion.so/Fit-Link-245764b4d45580da9230e07a9e3b374e?source=copy_link)를 생성하여 가이드 내용을 옮겨두었으며, 사용자 가이드에 앱으로 이용하는 방법에 대한 내용을 추가하였습니다.

앱 우측 상단에 유저 가이드 페이지로 이동할 수 있는 기능을 구현하였습니다.

데스크탑 클릭 시 새로운 탭을, 앱에서 클릭 시 앱을 벗어나지 않고 새로운 윈도우에서 가이드 페이지가 나타나도록 하였습니다.
Header가 공통으로 사용되고 있어 연결 링크는 가이드 페이지의 부모페이지인 앱 서비스 인사 페이지로 연결하였습니다.


<img width="280" alt="스크린샷 2025-08-05 오전 2 49 16" src="https://github.com/user-attachments/assets/c7157ca2-f3e2-47c4-9fb3-b919aa193baa" />

<img width="280" alt="스크린샷 2025-08-05 오전 2 49 26" src="https://github.com/user-attachments/assets/616e31ab-6b48-43a4-a6f5-193baf8239f4" />




> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
