### PR TITLE
[FLIZ-469/root] fix: changeset commit 시 commitlint 적용 해제

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -19,4 +19,6 @@ module.exports = {
       headerCorrespondence: ["ticket", "type", "subject"],
     },
   },
+  // Ignore automatic Changeset commits entirely
+  ignores: [(commit) => commit.startsWith("chore: add changeset")],
 };


### PR DESCRIPTION
# [FLIZ-469/root] fix: changeset commit 시 commitlint 적용 해제

## 📝 작업 내용

changeset commit의 경우 commitlint 규칙 적용을 해제하는 작업을 진행했습니다

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
