### PR TITLE
[FLIZ-462] feat: axios 토큰 검사 시,  SSR에서의 window 참조 방지를 위한 조건 설정

### DIFF
--- a/packages/core/src/api/core.ts
+++ b/packages/core/src/api/core.ts
@@ -34,7 +34,9 @@ export const initCoreApi = ({ baseUrl, tokenProvider }: CoreApiConfig) => {
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     } else {
-      window.location.href = "/login";
+      if (typeof window !== "undefined") {
+        window.location.href = "/login";
+      }
     }
 
     return config;


### PR DESCRIPTION
## 📝 작업 내용
기존 SSR에서도 토큰이 없는 경우  `window`를 사용할 수 있는 경우를 방지하기 위하여 조건값을 추가하였습니다.

❓ 왜 기존 코드에서 조건만 더했는가
[StackOveflow](https://stackoverflow.com/questions/77872949/next-js-14-0-4-browser-back-button-allows-access-to-protected-routes-after-log) 및 블로그를 확인해본 결과 
axios 사용처 혹은 middleware에서 토큰을 검사 후 NextResponse.redirect()를 통하여  페이지를 이동시켜주는 것을 확인하였습니다.

좀 더 안전하게 진입을 막기 위해서 클라이언트 컴포넌트에서 (로그아웃 후 뒤로가기를 하였을 때 마이페이지에 진입할 수 밖에 없는 상황이라 MyPage에서 토큰을 검사하려하였으나 Next useRouter 이벤트 사용)
클라이언트 컴포넌트에서 검사하고자한다면, access-token만을 검사할 수 있는데, access-token이 없는 상태라고 login 페이지로 사용자를 보내주는 것은 동작에 맞지 않는다고 생각하였습니다.(리프레시가 있으면 access-token이 만료됐거나 없을 때 재발급할 수 있기 때문에)

Next 서버에서 검사하면 보일러 플레이트가 발생할 것 같으며, 뒤로가기 후,  core 파일의 axios가 실행되는 것을 확인하고 core.ts 단에서 방지하고자 하였습니다.

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
