### PR TITLE
[FLIZ-465/trainer] fix: 알림 검색 overflow bug fix

### DIFF
--- a/apps/trainer/app/notification/_components/NotificationSearch/MemberNotificationResult.tsx
+++ b/apps/trainer/app/notification/_components/NotificationSearch/MemberNotificationResult.tsx
@@ -55,7 +55,7 @@ function MemberNotificationResultContent({
         <span className="text-body-3">최신순</span>
       </div>
       {data.pages[0].data.totalElements ? (
-        <ul>
+        <ul className="flex flex-1 flex-col gap-3 overflow-auto">
           {data.pages.map((group, index) => (
             <Fragment key={`search-notificationGroup-${index}`}>
               {group.data.content.filter(handleNotificationFilter(status)).map((notification) => (

--- a/apps/trainer/app/notification/_components/NotificationSearch/index.tsx
+++ b/apps/trainer/app/notification/_components/NotificationSearch/index.tsx
@@ -62,7 +62,7 @@ function NotificationSearchContent({ search, onProfileClick }: NotificationSearc
   }
 
   return (
-    <ul className="flex flex-1 flex-col gap-3">
+    <ul className="flex flex-1 flex-col gap-3 overflow-auto">
       {data.pages[0].data.totalElements ? (
         data.pages.map((group, index) => (
           <Fragment key={`search-notificationMemberGroup-${index}`}>


### PR DESCRIPTION
# [FLIZ-465/trainer] fix: 알림 검색 overflow bug fix

## 📝 작업 내용

알림 검색 리스트에서 레이아웃 문제로 무한 스크롤이 안 되는 버그를 해결했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
