### PR TITLE
[FLIZ-456/root] fix: 예약 변경 승인 타임블록 이슈 수정

### DIFF
--- a/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
@@ -80,12 +80,11 @@ export default function TimeBlock({
 
   const currentStatus: Exclude<
     ReservationStatus,
-    "휴무일" | "예약 취소 요청" | "예약 변경 요청" | "예약 취소" | "예약 거절"
+    "휴무일" | "예약 취소 요청" | "예약 취소" | "예약 거절"
   > | null =
     reservationContent.length > 0 &&
     reservationContent[0].status !== "휴무일" &&
     reservationContent[0].status !== "예약 취소 요청" &&
-    reservationContent[0].status !== "예약 변경 요청" &&
     reservationContent[0].status !== "예약 취소" &&
     reservationContent[0].status !== "예약 거절"
       ? reservationContent[0].status

--- a/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/TimeBlock.tsx
@@ -64,7 +64,6 @@ export default function TimeBlock({
     reservationContent.length > 0 &&
     reservationContent[0].status !== "휴무일" &&
     reservationContent[0].status !== "예약 취소 요청" &&
-    reservationContent[0].status !== "예약 변경 요청" &&
     reservationContent[0].status !== "예약 취소"
       ? RESERVATION_CONFIG[reservationContent[0].status as keyof typeof RESERVATION_CONFIG]
       : null;

--- a/apps/trainer/app/schedule-management/_components/Calendar/WeekRow.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/WeekRow.tsx
@@ -39,6 +39,7 @@ export default function WeekRow({
   const { data: reservationInformation, isLoading } = useQuery({
     ...reservationQueries.list(reservationQueryDate),
     enabled: isCurrentWeek,
+    refetchOnMount: true,
   });
 
   if (!reservationInformation || isLoading) return null;

--- a/apps/trainer/app/schedule-management/_components/Calendar/index.tsx
+++ b/apps/trainer/app/schedule-management/_components/Calendar/index.tsx
@@ -48,7 +48,10 @@ function Calendar() {
   const currentMonth = currentWeek[0].getMonth() + MONTH_START_INDEX;
 
   const [{ data: dayoff }, { data: ptAvailableTime }] = useSuspenseQueries({
-    queries: [myInformationQueries.dayOff(), myInformationQueries.ptAvailableTime()],
+    queries: [
+      { ...myInformationQueries.dayOff(), refetchOnMount: true },
+      { ...myInformationQueries.ptAvailableTime(), refetchOnMount: true },
+    ],
   });
 
   const handleChangeSlide = (swiperConfig: SwiperConfig) => {

--- a/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/ReservationChangeRequestBottomSheet.tsx
+++ b/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/ReservationChangeRequestBottomSheet.tsx
@@ -1,0 +1,88 @@
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@ui/components/Button";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@ui/components/Sheet";
+import DateController from "@ui/lib/DateController";
+import { useRouter } from "next/navigation";
+
+import { userManagementQueries } from "@trainer/queries/userManagement";
+
+import { ModifiedReservationListItem } from "@trainer/services/types/reservations.dto";
+
+import ProfileCard from "@trainer/components/ProfileCard";
+
+import RouteInstance from "@trainer/constants/route";
+
+import ProfileCardFallback from "../Fallback/ProfileCardFallback";
+
+type ReservationChangeRequestBottomSheetProps = {
+  open: boolean;
+  onChangeOpen: (isOpen: boolean) => void;
+  selectedDate: Date;
+  memberInformation: ModifiedReservationListItem;
+};
+
+function ReservationChangeRequestBottomSheet({
+  open,
+  onChangeOpen,
+  selectedDate,
+  memberInformation,
+}: ReservationChangeRequestBottomSheetProps) {
+  const router = useRouter();
+
+  const { memberInfo } = memberInformation;
+  const { memberId, name } = memberInfo;
+
+  const selectedFormatDate = DateController(selectedDate).toDateTimeWithDayFormat();
+
+  const { data: userInformationDetail, isLoading: userInformationDetailLoading } = useQuery({
+    ...userManagementQueries.detail(memberId as number),
+    enabled: !!memberId,
+  });
+
+  const handleClicMovekNotificationPage = () => {
+    router.push(RouteInstance.notification("reservation-change"));
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onChangeOpen}>
+      <SheetContent side={"bottom"} className="md:w-mobile md:inset-x-[calc((100%-30rem)/2)]">
+        <SheetHeader className="items-center">
+          <SheetTitle className="flex justify-center">{selectedFormatDate}</SheetTitle>
+          <SheetDescription className="whitespace-pre-line text-center">
+            {`${name}님이 예약 변경을 요청하였습니다.\n예약 페이지에서 요청 사항을 확인하고 거절 또는 승인해주세요.`}
+          </SheetDescription>
+        </SheetHeader>
+        {userInformationDetailLoading ? (
+          <ProfileCardFallback />
+        ) : (
+          userInformationDetail && (
+            <ProfileCard
+              imgUrl={userInformationDetail.data.profilePictureUrl}
+              userBirth={new Date(userInformationDetail.data.birthDate)}
+              userName={userInformationDetail.data.name}
+              phoneNumber={userInformationDetail.data.phoneNumber}
+              className="bg-background-sub1 w-full md:hover:bg-none"
+            />
+          )
+        )}
+        <SheetFooter>
+          <SheetClose asChild>
+            <Button className="h-[3.375rem] w-full" onClick={handleClicMovekNotificationPage}>
+              알림 페이지로 이동
+            </Button>
+          </SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export default ReservationChangeRequestBottomSheet;

--- a/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/index.tsx
+++ b/apps/trainer/app/schedule-management/_components/ReservationManagementSheet/index.tsx
@@ -3,6 +3,7 @@ import { isPast, parseISO } from "date-fns";
 
 import { ModifiedReservationListItem } from "@trainer/services/types/reservations.dto";
 
+import ReservationChangeRequestBottomSheet from "./ReservationChangeRequestBottomSheet";
 import ReservationControlSheet from "./ReservationControlSheet";
 import ReservationNotAllowedCancelSheet from "./ReservationNotAllowedCancelSheet";
 import ReservationOutcomeSheet from "./ReservationOutcomeSheet";
@@ -28,10 +29,7 @@ const isReservationPast = (reservation: ModifiedReservationListItem): boolean =>
 };
 
 export const SheetAdapter: Record<
-  Exclude<
-    ReservationStatus,
-    "휴무일" | "예약 취소 요청" | "예약 변경 요청" | "예약 취소" | "예약 거절"
-  >,
+  Exclude<ReservationStatus, "휴무일" | "예약 취소 요청" | "예약 취소" | "예약 거절">,
   ReservationSheetRenderer
 > = {
   "예약 불가 설정": (commonProps, reservationContent) => (
@@ -110,4 +108,10 @@ export const SheetAdapter: Record<
       />
     );
   },
+  "예약 변경 요청": (commonProps, reservationContent) => (
+    <ReservationChangeRequestBottomSheet
+      {...commonProps}
+      memberInformation={reservationContent[0]}
+    />
+  ),
 };

--- a/apps/trainer/app/schedule-management/_constants/reservationConfig.ts
+++ b/apps/trainer/app/schedule-management/_constants/reservationConfig.ts
@@ -12,10 +12,12 @@ type ReservationConfig = {
   }) => string;
 };
 
+// 예약 변경 요청 필터링 X
+// 캘린더 페이지 진입할때마다 캐시 날리고 쿼리 다시 가져오기
 export const RESERVATION_CONFIG: Record<
   Exclude<
     ModifiedReservationListItem["status"],
-    "휴무일" | "예약 취소 요청" | "예약 변경 요청" | "예약 취소" | "예약 거절"
+    "휴무일" | "예약 취소 요청" | "예약 취소" | "예약 거절"
   >,
   ReservationConfig
 > = {
@@ -53,5 +55,10 @@ export const RESERVATION_CONFIG: Record<
     style: "bg-brand-primary-500 md:hover:bg-brand-primary-600",
     content: (reservationContent) => reservationContent.memberInfo.name,
     ptStatus: () => "예약 확정",
+  },
+  "예약 변경 요청": {
+    style: "bg-brand-primary-500 md:hover:bg-brand-primary-600",
+    content: (reservationContent) => reservationContent.memberInfo.name,
+    ptStatus: () => "예약 변경 요청",
   },
 };

--- a/apps/user/app/schedule-management/_components/Calendar/index.tsx
+++ b/apps/user/app/schedule-management/_components/Calendar/index.tsx
@@ -43,6 +43,7 @@ export default function Calendar() {
   const { data: reservations } = useQuery({
     ...reservationQueries.list(format(firstDayOfMonth, "yyyy-MM-dd")),
     enabled: myInformation?.data?.connectingStatus === "CONNECTED",
+    refetchOnMount: true,
   });
 
   if (myInformation?.data?.connectingStatus !== "CONNECTED") {

--- a/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/index.tsx
+++ b/apps/user/app/schedule-management/reservation/[mode]/_components/ReservationContainer/index.tsx
@@ -28,7 +28,7 @@ function ReservationContainer({
   const searchParams = useSearchParams();
   const dateParam = searchParams.get("selectedDate");
   const currentDate = new Date();
-  const today = `${currentDate.getFullYear()}-0${currentDate.getMonth() + 1}-${currentDate.getDate()}`;
+  const today = `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, "0")}-${String(currentDate.getDate()).padStart(2, "0")}`;
 
   const [selectedDate, setSelectedDate] = useState<Date>(
     reservationDate ? new Date(reservationDate) : new Date(dateParam || Date.now()),
@@ -36,6 +36,7 @@ function ReservationContainer({
 
   const { data: trainerReservationStatus } = useSuspenseQuery({
     ...reservationQueries.trainerReservationStatus(today),
+    refetchOnMount: true,
   });
 
   return (

--- a/packages/core/src/api/types/common.ts
+++ b/packages/core/src/api/types/common.ts
@@ -78,6 +78,7 @@ export type BaseReservationListItem = {
   isDayOff: boolean;
   dayOfWeek: DayOfWeek;
   reservationDates: string[];
+  confirmDate: null | string;
   status: ReservationStatus;
   memberInfo: BaseMemberInfo;
 };


### PR DESCRIPTION
## 📝 작업 내용

- 트레이너/회원 예약 현황 API DTO 변경
- 트레이너 휴무일, PT 가능시간, 예약 현황 데이터 mount 될때마다 refetch
- 트레이너 도메인 캘린더의 타임 블록에 예약 변경 요청 상태 나타나지 않는 버그 수정
- 예약 페이지 mount시 데이터 refetch
- 예약 변경 요청 상태 타임 블록 클릭시 나타나는 바텀시트 구현

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
