### PR TITLE
[FLIZ-474/root] fix: 로고 클릭 시 도메인별 각 접속중인 특정 페이지의 스케줄 페이지로 이동 구현

### DIFF
--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronLeft } from "lucide-react";
-import { MouseEventHandler, ReactNode } from "react";
+import { MouseEventHandler, ReactNode, useCallback } from "react";
 
 import { cn } from "@ui/lib/utils";
 
@@ -21,11 +21,6 @@ const GUIDE_URL =
 function HeaderRoot({ logo, subHeader, children, className }: HeaderRootProps) {
   const hasChildren = Array.isArray(children) ? children.some((child) => !!child) : children;
 
-  const hostname = typeof window !== "undefined" ? window.location.hostname : "";
-  const isUser = hostname.includes("user");
-  const isTrainer = hostname.includes("trainer");
-  const isLocal = hostname.includes("localhost");
-
   const handleClickOpenInformation = () => {
     if (typeof window !== "undefined") {
       if (window.matchMedia("(display-mode: standalone)").matches) {
@@ -36,15 +31,9 @@ function HeaderRoot({ logo, subHeader, children, className }: HeaderRootProps) {
     }
   };
 
-  const handleClickLogo = () => {
-    if (isUser) {
-      window.location.href = "https://dev.user.fitlink.biz/schedule-management";
-    } else if (isTrainer) {
-      window.location.href = "https://dev.trainer.fitlink.biz/schedule-management";
-    } else if (isLocal) {
-      window.location.href = "http://localhost:3000/schedule-management";
-    }
-  };
+  const handleClickLogo = useCallback(() => {
+    window.location.href = `${window.location.origin}/schedule-management`;
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## 📝 작업 내용
* react hook을 사용하려면 컴포넌트로 감싸는 작업이 필요하여 `window` 기능을 통하여 구현하였습니다.
* window.location.origin을 통해 사용자가 접근한 도메인 주소를 가져와 뒤에 스케줄 관리 도메인을 붙여줍니다.
* useCallback을 통해 불필요한 재선언을 방지합니다.
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
